### PR TITLE
GUACAMOLE-113: Implement hotkey for sending Ctrl-Alt-Del

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -77,12 +77,9 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         MENU_KEYS   = angular.extend({}, SHIFT_KEYS, ALT_KEYS, CTRL_KEYS);
 
     /**
-     * Keys needed to support the Ctrl-Alt-End hotkey for sending
-     * Ctrl-Alt-Delete.
+     * Keysym for sending the DELETE key when the Ctrl-Alt-End hotkey
+     * combo is pressed.
      */
-    CAD_KEYS    = angular.extend({}, ALT_KEYS, CTRL_KEYS, END_KEYS);
-    var CTRL_KEY    = 0xFFE3;
-    var ALT_KEY     = 0xFFE9;
     var DEL_KEY     = 0xFFFF;
 
     /**

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -278,6 +278,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
      * Map of all substituted key presses.  If one key is pressed in place of another
      * the value of the substituted key is stored in an object with the keysym of
      * the original key.
+     *
      * @type Object.<Number, Number>
      */
     var substituteKeysPressed = {};
@@ -505,20 +506,17 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
     };
 
-    /**
-     * Track pressed keys, opening the Guacamole menu after Ctrl+Alt+Shift, or
-     * send Ctrl-Alt-Delete when Ctrl-Alt-End is pressed.
-     */
+    // Track pressed keys, opening the Guacamole menu after Ctrl+Alt+Shift, or
+    // send Ctrl-Alt-Delete when Ctrl-Alt-End is pressed.
     $scope.$on('guacKeydown', function keydownListener(event, keysym, keyboard) {
 
         // Record key as pressed
         keysCurrentlyPressed[keysym] = true;   
         
         var currentKeysPressedKeys = Object.keys(keysCurrentlyPressed);
-        /**
-         * If only menu keys are pressed, and we have one keysym from each group,
-         * and one of the keys is being released, show the menu. 
-         */
+
+        // If only menu keys are pressed, and we have one keysym from each group,
+        // and one of the keys is being released, show the menu. 
         if (checkMenuModeActive()) {
             
             // Check that there is a key pressed for each of the required key classes
@@ -541,10 +539,8 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             }
         }
 
-        /**
-         * If only Ctrl-Alt-End is pressed, and we have a one keysym from each
-         * group, and one key is being released, send Ctrl-Alt-Delete.
-         */
+        // If only Ctrl-Alt-End is pressed, and we have a one keysym from each
+        // group, and one key is being released, send Ctrl-Alt-Delete.
         if (END_KEYS[keysym] &&
             !_.isEmpty(_.pick(ALT_KEYS, currentKeysPressedKeys)) &&
             !_.isEmpty(_.pick(CTRL_KEYS, currentKeysPressedKeys))

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -72,7 +72,9 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         ALT_KEYS    = {0xFFE9 : true, 0xFFEA : true, 0xFE03 : true,
                        0xFFE7 : true, 0xFFE8 : true},
         CTRL_KEYS   = {0xFFE3 : true, 0xFFE4 : true},
+        END_KEYS    = {0xFF57 : true, 0xFFB1 : true},
         MENU_KEYS   = angular.extend({}, SHIFT_KEYS, ALT_KEYS, CTRL_KEYS);
+        CAD_KEYS    = angular.extend({}, ALT_KEYS, CTRL_KEYS, END_KEYS);
 
     /**
      * All client error codes handled and passed off for translation. Any error
@@ -288,6 +290,16 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         return true;
     }
 
+    function checkCADHotkeyActive() {
+        for(var keysym in keysCurrentlyPressed) {
+            if(!CAD_KEYS[keysym]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     // Hide menu when the user swipes from the right
     $scope.menuDrag = function menuDrag(inProgress, startX, startY, currentX, currentY, deltaX, deltaY) {
 
@@ -495,12 +507,12 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         // Record key as pressed
         keysCurrentlyPressed[keysym] = true;   
         
+        var currentKeysPressedKeys = Object.keys(keysCurrentlyPressed);
         /* 
          * If only menu keys are pressed, and we have one keysym from each group,
          * and one of the keys is being released, show the menu. 
          */
         if(checkMenuModeActive()) {
-            var currentKeysPressedKeys = Object.keys(keysCurrentlyPressed);
             
             // Check that there is a key pressed for each of the required key classes
             if(!_.isEmpty(_.pick(SHIFT_KEYS, currentKeysPressedKeys)) &&
@@ -519,6 +531,26 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
                 $scope.$apply(function() {
                     $scope.menu.shown = !$scope.menu.shown;
                 });
+            }
+        }
+
+        if(checkCADHotkeyActive()) {
+
+            // Check that there is a key pressed for each of the required key classes
+            if(!_.isEmpty(_.pick(ALT_KEYS, currentKeysPressedKeys)) &&
+               !_.isEmpty(_.pick(CTRL_KEYS, currentKeysPressedKeys)) &&
+               !_.isEmpty(_.pick(END_KEYS, currentKeysPressedKeys))
+            ) {
+
+               // Don't send this key event through to the client
+               event.preventDefault();
+
+               // Log the event
+               console.log('We should trigger Ctrl-Alt-Delete here.');
+
+               // Reset the keys pressed
+               keysCurrentlyPressed = {};
+               keyboard.reset();
             }
         }
 

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -551,10 +551,19 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             !_.isEmpty(_.pick(ALT_KEYS, currentKeysPressedKeys)) &&
             !_.isEmpty(_.pick(CTRL_KEYS, currentKeysPressedKeys))
         ) {
-                event.preventDefault();
-                delete keysCurrentlyPressed[keysym];
-                substituteKeysPressed[keysym] = DEL_KEY;
-                $scope.$broadcast('guacSyntheticKeydown', DEL_KEY);
+
+            // Don't send this event through to the client.
+            event.preventDefault();
+
+            // Remove the original key press
+            delete keysCurrentlyPressed[keysym];
+
+            // Record the substituted key press so that it can be
+            // properly dealt with later.
+            substituteKeysPressed[keysym] = DEL_KEY;
+
+            // Send through the delete key.
+            $scope.$broadcast('guacSyntheticKeydown', DEL_KEY);
         }
 
     });

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -31,7 +31,6 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
     // Required services
     var $location             = $injector.get('$location');
