### PR TITLE
GUACAMOLE-232: Handle known platform/browser keyboard quirks semantically.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -66,6 +66,13 @@ Guacamole.Keyboard = function(element) {
     var quirks = {
 
         /**
+         * Whether keyup events are universally unreliable.
+         *
+         * @type {Boolean}
+         */
+        keyupUnreliable: false,
+
+        /**
          * Whether the Alt key is actually a modifier for typable keys and is
          * thus never used for keyboard shortcuts.
          *
@@ -79,8 +86,12 @@ Guacamole.Keyboard = function(element) {
     // available
     if (navigator && navigator.platform) {
 
+        // All keyup events are unreliable on iOS (sadly)
+        if (navigator.platform.match(/ipad|iphone|ipod/i))
+            quirks.keyupUnreliable = true;
+
         // The Alt key on Mac is never used for keyboard shortcuts
-        if (navigator.platform.match(/^mac/i))
+        else if (navigator.platform.match(/^mac/i))
             quirks.altIsTypableOnly = true;
 
     }
@@ -211,7 +222,7 @@ Guacamole.Keyboard = function(element) {
          *
          * @type {Boolean}
          */
-        this.keyupReliable = true;
+        this.keyupReliable = !quirks.keyupUnreliable;
 
         // DOM3 and keyCode are reliable sources if the corresponding key is
         // not a printable key
@@ -1021,7 +1032,7 @@ Guacamole.Keyboard = function(element) {
         } // end if keydown
 
         // Keyup event
-        else if (first instanceof KeyupEvent) {
+        else if (first instanceof KeyupEvent && !quirks.keyupUnreliable) {
 
             // Release specific key if known
             var keysym = first.keysym;


### PR DESCRIPTION
This change adds a new private set of boolean flags within `Guacamole.Keyboard` which tracks whether certain platform-specific and browser-specific quirks are present, particularly those which can be reliably detected only through platform/browser-sniffing, specifically:

* Whether keyup events cannot really be relied upon at all (they are randomly dropped on iOS)
* ~Whether the keyup event is specifically unreliable for Caps Lock (a quirk of the Mac OS X event model, as noted by @flangelo in #209: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Special_cases)~ (removed to be re-added in a separate PR)
* Whether the "Alt" key is safe to allow through to the browser, as it never represents a keyboard shortcut.
