### PR TITLE
GUACAMOLE-499: Have REST API leverage built-in HTTP Status Codes

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
@@ -171,17 +171,11 @@ public class RESTExceptionWrapper implements MethodInterceptor {
         }
 
         // Translate GuacamoleException subclasses to HTTP error codes
-        catch (GuacamoleSecurityException e) {
-            throw new APIException(Response.Status.FORBIDDEN, e);
-        }
-        catch (GuacamoleResourceNotFoundException e) {
-            throw new APIException(Response.Status.NOT_FOUND, e);
-        }
-        catch (GuacamoleClientException e) {
-            throw new APIException(Response.Status.BAD_REQUEST, e);
-        }
         catch (GuacamoleException e) {
-            throw new APIException(Response.Status.INTERNAL_SERVER_ERROR, e);
+            throw new APIException(
+                Response.Status.fromStatusCode(e.getStatus().getHttpStatusCode()),
+                e
+            );
         }
 
         // Rethrow unchecked exceptions such that they are properly wrapped


### PR DESCRIPTION
This updates the exception handling in the `RESTExceptionWrapper` such that it uses the HTTP Status codes built into the `GuacamoleStatus` class instead of parsing out the `Response.Status` codes manually.