-    var $rootScope            = $injector.get('$rootScope');
     var authenticationService = $injector.get('authenticationService');
     var clipboardService      = $injector.get('clipboardService');
     var guacClientManager     = $injector.get('guacClientManager');
@@ -79,7 +78,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
      * Keysym for detecting any END key presses, for the purpose of passing through
      * the Ctrl-Alt-Del sequence to a remote system.
      */
-    END_KEYS = {0xFF57 : true, 0xFFB1 : true},
+    var END_KEYS = {0xFF57 : true, 0xFFB1 : true};
 
     /**
      * Keysym for sending the DELETE key when the Ctrl-Alt-End hotkey
@@ -555,7 +554,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
                 event.preventDefault();
                 delete keysCurrentlyPressed[keysym];
                 substituteKeysPressed[keysym] = DEL_KEY;
-                $rootScope.$broadcast('guacSyntheticKeydown', DEL_KEY);
+                $scope.$broadcast('guacSyntheticKeydown', DEL_KEY);
         }
 
     });
@@ -574,7 +573,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         if (substituteKeysPressed[keysym]) {
             event.preventDefault();
             delete substituteKeysPressed[keysym];
-            $rootScope.$broadcast('guacSyntheticKeyup', substituteKeysPressed[keysym]);
+            $scope.$broadcast('guacSyntheticKeyup', substituteKeysPressed[keysym]);
         }
 
         // Mark key as released

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -73,14 +73,21 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         ALT_KEYS    = {0xFFE9 : true, 0xFFEA : true, 0xFE03 : true,
                        0xFFE7 : true, 0xFFE8 : true},
         CTRL_KEYS   = {0xFFE3 : true, 0xFFE4 : true},
-        END_KEYS    = {0xFF57 : true, 0xFFB1 : true},
         MENU_KEYS   = angular.extend({}, SHIFT_KEYS, ALT_KEYS, CTRL_KEYS);
+
+    /**
+     * Keysym for detecting any END key presses, for the purpose of passing through
+     * the Ctrl-Alt-Del sequence to a remote system.
+     */
+    END_KEYS = {0xFF57 : true, 0xFFB1 : true},
 
     /**
      * Keysym for sending the DELETE key when the Ctrl-Alt-End hotkey
      * combo is pressed.
+     *
+     * @type Number
      */
-    var DEL_KEY     = 0xFFFF;
+    var DEL_KEY = 0xFFFF;
 
     /**
      * All client error codes handled and passed off for translation. Any error
@@ -539,8 +546,8 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             }
         }
 
-        // If only Ctrl-Alt-End is pressed, and we have a one keysym from each
-        // group, and one key is being released, send Ctrl-Alt-Delete.
+        // If one of the End keys is pressed, and we have a one keysym from each
+        // of Ctrl and Alt groups, send Ctrl-Alt-Delete.
         if (END_KEYS[keysym] &&
             !_.isEmpty(_.pick(ALT_KEYS, currentKeysPressedKeys)) &&
             !_.isEmpty(_.pick(CTRL_KEYS, currentKeysPressedKeys))
@@ -556,8 +563,6 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     // Update pressed keys as they are released, synchronizing the clipboard
     // with any data that appears to have come from those key presses
     $scope.$on('guacKeyup', function keyupListener(event, keysym, keyboard) {
-
-        var currentKeysPressedKeys = Object.keys(keysCurrentlyPressed);
 
         // Sync local clipboard with any clipboard data received while this
         // key was pressed (if any) as long as the menu is not open


### PR DESCRIPTION
This change implements sending Ctrl-Alt-Del to the remote system by capturing Ctrl-Alt-End, which is a pretty standard hotkey among RDP clients for passing through the three-finger-salute to remote systems.