### PR TITLE
GUACAMOLE-494: Remove support for properties which have been deprecated for sufficiently long.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLEnvironment.java
@@ -60,41 +60,27 @@ public class MySQLEnvironment extends JDBCEnvironment {
 
     /**
      * The default value for the default maximum number of connections to be
-     * allowed per user to any one connection. Note that, as long as the
-     * legacy "disallow duplicate" and "disallow simultaneous" properties are
-     * still supported, these cannot be constants, as the legacy properties
-     * dictate the values that should be used in the absence of the correct
-     * properties.
+     * allowed per user to any one connection.
      */
-    private int DEFAULT_MAX_CONNECTIONS_PER_USER = 1;
+    private final int DEFAULT_MAX_CONNECTIONS_PER_USER = 1;
 
     /**
      * The default value for the default maximum number of connections to be
-     * allowed per user to any one connection group. Note that, as long as the
-     * legacy "disallow duplicate" and "disallow simultaneous" properties are
-     * still supported, these cannot be constants, as the legacy properties
-     * dictate the values that should be used in the absence of the correct
-     * properties.
+     * allowed per user to any one connection group.
      */
-    private int DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 1;
+    private final int DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 1;
 
     /**
      * The default value for the default maximum number of connections to be
-     * allowed to any one connection. Note that, as long as the legacy
-     * "disallow duplicate" and "disallow simultaneous" properties are still
-     * supported, these cannot be constants, as the legacy properties dictate
-     * the values that should be used in the absence of the correct properties.
+     * allowed to any one connection.
      */
-    private int DEFAULT_MAX_CONNECTIONS = 0;
+    private final int DEFAULT_MAX_CONNECTIONS = 0;
 
     /**
      * The default value for the default maximum number of connections to be
-     * allowed to any one connection group. Note that, as long as the legacy
-     * "disallow duplicate" and "disallow simultaneous" properties are still
-     * supported, these cannot be constants, as the legacy properties dictate
-     * the values that should be used in the absence of the correct properties.
+     * allowed to any one connection group.
      */
-    private int DEFAULT_MAX_GROUP_CONNECTIONS = 0;
+    private final int DEFAULT_MAX_GROUP_CONNECTIONS = 0;
 
     /**
      * Constructs a new MySQLEnvironment, providing access to MySQL-specific
@@ -108,66 +94,6 @@ public class MySQLEnvironment extends JDBCEnvironment {
 
         // Init underlying JDBC environment
         super();
-
-        // Read legacy concurrency-related property
-        Boolean disallowSimultaneous = getProperty(MySQLGuacamoleProperties.MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS);
-        Boolean disallowDuplicate    = getProperty(MySQLGuacamoleProperties.MYSQL_DISALLOW_DUPLICATE_CONNECTIONS);
-
-        // Legacy "simultaneous" property dictates only the maximum number of
-        // connections per connection
-        if (disallowSimultaneous != null) {
-
-            // Translate legacy property
-            if (disallowSimultaneous) {
-                DEFAULT_MAX_CONNECTIONS       = 1;
-                DEFAULT_MAX_GROUP_CONNECTIONS = 0;
-            }
-            else {
-                DEFAULT_MAX_CONNECTIONS       = 0;
-                DEFAULT_MAX_GROUP_CONNECTIONS = 0;
-            }
-
-            // Warn of deprecation
-            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
-                    MySQLGuacamoleProperties.MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(),
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS.getName(),
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
-
-            // Inform of new equivalent
-            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
-                    MySQLGuacamoleProperties.MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(), disallowSimultaneous,
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS.getName(),           DEFAULT_MAX_CONNECTIONS,
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName(),     DEFAULT_MAX_GROUP_CONNECTIONS);
-
-        }
-
-        // Legacy "duplicate" property dictates whether connections and groups
-        // may be used concurrently only by different users
-        if (disallowDuplicate != null) {
-
-            // Translate legacy property
-            if (disallowDuplicate) {
-                DEFAULT_MAX_CONNECTIONS_PER_USER       = 1;
-                DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 1;
-            }
-            else {
-                DEFAULT_MAX_CONNECTIONS_PER_USER       = 0;
-                DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 0;
-            }
-
-            // Warn of deprecation
-            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
-                    MySQLGuacamoleProperties.MYSQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
-
-            // Inform of new equivalent
-            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
-                    MySQLGuacamoleProperties.MYSQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),         disallowDuplicate,
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),       DEFAULT_MAX_CONNECTIONS_PER_USER,
-                    MySQLGuacamoleProperties.MYSQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER.getName(), DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER);
-
-        }
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLGuacamoleProperties.java
@@ -101,28 +101,6 @@ public class MySQLGuacamoleProperties {
     };
 
     /**
-     * Whether or not multiple users accessing the same connection at the same 
-     * time should be disallowed.
-     */
-    public static final BooleanGuacamoleProperty MYSQL_DISALLOW_SIMULTANEOUS_CONNECTIONS = new BooleanGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "mysql-disallow-simultaneous-connections"; }
-
-    };
-
-    /**
-     * Whether or not the same user accessing the same connection or connection 
-     * group at the same time should be disallowed.
-     */
-    public static final BooleanGuacamoleProperty MYSQL_DISALLOW_DUPLICATE_CONNECTIONS = new BooleanGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "mysql-disallow-duplicate-connections"; }
-
-    };
-
-    /**
      * The maximum number of concurrent connections to allow overall. Zero
      * denotes unlimited.
      */

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLEnvironment.java
@@ -66,7 +66,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
      * dictate the values that should be used in the absence of the correct
      * properties.
      */
