### PR TITLE
GUACAMOLE-464: configuration properties from OS environment

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/environment/LocalEnvironment.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/environment/LocalEnvironment.java
@@ -78,11 +78,11 @@ public class LocalEnvironment implements Environment {
      * A property that determines whether environment variables are evaluated
      * to override properties specified in guacamole.properties.
      */
-    private static final BooleanGuacamoleProperty ENVIRONMENT_PROPERTY_OVERRIDE =
+    private static final BooleanGuacamoleProperty ENABLE_ENVIRONMENT_PROPERTIES =
         new BooleanGuacamoleProperty() {
             @Override
             public String getName() {
-                return "enable-environment-overrides";
+                return "enable-environment-properties";
             }
         };
 
@@ -104,7 +104,7 @@ public class LocalEnvironment implements Environment {
     /**
      * Flag indicating whether environment variables can override properties.
      */
-    private final boolean environmentPropertyOverride;
+    private final boolean environmentPropertiesEnabled;
 
     /**
      * The Jackson parser for parsing JSON files.
@@ -161,7 +161,7 @@ public class LocalEnvironment implements Environment {
         availableProtocols = readProtocols();
 
         // Should environment variables override configuration properties?
-        environmentPropertyOverride = propertyOverrideEnabled(properties);
+        environmentPropertiesEnabled = environmentPropertiesEnabled(properties);
     }
 
     /**
@@ -321,7 +321,7 @@ public class LocalEnvironment implements Environment {
     }
 
     /**
-     * Checks for the presence of the {@link #ENVIRONMENT_PROPERTY_OVERRIDE}
+     * Checks for the presence of the {@link #ENABLE_ENVIRONMENT_PROPERTIES}
      * property in the given properties collection.
      *
      * @param properties
@@ -335,13 +335,13 @@ public class LocalEnvironment implements Environment {
      *                            cannot be successfully parsed as a Boolean
      *
      */
-    private static boolean propertyOverrideEnabled(Properties properties)
+    private static boolean environmentPropertiesEnabled(Properties properties)
             throws GuacamoleException {
 
-        final Boolean enableOverrides = ENVIRONMENT_PROPERTY_OVERRIDE.parseValue(
-                properties.getProperty(ENVIRONMENT_PROPERTY_OVERRIDE.getName()));
+        final Boolean enabled = ENABLE_ENVIRONMENT_PROPERTIES.parseValue(
+                properties.getProperty(ENABLE_ENVIRONMENT_PROPERTIES.getName()));
 
-        return enableOverrides != null && enableOverrides;
+        return enabled != null && enabled;
     }
 
     @Override
@@ -371,7 +371,7 @@ public class LocalEnvironment implements Environment {
     private String getPropertyValue(String name) {
 
         // Check for corresponding environment variable if overrides enabled
-        if (environmentPropertyOverride) {
+        if (environmentPropertiesEnabled) {
 
             // Transform the name according to common convention
             final String envName = name.replace('-', '_').toUpperCase();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/environment/LocalEnvironment.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/environment/LocalEnvironment.java
@@ -27,12 +27,11 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
-import org.apache.guacamole.properties.BooleanGuacamoleProperty;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.net.auth.GuacamoleProxyConfiguration;
+import org.apache.guacamole.properties.BooleanGuacamoleProperty;
 import org.apache.guacamole.properties.GuacamoleProperty;
 import org.apache.guacamole.protocols.ProtocolInfo;
 import org.slf4j.Logger;

--- a/guacamole-ext/src/main/java/org/apache/guacamole/environment/LocalEnvironment.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/environment/LocalEnvironment.java
@@ -304,9 +304,41 @@ public class LocalEnvironment implements Environment {
         return guacHome;
     }
 
+    /**
+     * Gets the string value for a property name.
+     *
+     * The value may come from either the OS environment or the Properties
+     * collection that was loaded from guacamole.properties. When checking the
+     * environment for the named property, the name is first transformed by
+     * converting all hyphens to underscores and converting the string to
+     * upper case letter, in accordance with common convention for environment
+     * strings.
+     *
+     * @param name
+     *     The name of the property value to retrieve.
+     *
+     * @return
+     *     The corresponding value for the property. If the value is found in
+     *     the OS environment, any corresponding value from the Properties
+     *     collection containing properties from guacamole.properties is
+     *     ignored.
+     */
+    private String getPropertyValue(String name) {
+
+        // transform the name according to common convention
+        final String envName = name.replace('-', '_').toUpperCase();
+        final String envValue = System.getenv(envName);
+
+        if (envValue != null) {
+            return envValue;
+        }
+
+        return properties.getProperty(name);
+    }
+
     @Override
     public <Type> Type getProperty(GuacamoleProperty<Type> property) throws GuacamoleException {
-        return property.parseValue(properties.getProperty(property.getName()));
+        return property.parseValue(getPropertyValue(property.getName()));
     }
 
     @Override


### PR DESCRIPTION
Wanted to see how others feel about this feature before spending more time on it. If the concept is agreeable, there's some work to do in updating documentation. Additionally, the start.sh script for the docker container image should probably be revised to take advantage of this feature.

Might also want to consider whether this feature must be enabled by the presence of another environment variable. This would prevent unexpected configuration of extension properties via the environment, with minor additional nuisance factor for using the feature.