### PR TITLE
GUACAMOLE-347: Fix issue with IE missing window.location.origin

### DIFF
--- a/guacamole/src/main/webapp/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/webapp/app/rest/services/tunnelService.js
@@ -189,8 +189,14 @@ angular.module('rest').factory('tunnelService', ['$injector',
      */
     service.downloadStream = function downloadStream(tunnel, stream, mimetype, filename) {
 
+        // Work-around for IE missing window.location.origin
+        if (!$window.location.origin)
+            var streamOrigin = $window.location.protocol + '//' + $window.location.hostname + ($window.location.port ? (':' + $window.location.port) : '');
+        else
+            var streamOrigin = $window.location.origin;
+
         // Build download URL
-        var url = $window.location.origin
+        var url = streamOrigin
                 + $window.location.pathname
                 + 'api/session/tunnels/' + encodeURIComponent(tunnel)
                 + '/streams/' + encodeURIComponent(stream.index)
@@ -267,8 +273,14 @@ angular.module('rest').factory('tunnelService', ['$injector',
 
         var deferred = $q.defer();
 
+        // Work-around for IE missing window.location.origin
+        if (!$window.location.origin)
+            var streamOrigin = $window.location.protocol + '//' + $window.location.hostname + ($window.location.port ? (':' + $window.location.port) : '');
+        else
+            var streamOrigin = $window.location.origin;
+
         // Build upload URL
-        var url = $window.location.origin
+        var url = streamOrigin
                 + $window.location.pathname
                 + 'api/session/tunnels/' + encodeURIComponent(tunnel)
                 + '/streams/' + encodeURIComponent(stream.index)

--- a/guacamole/src/main/webapp/app/rest/types/UserCredentials.js
+++ b/guacamole/src/main/webapp/app/rest/types/UserCredentials.js
@@ -114,8 +114,14 @@ angular.module('rest').factory('UserCredentials', ['$injector', function defineU
      */
     UserCredentials.getLink = function getLink(userCredentials) {
 
+        // Work-around for IE missing window.location.origin
+        if (!$window.location.origin)
+            var linkOrigin = $window.location.protocol + '//' + $window.location.hostname + ($window.location.port ? (':' + $window.location.port) : '');
+        else
+            var linkOrigin = $window.location.origin;
+
         // Build base link
-        var link = $window.location.origin
+        var link = linkOrigin
                  + $window.location.pathname
                  + '#/';
 


### PR DESCRIPTION
Took a stab at locating all of the instances of window.location.origin and fixing this issue to maintain IE10/11 compatibility.  Basically used the fix suggested in the JIRA issue, with the slight modification of using $window.location instead of window.location.