### PR TITLE
GUACAMOLE-197: Fix compatibility with decoration API changes

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProvider.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProvider.java
@@ -69,6 +69,20 @@ public class RadiusAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
+    public UserContext decorate(UserContext context,
+            AuthenticatedUser authenticatedUser, Credentials credentials)
+            throws GuacamoleException {
+        return context;
+    }
+
+    @Override
+    public UserContext redecorate(UserContext decorated, UserContext context,
+            AuthenticatedUser authenticatedUser, Credentials credentials)
+            throws GuacamoleException {
+        return context;
+    }
+
+    @Override
     public void shutdown() {
         // Do nothing
     }


### PR DESCRIPTION
This slipped through the cracks before the merge - adding the overrides to the RADIUS extension for compatibility with the decoration changes from GUACAMOLE-96.