### PR TITLE
GUACAMOLE-363: Do not declare custom types as default "NOT NULL".

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/001-create-schema.sql
@@ -27,7 +27,7 @@ CREATE RULE [guacamole_connection_group_type_list] AS @list IN (
 );
 GO
 
-CREATE TYPE [guacamole_connection_group_type] FROM [nvarchar](16) NOT NULL;
+CREATE TYPE [guacamole_connection_group_type] FROM [nvarchar](16);
 EXEC sp_bindrule
     'guacamole_connection_group_type_list',
     'guacamole_connection_group_type';
@@ -45,7 +45,7 @@ CREATE RULE [guacamole_object_permission_list] AS @list IN (
 );
 GO
 
-CREATE TYPE [guacamole_object_permission] FROM [nvarchar](16) NOT NULL;
+CREATE TYPE [guacamole_object_permission] FROM [nvarchar](16);
 EXEC sp_bindrule
     'guacamole_object_permission_list',
     'guacamole_object_permission';
@@ -64,7 +64,7 @@ CREATE RULE [guacamole_system_permission_list] AS @list IN (
 );
 GO
 
-CREATE TYPE [guacamole_system_permission] FROM [nvarchar](32) NOT NULL;
+CREATE TYPE [guacamole_system_permission] FROM [nvarchar](32);
 EXEC sp_bindrule
     'guacamole_system_permission_list',
     'guacamole_system_permission';
@@ -80,7 +80,7 @@ CREATE RULE [guacamole_proxy_encryption_method_list] AS @list IN (
 );
 GO
 
-CREATE TYPE [guacamole_proxy_encryption_method] FROM [nvarchar](8) NOT NULL;
+CREATE TYPE [guacamole_proxy_encryption_method] FROM [nvarchar](8);
 EXEC sp_bindrule
     'guacamole_proxy_encryption_method_list',
     'guacamole_proxy_encryption_method';


### PR DESCRIPTION
By defining custom types with `NOT NULL`, columns which use those types default to being `NOT NULL` rather that the standard default of being nullable. With recent reformatting of the SQL scripts to match the style of the MySQL / PostgreSQL scripts, this causes inserts to fail for some tables where `NULL` values are meant to be allowed.

The `NOT NULL` qualifier should be removed from the custom types, with the schema instead relying on explicit specification of `NOT NULL` in the column definition.