### PR TITLE
GUACAMOLE-197: Convert state to Hex string to avoid encoding issues.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
@@ -170,8 +170,8 @@ public class AuthenticationProviderService {
                                                               stateBytes);
             }
             catch (IllegalArgumentException e) {
-                logger.warn("Illegal hexadecimal value while parsing RADIUS state string.", e.getMessage());
-                logger.debug("Encountered exception while attepmting to perse the hexidecimanl state value.", e);
+                logger.warn("Illegal hexadecimal value while parsing RADIUS state string: {}", e.getMessage());
+                logger.debug("Encountered exception while attempting to parse the hexidecimal state value.", e);
                 throw new GuacamoleInvalidCredentialsException("Authentication error.", CredentialsInfo.USERNAME_PASSWORD);
             }
             catch (GuacamoleException e) {

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
@@ -157,10 +157,17 @@ public class AuthenticationProviderService {
         // This is a response to a previous challenge, authenticate with that.
         else {
             try {
-                byte[] stateBytes = DatatypeConverter.parseHexBinary(request.getParameter(RadiusStateField.PARAMETER_NAME));
+                String stateString = request.getParameter(RadiusStateField.PARAMETER_NAME);
+                if (stateString == null) {
+                    logger.error("Could not retrieve RADIUS state.");
+                    logger.debug("Received null value while retrieving RADIUS state parameter.");
+                    throws new GuacamoleInvalidCredentialsException("Authentication error.", CredentialsInfo.USERNAME_PASSWORD);
+                }
+
+                byte[] stateBytes = DatatypeConverter.parseHexBinary(stateString);
                 radPack = radiusService.sendChallengeResponse(credentials.getUsername(),
-                                                     challengeResponse,
-                                                     stateBytes);
+                                                              challengeResponse,
+                                                              stateBytes);
             }
             catch (GuacamoleException e) {
                 logger.error("Cannot configure RADIUS server: {}", e.getMessage());

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
@@ -99,7 +99,7 @@ public class AuthenticationProviderService {
 
         // We have the required attributes - convert to strings and then generate the additional login box/field
         String replyMsg = replyAttr.toString();
-        String radiusState = javax.xml.bind.DatatypeConverter.printHexBinary(stateAttr.getValue().getBytes());
+        String radiusState = DatatypeConverter.printHexBinary(stateAttr.getValue().getBytes());
         Field radiusResponseField = new RadiusChallengeResponseField(replyMsg);
         Field radiusStateField = new RadiusStateField(radiusState);
 
@@ -157,7 +157,7 @@ public class AuthenticationProviderService {
         // This is a response to a previous challenge, authenticate with that.
         else {
             try {
-                byte[] stateBytes = javax.xml.bind.DatatypeConverter.parseHexBinary(request.getParameter(RadiusStateField.PARAMETER_NAME));
+                byte[] stateBytes = DatatypeConverter.parseHexBinary(request.getParameter(RadiusStateField.PARAMETER_NAME));
                 radPack = radiusService.sendChallengeResponse(credentials.getUsername(),
                                                      challengeResponse,
                                                      stateBytes);

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
@@ -21,6 +21,7 @@ package org.apache.guacamole.auth.radius;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import java.lang.IllegalArgumentException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import javax.servlet.http.HttpServletRequest;
@@ -161,13 +162,18 @@ public class AuthenticationProviderService {
                 if (stateString == null) {
                     logger.error("Could not retrieve RADIUS state.");
                     logger.debug("Received null value while retrieving RADIUS state parameter.");
-                    throws new GuacamoleInvalidCredentialsException("Authentication error.", CredentialsInfo.USERNAME_PASSWORD);
+                    throw new GuacamoleInvalidCredentialsException("Authentication error.", CredentialsInfo.USERNAME_PASSWORD);
                 }
 
                 byte[] stateBytes = DatatypeConverter.parseHexBinary(stateString);
                 radPack = radiusService.sendChallengeResponse(credentials.getUsername(),
                                                               challengeResponse,
                                                               stateBytes);
+            }
+            catch (IllegalArgumentException e) {
+                logger.error("Illegal argument while parsing RADIUS state string.", e.getMessage());
+                logger.debug("Illegal argument found while parsing the RADIUS state string.", e);
+                throw new GuacamoleInvalidCredentialsException("Authentication error.", CredentialsInfo.USERNAME_PASSWORD);
             }
             catch (GuacamoleException e) {
                 logger.error("Cannot configure RADIUS server: {}", e.getMessage());

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
@@ -160,8 +160,7 @@ public class AuthenticationProviderService {
             try {
                 String stateString = request.getParameter(RadiusStateField.PARAMETER_NAME);
                 if (stateString == null) {
-                    logger.error("Could not retrieve RADIUS state.");
-                    logger.debug("Received null value while retrieving RADIUS state parameter.");
+                    logger.warn("Expected state parameter was not present in challenge/response.");
                     throw new GuacamoleInvalidCredentialsException("Authentication error.", CredentialsInfo.USERNAME_PASSWORD);
                 }
 
@@ -171,8 +170,8 @@ public class AuthenticationProviderService {
                                                               stateBytes);
             }
             catch (IllegalArgumentException e) {
-                logger.error("Illegal argument while parsing RADIUS state string.", e.getMessage());
-                logger.debug("Illegal argument found while parsing the RADIUS state string.", e);
+                logger.warn("Illegal hexadecimal value while parsing RADIUS state string.", e.getMessage());
+                logger.debug("Encountered exception while attepmting to perse the hexidecimanl state value.", e);
                 throw new GuacamoleInvalidCredentialsException("Authentication error.", CredentialsInfo.USERNAME_PASSWORD);
             }
             catch (GuacamoleException e) {

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
@@ -187,7 +187,7 @@ public class RadiusConnectionService {
      * @throws GuacamoleException
      *     If an error occurs while talking to the server.
      */
-    public RadiusPacket authenticate(String username, String secret, String state)
+    public RadiusPacket authenticate(String username, String secret, byte[] state)
             throws GuacamoleException {
 
         // If a username wasn't passed, we quit
@@ -219,7 +219,7 @@ public class RadiusConnectionService {
         try {
             AttributeList radAttrs = new AttributeList();
             radAttrs.add(new Attr_UserName(username));
-            if (state != null && !state.isEmpty())
+            if (state != null && state.length > 0)
                 radAttrs.add(new Attr_State(state));
             radAttrs.add(new Attr_UserPassword(secret));
             radAttrs.add(new Attr_CleartextPassword(secret));
@@ -282,7 +282,7 @@ public class RadiusConnectionService {
      * @throws GuacamoleException
      *     If an error is encountered trying to talk to the RADIUS server.
      */
-    public RadiusPacket sendChallengeResponse(String username, String response, String state)
+    public RadiusPacket sendChallengeResponse(String username, String response, byte[] state)
             throws GuacamoleException {
 
         if (username == null || username.isEmpty()) {
@@ -290,7 +290,7 @@ public class RadiusConnectionService {
             return null;
         }
 
-        if (state == null || state.isEmpty()) {
+        if (state == null || state.length < 1) {
             logger.error("Challenge/response to RADIUS requires a prior state.");
             return null;
         }

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
@@ -290,7 +290,7 @@ public class RadiusConnectionService {
             return null;
         }
 
-        if (state == null || state.length < 1) {
+        if (state == null || state.length == 0) {
             logger.error("Challenge/response to RADIUS requires a prior state.");
             return null;
         }


### PR DESCRIPTION
Okay, PR to convert the RADIUS state from a `byte[]` to a hex string to avoid the encoding issues.  Tested with Challenge/Response authentication, and it appears to work.

Not sure if there's anywhere the documentation should be updated, since it still ends up as a `String` - I can throw some language about it being a hex string into the `RadiusStateField` class, if that makes sense.