-    private int DEFAULT_MAX_CONNECTIONS_PER_USER = 1;
+    private final int DEFAULT_MAX_CONNECTIONS_PER_USER = 1;
 
     /**
      * The default value for the default maximum number of connections to be
@@ -76,7 +76,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
      * dictate the values that should be used in the absence of the correct
      * properties.
      */
-    private int DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 1;
+    private final int DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 1;
 
     /**
      * The default value for the default maximum number of connections to be
@@ -85,7 +85,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
      * supported, these cannot be constants, as the legacy properties dictate
      * the values that should be used in the absence of the correct properties.
      */
-    private int DEFAULT_MAX_CONNECTIONS = 0;
+    private final int DEFAULT_MAX_CONNECTIONS = 0;
 
     /**
      * The default value for the default maximum number of connections to be
@@ -94,7 +94,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
      * supported, these cannot be constants, as the legacy properties dictate
      * the values that should be used in the absence of the correct properties.
      */
-    private int DEFAULT_MAX_GROUP_CONNECTIONS = 0;
+    private final int DEFAULT_MAX_GROUP_CONNECTIONS = 0;
 
     /**
      * Constructs a new PostgreSQLEnvironment, providing access to PostgreSQL-specific
@@ -108,66 +108,6 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
 
         // Init underlying JDBC environment
         super();
-
-        // Read legacy concurrency-related property
-        Boolean disallowSimultaneous = getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS);
-        Boolean disallowDuplicate    = getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS);
-
-        // Legacy "simultaneous" property dictates only the maximum number of
-        // connections per connection
-        if (disallowSimultaneous != null) {
-
-            // Translate legacy property
-            if (disallowSimultaneous) {
-                DEFAULT_MAX_CONNECTIONS       = 1;
-                DEFAULT_MAX_GROUP_CONNECTIONS = 0;
-            }
-            else {
-                DEFAULT_MAX_CONNECTIONS       = 0;
-                DEFAULT_MAX_GROUP_CONNECTIONS = 0;
-            }
-
-            // Warn of deprecation
-            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(),
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS.getName(),
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
-
-            // Inform of new equivalent
-            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS.getName(), disallowSimultaneous,
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS.getName(),           DEFAULT_MAX_CONNECTIONS,
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName(),     DEFAULT_MAX_GROUP_CONNECTIONS);
-
-        }
-
-        // Legacy "duplicate" property dictates whether connections and groups
-        // may be used concurrently only by different users
-        if (disallowDuplicate != null) {
-
-            // Translate legacy property
-            if (disallowDuplicate) {
-                DEFAULT_MAX_CONNECTIONS_PER_USER       = 1;
-                DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 1;
-            }
-            else {
-                DEFAULT_MAX_CONNECTIONS_PER_USER       = 0;
-                DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER = 0;
-            }
-
-            // Warn of deprecation
-            logger.warn("The \"{}\" property is deprecated. Use \"{}\" and \"{}\" instead.",
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS.getName());
-
-            // Inform of new equivalent
-            logger.info("To achieve the same result of setting \"{}\" to \"{}\", set \"{}\" to \"{}\" and \"{}\" to \"{}\".",
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS.getName(),         disallowDuplicate,
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_CONNECTIONS_PER_USER.getName(),       DEFAULT_MAX_CONNECTIONS_PER_USER,
-                    PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER.getName(), DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER);
-
-        }
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLGuacamoleProperties.java
@@ -106,32 +106,6 @@ public class PostgreSQLGuacamoleProperties {
     };
 
     /**
-     * Whether or not multiple users accessing the same connection at the same
-     * time should be disallowed.
-     */
-    public static final BooleanGuacamoleProperty
-            POSTGRESQL_DISALLOW_SIMULTANEOUS_CONNECTIONS =
-            new BooleanGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "postgresql-disallow-simultaneous-connections"; }
-
-    };
-
-    /**
-     * Whether or not the same user accessing the same connection or connection
-     * group at the same time should be disallowed.
-     */
-    public static final BooleanGuacamoleProperty
-            POSTGRESQL_DISALLOW_DUPLICATE_CONNECTIONS =
-            new BooleanGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "postgresql-disallow-duplicate-connections"; }
-
-    };
-
-    /**
      * The maximum number of concurrent connections to allow overall. Zero
      * denotes unlimited.
      */

