### PR TITLE
GUACAMOLE-316: Tweak to handling IE Compatibility Mode

### DIFF
--- a/guacamole/src/main/webapp/index.html
+++ b/guacamole/src/main/webapp/index.html
@@ -19,7 +19,8 @@
 -->
 <html ng-app="index" ng-controller="indexController">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta http-equiv="x-ua-compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, target-densitydpi=medium-dpi"/>
         <meta name="mobile-web-app-capable" content="yes"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>


### PR DESCRIPTION
This is a quick tweak suggested by the person who opened -316 in JIRA to correctly preventing Compatibility Mode from kicking in for IE when it is enabled for subnets or certain networks.

Tested with Chrome on Linux and Windows to make sure there were no adverse impacts, there, and then tested on IE11 and Edge in Windows 10.  I don't have compatibility mode enabled across my network, so I don't know that it actually resolves the issue, but it doesn't make things worse.  Will ping back on the JIRA issue and see if I can get the owner to test it for me - unless someone else can give it a try??