### PR TITLE
GUACAMOLE-197: Use FileGuacamoleProperty for CA and Key file propeties.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/ConfigurationService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/ConfigurationService.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.auth.radius;
 
 import com.google.inject.Inject;
+import java.io.File;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
 
@@ -176,9 +177,10 @@ public class ConfigurationService {
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public String getRadiusCAFile() throws GuacamoleException {
+    public File getRadiusCAFile() throws GuacamoleException {
         return environment.getProperty(
-            RadiusGuacamoleProperties.RADIUS_CA_FILE
+            RadiusGuacamoleProperties.RADIUS_CA_FILE,
+            new File(environment.getGuacamoleHome(), "ca.crt")
         );
     }
 
@@ -195,10 +197,10 @@ public class ConfigurationService {
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public String getRadiusKeyFile() throws GuacamoleException {
+    public File getRadiusKeyFile() throws GuacamoleException {
         return environment.getProperty(
             RadiusGuacamoleProperties.RADIUS_KEY_FILE,
-            "radius.pem"
+            new File(environment.getGuacamoleHome(), "radius.key")
         );
     }
 

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
@@ -27,7 +27,6 @@ import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
-import org.apache.guacamole.environment.LocalEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.jradius.client.RadiusClient;
@@ -136,15 +135,13 @@ public class RadiusConnectionService {
             radAuth instanceof EAPTTLSAuthenticator) {
 
             // Pull TLS configuration parameters from guacamole.properties
-            LocalEnvironment guacEnv = new LocalEnvironment();
-            File guacHome = guacEnv.getGuacamoleHome();
-            String caFile = confService.getRadiusCAFile();
+            File caFile = confService.getRadiusCAFile();
             String caPassword = confService.getRadiusCAPassword();
-            String keyFile = confService.getRadiusKeyFile();
+            File keyFile = confService.getRadiusKeyFile();
             String keyPassword = confService.getRadiusKeyPassword();
 
             if (caFile != null) {
-                ((EAPTLSAuthenticator)radAuth).setCaFile((new File(guacHome, caFile)).toString());
+                ((EAPTLSAuthenticator)radAuth).setCaFile(caFile.toString());
                 ((EAPTLSAuthenticator)radAuth).setCaFileType(confService.getRadiusCAType());
                 if (caPassword != null)
                     ((EAPTLSAuthenticator)radAuth).setCaPassword(caPassword);
@@ -153,7 +150,7 @@ public class RadiusConnectionService {
             if (keyPassword != null)
                 ((EAPTLSAuthenticator)radAuth).setKeyPassword(keyPassword);
 
-            ((EAPTLSAuthenticator)radAuth).setKeyFile((new File(guacHome, keyFile)).toString());
+            ((EAPTLSAuthenticator)radAuth).setKeyFile(keyFile.toString());
             ((EAPTLSAuthenticator)radAuth).setKeyFileType(confService.getRadiusKeyType());
             ((EAPTLSAuthenticator)radAuth).setTrustAll(confService.getRadiusTrustAll());
         }

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusGuacamoleProperties.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusGuacamoleProperties.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.auth.radius;
 
 import org.apache.guacamole.properties.BooleanGuacamoleProperty;
+import org.apache.guacamole.properties.FileGuacamoleProperty;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
 
@@ -110,7 +111,7 @@ public class RadiusGuacamoleProperties {
     /**
      * The CA file to use to validate RADIUS server certificates.
      */
-    public static final StringGuacamoleProperty RADIUS_CA_FILE = new StringGuacamoleProperty() {
+    public static final FileGuacamoleProperty RADIUS_CA_FILE = new FileGuacamoleProperty() {
 
         @Override
         public String getName() { return "radius-ca-file"; }
@@ -140,7 +141,7 @@ public class RadiusGuacamoleProperties {
     /**
      * The file that stores the key/certificate pair to use for the RADIUS client connection.
      */
-    public static final StringGuacamoleProperty RADIUS_KEY_FILE = new StringGuacamoleProperty() {
+    public static final FileGuacamoleProperty RADIUS_KEY_FILE = new FileGuacamoleProperty() {
 
         @Override
         public String getName() { return "radius-key-file"; }


### PR DESCRIPTION
Quick modification to the RADIUS extension to use FileGuacamoleProperty for CA and Key file properties.