--- a/guacamole/src/main/java/org/apache/guacamole/auth/file/FileAuthenticationProvider.java
+++ b/guacamole/src/main/java/org/apache/guacamole/auth/file/FileAuthenticationProvider.java
@@ -31,7 +31,6 @@ import org.apache.guacamole.environment.LocalEnvironment;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.simple.SimpleAuthenticationProvider;
 import org.apache.guacamole.xml.DocumentHandler;
-import org.apache.guacamole.properties.FileGuacamoleProperty;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,20 +69,6 @@ public class FileAuthenticationProvider extends SimpleAuthenticationProvider {
     private final Environment environment;
 
     /**
-     * The XML file to read the user mapping from. This property has been
-     * deprecated, as the name "basic" is ridiculous, and providing for
-     * configurable user-mapping.xml locations is unnecessary complexity. Use
-     * GUACAMOLE_HOME/user-mapping.xml instead.
-     */
-    @Deprecated
-    public static final FileGuacamoleProperty BASIC_USER_MAPPING = new FileGuacamoleProperty() {
-
-        @Override
-        public String getName() { return "basic-user-mapping"; }
-
-    };
-
-    /**
      * The filename to use for the user mapping.
      */
     public static final String USER_MAPPING_FILENAME = "user-mapping.xml";
@@ -107,38 +92,17 @@ public class FileAuthenticationProvider extends SimpleAuthenticationProvider {
 
     /**
      * Returns a UserMapping containing all authorization data given within
-     * the XML file specified by the "basic-user-mapping" property in
-     * guacamole.properties. If the XML file has been modified or has not yet
-     * been read, this function may reread the file.
+     * GUACAMOLE_HOME/user-mapping.xml. If the XML file has been modified or has
+     * not yet been read, this function may reread the file.
      *
      * @return
      *     A UserMapping containing all authorization data within the user
      *     mapping XML file, or null if the file cannot be found/parsed.
      */
-    @SuppressWarnings("deprecation") // We must continue to use the "basic-user-mapping" property until it is truly no longer supported
     private UserMapping getUserMapping() {
 
-        // Get user mapping file, defaulting to GUACAMOLE_HOME/user-mapping.xml
-        File userMappingFile;
-        try {
-
-            // Continue supporting deprecated property, but warn in the logs
-            userMappingFile = environment.getProperty(BASIC_USER_MAPPING);
-            if (userMappingFile != null)
-                logger.warn("The \"basic-user-mapping\" property is deprecated. Please use the \"GUACAMOLE_HOME/user-mapping.xml\" file instead.");
-
-            // Read user mapping from GUACAMOLE_HOME
-            if (userMappingFile == null)
-                userMappingFile = new File(environment.getGuacamoleHome(), USER_MAPPING_FILENAME);
-
-        }
-
-        // Abort if property cannot be parsed
-        catch (GuacamoleException e) {
-            logger.warn("Unable to read user mapping filename from properties: {}", e.getMessage());
-            logger.debug("Error parsing user mapping property.", e);
-            return null;
-        }
+        // Read user mapping from GUACAMOLE_HOME/user-mapping.xml
+        File userMappingFile = new File(environment.getGuacamoleHome(), USER_MAPPING_FILENAME);
 
         // Abort if user mapping does not exist
         if (!userMappingFile.exists()) {


### PR DESCRIPTION
This change removes support for the following properties:

* `basic-user-mapping`, which has been deprecated since 0.9.10-incubating (8590a0a)
* `mysql-disallow-*` and `postgresql-disallow-*`, which have been deprecated since 0.9.8 (9b27a27)