### PR TITLE
GUACAMOLE-504: Add getHttpStatusCode() method to GuacamoleException class

### DIFF
--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleException.java
@@ -80,5 +80,17 @@ public class GuacamoleException extends Exception {
     public int getHttpStatusCode() {
         return getStatus().getHttpStatusCode();
     }
+
+    /**
+     * Returns the most applicable WebSocket status code that can be
+     * associated with this exception.
+     *
+     * @return
+     *     An integer representing the most applicable WebSocket status
+     *     code associated with this exception.
+     */
+    public int getWebSocketCode() {
+        return getStatus().getWebSocketCode();
+    }
     
 }

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleException.java
@@ -70,12 +70,14 @@ public class GuacamoleException extends Exception {
     }
 
     /**
-     * Returns the numeric HTTP status code associated with this exception.
+     * Returns the most applicable HTTP status code that can be associated
+     * with this exception.
      *
      * @return
-     *     The numeric HTTP status code associated with this exception.
+     *     An integer representing the most applicable HTTP status code
+     *     associated with this exception.
      */
-    public Integer getHttpStatusCode() {
+    public int getHttpStatusCode() {
         return getStatus().getHttpStatusCode();
     }
     

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleException.java
@@ -68,5 +68,15 @@ public class GuacamoleException extends Exception {
     public GuacamoleStatus getStatus() {
         return GuacamoleStatus.SERVER_ERROR;
     }
+
+    /**
+     * Returns the numeric HTTP status code associated with this exception.
+     *
+     * @return
+     *     The numeric HTTP status code associated with this exception.
+     */
+    public Integer getHttpStatusCode() {
+        return getStatus().getHttpStatusCode();
+    }
     
 }

--- a/guacamole-common/src/main/java/org/apache/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
@@ -149,26 +149,23 @@ public abstract class GuacamoleHTTPTunnelServlet extends HttpServlet {
      * @param response
      *     The HTTP response to use to send the error.
      *
-     * @param guacStatus
-     *     The status to send
-     *
-     * @param message
-     *     A human-readable message that can be presented to the user.
+     * @param guacamoleException
+     *     The exception that caused this error.
      *
      * @throws ServletException
      *     If an error prevents sending of the error code.
      */
     protected void sendError(HttpServletResponse response,
-            GuacamoleStatus guacStatus, String message)
+            GuacamoleException guacamoleException)
             throws ServletException {
 
         try {
 
             // If response not committed, send error code and message
             if (!response.isCommitted()) {
-                response.addHeader("Guacamole-Status-Code", Integer.toString(guacStatus.getGuacamoleStatusCode()));
-                response.addHeader("Guacamole-Error-Message", message);
-                response.sendError(guacStatus.getHttpStatusCode());
+                response.addHeader("Guacamole-Status-Code", Integer.toString(guacamoleException.getStatus().getGuacamoleStatusCode()));
+                response.addHeader("Guacamole-Error-Message", guacamoleException.getMessage());
+                response.sendError(guacamoleException.getHttpStatusCode());
             }
 
         }
@@ -258,12 +255,12 @@ public abstract class GuacamoleHTTPTunnelServlet extends HttpServlet {
         // HTTP response, logging each error appropriately.
         catch (GuacamoleClientException e) {
             logger.warn("HTTP tunnel request rejected: {}", e.getMessage());
-            sendError(response, e.getStatus(), e.getMessage());
+            sendError(response, e);
         }
         catch (GuacamoleException e) {
             logger.error("HTTP tunnel request failed: {}", e.getMessage());
             logger.debug("Internal error in HTTP tunnel.", e);
-            sendError(response, e.getStatus(), "Internal server error.");
+            sendError(response, e);
         }
 
     }

--- a/guacamole-common/src/main/java/org/apache/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
@@ -259,18 +259,16 @@ public abstract class GuacamoleHTTPTunnelServlet extends HttpServlet {
 
         // Catch any thrown guacamole exception and attempt to pass within the
         // HTTP response, logging each error appropriately.
+        catch (GuacamoleClientException e) {
+            logger.warn("HTTP tunnel request rejected: {}", e.getMessage());
+            sendError(response, e.getStatus().getGuacamoleStatusCode(),
+                    e.getStatus().getHttpStatusCode(), e.getMessage());
+        }
         catch (GuacamoleException e) {
-            if (e instanceof GuacamoleClientException) {
-                logger.warn("HTTP tunnel request rejected: {}", e.getMessage());
-                sendError(response, e.getStatus().getGuacamoleStatusCode(),
-                        e.getStatus().getHttpStatusCode(), e.getMessage());
-            }
-            else {
-                logger.error("HTTP tunnel request failed: {}", e.getMessage());
-                logger.debug("Internal error in HTTP tunnel.", e);
-                sendError(response, e.getStatus().getGuacamoleStatusCode(),
-                        e.getStatus().getHttpStatusCode(), "Internal server error.");
-            }
+            logger.error("HTTP tunnel request failed: {}", e.getMessage());
+            logger.debug("Internal error in HTTP tunnel.", e);
+            sendError(response, e.getStatus().getGuacamoleStatusCode(),
+                    e.getStatus().getHttpStatusCode(), "Internal server error.");
         }
 
     }

--- a/guacamole-common/src/main/java/org/apache/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/servlet/GuacamoleHTTPTunnelServlet.java
@@ -165,7 +165,6 @@ public abstract class GuacamoleHTTPTunnelServlet extends HttpServlet {
             int guacamoleHttpCode, String message)
             throws ServletException {
 
-
         try {
 
             // If response not committed, send error code and message
@@ -241,14 +240,14 @@ public abstract class GuacamoleHTTPTunnelServlet extends HttpServlet {
 
             // If read operation, call doRead() with tunnel UUID, ignoring any
             // characters following the tunnel UUID.
-            else if(query.startsWith(READ_PREFIX))
+            else if (query.startsWith(READ_PREFIX))
                 doRead(request, response, query.substring(
                         READ_PREFIX_LENGTH,
                         READ_PREFIX_LENGTH + UUID_LENGTH));
 
             // If write operation, call doWrite() with tunnel UUID, ignoring any
             // characters following the tunnel UUID.
-            else if(query.startsWith(WRITE_PREFIX))
+            else if (query.startsWith(WRITE_PREFIX))
                 doWrite(request, response, query.substring(
                         WRITE_PREFIX_LENGTH,
                         WRITE_PREFIX_LENGTH + UUID_LENGTH));

--- a/guacamole-common/src/main/java/org/apache/guacamole/websocket/GuacamoleWebSocketTunnelEndpoint.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/websocket/GuacamoleWebSocketTunnelEndpoint.java
@@ -73,14 +73,12 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
      * @param guac_status The status to send.
      * @param webSocketCode The numeric WebSocket status to send.
      */
-    private void closeConnection(Session session, GuacamoleStatus guac_status,
-            Integer webSocketCode) {
+    private void closeConnection(Session session, int guacamoleStatusCode,
+            int webSocketCode) {
 
         try {
-            if (webSocketCode == null)
-                webSocketCode = guac_status.getWebSocketCode();
             CloseCode code = CloseReason.CloseCodes.getCloseCode(webSocketCode);
-            String message = Integer.toString(guac_status.getGuacamoleStatusCode());
+            String message = Integer.toString(guacamoleStatusCode);
             session.close(new CloseReason(code, message));
         }
         catch (IOException e) {
@@ -113,7 +111,8 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
             // Get tunnel
             tunnel = createTunnel(session, config);
             if (tunnel == null) {
-                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND, null);
+                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
+                        GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
                 return;
             }
 
@@ -121,7 +120,7 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
         catch (GuacamoleException e) {
             logger.error("Creation of WebSocket tunnel to guacd failed: {}", e.getMessage());
             logger.debug("Error connecting WebSocket tunnel.", e);
-            closeConnection(session, e.getStatus(), e.getWebSocketCode());
+            closeConnection(session, e.getStatus().getGuacamoleStatusCode(), e.getWebSocketCode());
             return;
         }
 
@@ -175,7 +174,8 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
                         }
 
                         // No more data
-                        closeConnection(session, GuacamoleStatus.SUCCESS, null);
+                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                GuacamoleStatus.SUCCESS.getWebSocketCode());
 
                     }
 
@@ -185,22 +185,24 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
                     catch (GuacamoleClientException e) {
                         logger.info("WebSocket connection terminated: {}", e.getMessage());
                         logger.debug("WebSocket connection terminated due to client error.", e);
-                        closeConnection(session, e.getStatus(), e.getWebSocketCode());
+                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(), e.getWebSocketCode());
                     }
                     catch (GuacamoleConnectionClosedException e) {
                         logger.debug("Connection to guacd closed.", e);
-                        closeConnection(session, GuacamoleStatus.SUCCESS, null);
+                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                GuacamoleStatus.SUCCESS.getWebSocketCode());
                     }
                     catch (GuacamoleException e) {
                         logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
                         logger.debug("Internal error during connection to guacd.", e);
-                        closeConnection(session, e.getStatus(), e.getWebSocketCode());
+                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(), e.getWebSocketCode());
                     }
 
                 }
                 catch (IOException e) {
                     logger.debug("I/O error prevents further reads.", e);
-                    closeConnection(session, GuacamoleStatus.SERVER_ERROR, null);
+                    closeConnection(session, GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
+                            GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
                 }
 
             }

--- a/guacamole-common/src/main/java/org/apache/guacamole/websocket/GuacamoleWebSocketTunnelEndpoint.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/websocket/GuacamoleWebSocketTunnelEndpoint.java
@@ -99,12 +99,12 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
      * @param session
      *     The outbound WebSocket connection to close.
      *
-     * @param guac_status
+     * @param guacStatus
      *     The status to use for the connection.
      */
-    private void closeConnection(Session session, GuacamoleStatus guac_status) {
-        closeConnection(session, guac_status.getGuacamoleStatusCode(),
-                guac_status.getWebSocketCode());
+    private void closeConnection(Session session, GuacamoleStatus guacStatus) {
+        closeConnection(session, guacStatus.getGuacamoleStatusCode(),
+                guacStatus.getWebSocketCode());
     }
 
     /**

--- a/guacamole-common/src/main/java/org/apache/guacamole/websocket/GuacamoleWebSocketTunnelEndpoint.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/websocket/GuacamoleWebSocketTunnelEndpoint.java
@@ -66,12 +66,17 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
     private GuacamoleTunnel tunnel;
     
     /**
-     * Sends the given status on the given WebSocket connection and closes the
-     * connection.
+     * Sends the numeric Guacaomle Status Code and Web Socket
+     * code and closes the connection.
      *
-     * @param session The outbound WebSocket connection to close.
-     * @param guac_status The status to send.
-     * @param webSocketCode The numeric WebSocket status to send.
+     * @param session
+     *     The outbound WebSocket connection to close.
+     *
+     * @param guacamoleStatusCode
+     *     The numeric Guacamole status to send.
+     *
+     * @param webSocketCode
+     *     The numeric WebSocket status to send.
      */
     private void closeConnection(Session session, int guacamoleStatusCode,
             int webSocketCode) {
@@ -85,6 +90,21 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
             logger.debug("Unable to close WebSocket connection.", e);
         }
 
+    }
+
+    /**
+     * Sends the given Guacaomle Status and closes the given
+     * connection.
+     *
+     * @param session
+     *     The outbound WebSocket connection to close.
+     *
+     * @param guac_status
+     *     The status to use for the connection.
+     */
+    private void closeConnection(Session session, GuacamoleStatus guac_status) {
+        closeConnection(session, guac_status.getGuacamoleStatusCode(),
+                guac_status.getWebSocketCode());
     }
 
     /**
@@ -111,8 +131,7 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
             // Get tunnel
             tunnel = createTunnel(session, config);
             if (tunnel == null) {
-                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
-                        GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
+                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND);
                 return;
             }
 
@@ -120,7 +139,8 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
         catch (GuacamoleException e) {
             logger.error("Creation of WebSocket tunnel to guacd failed: {}", e.getMessage());
             logger.debug("Error connecting WebSocket tunnel.", e);
-            closeConnection(session, e.getStatus().getGuacamoleStatusCode(), e.getWebSocketCode());
+            closeConnection(session, e.getStatus().getGuacamoleStatusCode(),
+                    e.getWebSocketCode());
             return;
         }
 
@@ -174,8 +194,7 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
                         }
 
                         // No more data
-                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                GuacamoleStatus.SUCCESS.getWebSocketCode());
+                        closeConnection(session, GuacamoleStatus.SUCCESS);
 
                     }
 
@@ -185,24 +204,24 @@ public abstract class GuacamoleWebSocketTunnelEndpoint extends Endpoint {
                     catch (GuacamoleClientException e) {
                         logger.info("WebSocket connection terminated: {}", e.getMessage());
                         logger.debug("WebSocket connection terminated due to client error.", e);
-                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(), e.getWebSocketCode());
+                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(),
+                                e.getWebSocketCode());
                     }
                     catch (GuacamoleConnectionClosedException e) {
                         logger.debug("Connection to guacd closed.", e);
-                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                GuacamoleStatus.SUCCESS.getWebSocketCode());
+                        closeConnection(session, GuacamoleStatus.SUCCESS);
                     }
                     catch (GuacamoleException e) {
                         logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
                         logger.debug("Internal error during connection to guacd.", e);
-                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(), e.getWebSocketCode());
+                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(),
+                                e.getWebSocketCode());
                     }
 
                 }
                 catch (IOException e) {
                     logger.debug("I/O error prevents further reads.", e);
-                    closeConnection(session, GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
-                            GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
+                    closeConnection(session, GuacamoleStatus.SERVER_ERROR);
                 }
 
             }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/RESTExceptionWrapper.java
@@ -173,7 +173,7 @@ public class RESTExceptionWrapper implements MethodInterceptor {
         // Translate GuacamoleException subclasses to HTTP error codes
         catch (GuacamoleException e) {
             throw new APIException(
-                Response.Status.fromStatusCode(e.getStatus().getHttpStatusCode()),
+                Response.Status.fromStatusCode(e.getHttpStatusCode()),
                 e
             );
         }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
@@ -53,18 +53,42 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
     private static final int BUFFER_SIZE = 8192;
 
     /**
-     * Sends the given status on the given WebSocket connection and closes the
+     * Sends the given numeric Guacamole and WebSocket status
+     * on the given WebSocket connection and closes the
      * connection.
      *
-     * @param connection The WebSocket connection to close.
-     * @param guac_status The status to send.
-     * @param webSocketCode The numeric WebSocket status code to send.
+     * @param connection
+     *     The WebSocket connection to close.
+     *
+     * @param guacamoleStatusCode
+     *     The numeric Guacamole Status code to send.
+     *
+     * @param webSocketCode
+     *     The numeric WebSocket status code to send.
      */
     private static void closeConnection(Connection connection,
             int guacamoleStatusCode, int webSocketCode) {
 
         connection.close(webSocketCode,
                 Integer.toString(guacamoleStatusCode));
+
+    }
+
+    /**
+     * Sends the given status on the given WebSocket connection
+     * and closes the connection.
+     *
+     * @param connection
+     *     The WebSocket connection to close.
+     *
+     * @param guac_status
+     *     The status to send.
+     */
+    private static void closeConnection(Connection connection,
+            GuacamoleStatus guac_status) {
+
+        closeConnection(connection, guac_status.getGuacamoleStatusCode(),
+                guac_status.getWebSocketCode());
 
     }
 
@@ -122,9 +146,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
 
                 // Do not start connection if tunnel does not exist
                 if (tunnel == null) {
-                    closeConnection(connection,
-                            GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
-                            GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
+                    closeConnection(connection, GuacamoleStatus.RESOURCE_NOT_FOUND);
                     return;
                 }
 
@@ -162,9 +184,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                                 }
 
                                 // No more data
-                                closeConnection(connection,
-                                        GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
+                                closeConnection(connection, GuacamoleStatus.SUCCESS);
                                 
                             }
 
@@ -179,9 +199,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                             }
                             catch (GuacamoleConnectionClosedException e) {
                                 logger.debug("Connection to guacd closed.", e);
-                                closeConnection(connection,
-                                        GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
+                                closeConnection(connection, GuacamoleStatus.SUCCESS);
                             }
                             catch (GuacamoleException e) {
                                 logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
@@ -193,9 +211,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                         }
                         catch (IOException e) {
                             logger.debug("WebSocket tunnel read failed due to I/O error.", e);
-                            closeConnection(connection,
-                                    GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
-                                    GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
+                            closeConnection(connection, GuacamoleStatus.SERVER_ERROR);
                         }
 
                     }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
@@ -58,11 +58,15 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
      *
      * @param connection The WebSocket connection to close.
      * @param guac_status The status to send.
+     * @param webSocketCode The numeric WebSocket status code to send.
      */
-    public static void closeConnection(Connection connection,
-            GuacamoleStatus guac_status) {
+    private static void closeConnection(Connection connection,
+            GuacamoleStatus guac_status, Integer webSocketCode) {
 
-        connection.close(guac_status.getWebSocketCode(),
+        if (webSocketCode == null)
+            webSocketCode = guac_status.getWebSocketCode();
+
+        connection.close(webSocketCode,
                 Integer.toString(guac_status.getGuacamoleStatusCode()));
 
     }
@@ -114,13 +118,13 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                 catch (GuacamoleException e) {
                     logger.error("Creation of WebSocket tunnel to guacd failed: {}", e.getMessage());
                     logger.debug("Error connecting WebSocket tunnel.", e);
-                    closeConnection(connection, e.getStatus());
+                    closeConnection(connection, e.getStatus(), e.getWebSocketCode());
                     return;
                 }
 
                 // Do not start connection if tunnel does not exist
                 if (tunnel == null) {
-                    closeConnection(connection, GuacamoleStatus.RESOURCE_NOT_FOUND);
+                    closeConnection(connection, GuacamoleStatus.RESOURCE_NOT_FOUND, null);
                     return;
                 }
 
@@ -158,7 +162,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                                 }
 
                                 // No more data
-                                closeConnection(connection, GuacamoleStatus.SUCCESS);
+                                closeConnection(connection, GuacamoleStatus.SUCCESS, null);
                                 
                             }
 
@@ -168,22 +172,22 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                             catch (GuacamoleClientException e) {
                                 logger.info("WebSocket connection terminated: {}", e.getMessage());
                                 logger.debug("WebSocket connection terminated due to client error.", e);
-                                closeConnection(connection, e.getStatus());
+                                closeConnection(connection, e.getStatus(), e.getWebSocketCode());
                             }
                             catch (GuacamoleConnectionClosedException e) {
                                 logger.debug("Connection to guacd closed.", e);
-                                closeConnection(connection, GuacamoleStatus.SUCCESS);
+                                closeConnection(connection, GuacamoleStatus.SUCCESS, null);
                             }
                             catch (GuacamoleException e) {
                                 logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
                                 logger.debug("Internal error during connection to guacd.", e);
-                                closeConnection(connection, e.getStatus());
+                                closeConnection(connection, e.getStatus(), e.getWebSocketCode());
                             }
 
                         }
                         catch (IOException e) {
                             logger.debug("WebSocket tunnel read failed due to I/O error.", e);
-                            closeConnection(connection, GuacamoleStatus.SERVER_ERROR);
+                            closeConnection(connection, GuacamoleStatus.SERVER_ERROR, null);
                         }
 
                     }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
@@ -81,14 +81,14 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
      * @param connection
      *     The WebSocket connection to close.
      *
-     * @param guac_status
+     * @param guacStatus
      *     The status to send.
      */
     private static void closeConnection(Connection connection,
-            GuacamoleStatus guac_status) {
+            GuacamoleStatus guacStatus) {
 
-        closeConnection(connection, guac_status.getGuacamoleStatusCode(),
-                guac_status.getWebSocketCode());
+        closeConnection(connection, guacStatus.getGuacamoleStatusCode(),
+                guacStatus.getWebSocketCode());
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty8/GuacamoleWebSocketTunnelServlet.java
@@ -61,13 +61,10 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
      * @param webSocketCode The numeric WebSocket status code to send.
      */
     private static void closeConnection(Connection connection,
-            GuacamoleStatus guac_status, Integer webSocketCode) {
-
-        if (webSocketCode == null)
-            webSocketCode = guac_status.getWebSocketCode();
+            int guacamoleStatusCode, int webSocketCode) {
 
         connection.close(webSocketCode,
-                Integer.toString(guac_status.getGuacamoleStatusCode()));
+                Integer.toString(guacamoleStatusCode));
 
     }
 
@@ -118,13 +115,16 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                 catch (GuacamoleException e) {
                     logger.error("Creation of WebSocket tunnel to guacd failed: {}", e.getMessage());
                     logger.debug("Error connecting WebSocket tunnel.", e);
-                    closeConnection(connection, e.getStatus(), e.getWebSocketCode());
+                    closeConnection(connection, e.getStatus().getGuacamoleStatusCode(),
+                            e.getWebSocketCode());
                     return;
                 }
 
                 // Do not start connection if tunnel does not exist
                 if (tunnel == null) {
-                    closeConnection(connection, GuacamoleStatus.RESOURCE_NOT_FOUND, null);
+                    closeConnection(connection,
+                            GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
+                            GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
                     return;
                 }
 
@@ -162,7 +162,9 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                                 }
 
                                 // No more data
-                                closeConnection(connection, GuacamoleStatus.SUCCESS, null);
+                                closeConnection(connection,
+                                        GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
                                 
                             }
 
@@ -172,22 +174,28 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                             catch (GuacamoleClientException e) {
                                 logger.info("WebSocket connection terminated: {}", e.getMessage());
                                 logger.debug("WebSocket connection terminated due to client error.", e);
-                                closeConnection(connection, e.getStatus(), e.getWebSocketCode());
+                                closeConnection(connection, e.getStatus().getGuacamoleStatusCode(),
+                                        e.getWebSocketCode());
                             }
                             catch (GuacamoleConnectionClosedException e) {
                                 logger.debug("Connection to guacd closed.", e);
-                                closeConnection(connection, GuacamoleStatus.SUCCESS, null);
+                                closeConnection(connection,
+                                        GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
                             }
                             catch (GuacamoleException e) {
                                 logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
                                 logger.debug("Internal error during connection to guacd.", e);
-                                closeConnection(connection, e.getStatus(), e.getWebSocketCode());
+                                closeConnection(connection, e.getStatus().getGuacamoleStatusCode(),
+                                        e.getWebSocketCode());
                             }
 
                         }
                         catch (IOException e) {
                             logger.debug("WebSocket tunnel read failed due to I/O error.", e);
-                            closeConnection(connection, GuacamoleStatus.SERVER_ERROR, null);
+                            closeConnection(connection,
+                                    GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
+                                    GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
                         }
 
                     }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty9/GuacamoleWebSocketTunnelListener.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty9/GuacamoleWebSocketTunnelListener.java
@@ -57,12 +57,18 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
     private GuacamoleTunnel tunnel;
  
     /**
-     * Sends the given status on the given WebSocket connection and closes the
+     * Sends the given numeric Guacamole and WebSocket status
+     * codes on the given WebSocket connection and closes the
      * connection.
      *
-     * @param session The outbound WebSocket connection to close.
-     * @param guac_status The status to send.
-     * @param webSocketCode The numeric WebSocket status code to send.
+     * @param session
+     *     The outbound WebSocket connection to close.
+     *
+     * @param guacamoleStatusCode
+     *     The numeric Guacamole status code to send.
+     *
+     * @param webSocketCode
+     *     The numeric WebSocket status code to send.
      */
     private void closeConnection(Session session, int guacamoleStatusCode,
             int webSocketCode) {
@@ -74,6 +80,24 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
         catch (IOException e) {
             logger.debug("Unable to close WebSocket connection.", e);
         }
+
+    }
+
+    /**
+     * Sends the given status on the given WebSocket connection
+     * and closes the connection.
+     *
+     * @param session
+     *     The outbound WebSocket connection to close.
+     *
+     * @param guac_status
+     *     The status to send.
+     */
+    private void closeConnection(Session session,
+            GuacamoleStatus guac_status) {
+
+        closeConnection(session, guac_status.getGuacamoleStatusCode(),
+                guac_status.getWebSocketCode());
 
     }
 
@@ -98,8 +122,7 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
             // Get tunnel
             tunnel = createTunnel(session);
             if (tunnel == null) {
-                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
-                        GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
+                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND);
                 return;
             }
 
@@ -151,8 +174,7 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
                         }
 
                         // No more data
-                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                GuacamoleStatus.SUCCESS.getWebSocketCode());
+                        closeConnection(session, GuacamoleStatus.SUCCESS);
 
                     }
 
@@ -167,8 +189,7 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
                     }
                     catch (GuacamoleConnectionClosedException e) {
                         logger.debug("Connection to guacd closed.", e);
-                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                GuacamoleStatus.SUCCESS.getWebSocketCode());
+                        closeConnection(session, GuacamoleStatus.SUCCESS);
                     }
                     catch (GuacamoleException e) {
                         logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
@@ -180,8 +201,7 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
                 }
                 catch (IOException e) {
                     logger.debug("I/O error prevents further reads.", e);
-                    closeConnection(session, GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
-                            GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
+                    closeConnection(session, GuacamoleStatus.SERVER_ERROR);
                 }
 
             }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty9/GuacamoleWebSocketTunnelListener.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty9/GuacamoleWebSocketTunnelListener.java
@@ -64,13 +64,11 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
      * @param guac_status The status to send.
      * @param webSocketCode The numeric WebSocket status code to send.
      */
-    private void closeConnection(Session session, GuacamoleStatus guac_status,
-            Integer webSocketCode) {
+    private void closeConnection(Session session, int guacamoleStatusCode,
+            int webSocketCode) {
 
         try {
-            if (webSocketCode == null)
-                webSocketCode = guac_status.getWebSocketCode();
-            String message = Integer.toString(guac_status.getGuacamoleStatusCode());
+            String message = Integer.toString(guacamoleStatusCode);
             session.close(new CloseStatus(webSocketCode, message));
         }
         catch (IOException e) {
@@ -100,7 +98,8 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
             // Get tunnel
             tunnel = createTunnel(session);
             if (tunnel == null) {
-                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND, null);
+                closeConnection(session, GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
+                        GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
                 return;
             }
 
@@ -108,7 +107,7 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
         catch (GuacamoleException e) {
             logger.error("Creation of WebSocket tunnel to guacd failed: {}", e.getMessage());
             logger.debug("Error connecting WebSocket tunnel.", e);
-            closeConnection(session, e.getStatus(), e.getWebSocketCode());
+            closeConnection(session, e.getStatus().getGuacamoleStatusCode(), e.getWebSocketCode());
             return;
         }
 
@@ -152,7 +151,8 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
                         }
 
                         // No more data
-                        closeConnection(session, GuacamoleStatus.SUCCESS, null);
+                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                GuacamoleStatus.SUCCESS.getWebSocketCode());
 
                     }
 
@@ -162,22 +162,26 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
                     catch (GuacamoleClientException e) {
                         logger.info("WebSocket connection terminated: {}", e.getMessage());
                         logger.debug("WebSocket connection terminated due to client error.", e);
-                        closeConnection(session, e.getStatus(), e.getWebSocketCode());
+                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(),
+                                e.getWebSocketCode());
                     }
                     catch (GuacamoleConnectionClosedException e) {
                         logger.debug("Connection to guacd closed.", e);
-                        closeConnection(session, GuacamoleStatus.SUCCESS, null);
+                        closeConnection(session, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                GuacamoleStatus.SUCCESS.getWebSocketCode());
                     }
                     catch (GuacamoleException e) {
                         logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
                         logger.debug("Internal error during connection to guacd.", e);
-                        closeConnection(session, e.getStatus(), e.getWebSocketCode());
+                        closeConnection(session, e.getStatus().getGuacamoleStatusCode(),
+                                e.getWebSocketCode());
                     }
 
                 }
                 catch (IOException e) {
                     logger.debug("I/O error prevents further reads.", e);
-                    closeConnection(session, GuacamoleStatus.SERVER_ERROR, null);
+                    closeConnection(session, GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
+                            GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
                 }
 
             }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty9/GuacamoleWebSocketTunnelListener.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/jetty9/GuacamoleWebSocketTunnelListener.java
@@ -90,14 +90,14 @@ public abstract class GuacamoleWebSocketTunnelListener implements WebSocketListe
      * @param session
      *     The outbound WebSocket connection to close.
      *
-     * @param guac_status
+     * @param guacStatus
      *     The status to send.
      */
     private void closeConnection(Session session,
-            GuacamoleStatus guac_status) {
+            GuacamoleStatus guacStatus) {
 
-        closeConnection(session, guac_status.getGuacamoleStatusCode(),
-                guac_status.getWebSocketCode());
+        closeConnection(session, guacStatus.getGuacamoleStatusCode(),
+                guacStatus.getWebSocketCode());
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
@@ -58,12 +58,18 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
     private final Logger logger = LoggerFactory.getLogger(GuacamoleWebSocketTunnelServlet.class);
 
     /**
-     * Sends the given status on the given WebSocket connection and closes the
+     * Sends the given Guacamole and WebSocket numeric status
+     * on the given WebSocket connection and closes the
      * connection.
      *
-     * @param outbound The outbound WebSocket connection to close.
-     * @param guac_status The status to send.
-     * @param webSocketCode The numeric WebSocket status code to send.
+     * @param outbound
+     *     The outbound WebSocket connection to close.
+     *
+     * @param guacamoleStatusCode
+     *     The status to send.
+     *
+     * @param webSocketCode
+     *     The numeric WebSocket status code to send.
      */
     private void closeConnection(WsOutbound outbound, int guacamoleStatusCode,
             int webSocketCode) {
@@ -75,6 +81,24 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
         catch (IOException e) {
             logger.debug("Unable to close WebSocket tunnel.", e);
         }
+
+    }
+
+    /**
+     * Sends the given status on the given WebSocket connection
+     * and closes the connection.
+     *
+     * @param outbound
+     *     The outbound WebSocket connection to close.
+     *
+     * @param guac_status
+     *     The status to send.
+     */
+    private void closeConnection(WsOutbound outbound,
+            GuacamoleStatus guac_status) {
+
+        closeConnection(outbound, guac_status.getGuacamoleStatusCode(),
+                guac_status.getWebSocketCode());
 
     }
 
@@ -151,8 +175,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
 
                 // Do not start connection if tunnel does not exist
                 if (tunnel == null) {
-                    closeConnection(outbound, GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
-                            GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
+                    closeConnection(outbound, GuacamoleStatus.RESOURCE_NOT_FOUND);
                     return;
                 }
 
@@ -190,8 +213,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                                 }
 
                                 // No more data
-                                closeConnection(outbound, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
+                                closeConnection(outbound, GuacamoleStatus.SUCCESS);
 
                             }
 
@@ -206,8 +228,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                             }
                             catch (GuacamoleConnectionClosedException e) {
                                 logger.debug("Connection to guacd closed.", e);
-                                closeConnection(outbound, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
-                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
+                                closeConnection(outbound, GuacamoleStatus.SUCCESS);
                             }
                             catch (GuacamoleException e) {
                                 logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
@@ -219,8 +240,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                         }
                         catch (IOException e) {
                             logger.debug("I/O error prevents further reads.", e);
-                            closeConnection(outbound, GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
-                                    GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
+                            closeConnection(outbound, GuacamoleStatus.SERVER_ERROR);
                         }
 
                     }

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
@@ -91,14 +91,14 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
      * @param outbound
      *     The outbound WebSocket connection to close.
      *
-     * @param guac_status
+     * @param guacStatus
      *     The status to send.
      */
     private void closeConnection(WsOutbound outbound,
-            GuacamoleStatus guac_status) {
+            GuacamoleStatus guacStatus) {
 
-        closeConnection(outbound, guac_status.getGuacamoleStatusCode(),
-                guac_status.getWebSocketCode());
+        closeConnection(outbound, guacStatus.getGuacamoleStatusCode(),
+                guacStatus.getWebSocketCode());
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
@@ -69,7 +69,7 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
             Integer webSocketCode) {
 
         try {
-            if(webSocketCode == null)
+            if (webSocketCode == null)
                 webSocketCode = guac_status.getWebSocketCode();
             byte[] message = Integer.toString(guac_status.getGuacamoleStatusCode()).getBytes("UTF-8");
             outbound.close(webSocketCode, ByteBuffer.wrap(message));

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/websocket/tomcat/GuacamoleWebSocketTunnelServlet.java
@@ -65,13 +65,11 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
      * @param guac_status The status to send.
      * @param webSocketCode The numeric WebSocket status code to send.
      */
-    private void closeConnection(WsOutbound outbound, GuacamoleStatus guac_status,
-            Integer webSocketCode) {
+    private void closeConnection(WsOutbound outbound, int guacamoleStatusCode,
+            int webSocketCode) {
 
         try {
-            if (webSocketCode == null)
-                webSocketCode = guac_status.getWebSocketCode();
-            byte[] message = Integer.toString(guac_status.getGuacamoleStatusCode()).getBytes("UTF-8");
+            byte[] message = Integer.toString(guacamoleStatusCode).getBytes("UTF-8");
             outbound.close(webSocketCode, ByteBuffer.wrap(message));
         }
         catch (IOException e) {
@@ -146,13 +144,15 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                 catch (GuacamoleException e) {
                     logger.error("Creation of WebSocket tunnel to guacd failed: {}", e.getMessage());
                     logger.debug("Error connecting WebSocket tunnel.", e);
-                    closeConnection(outbound, e.getStatus(), e.getWebSocketCode());
+                    closeConnection(outbound, e.getStatus().getGuacamoleStatusCode(),
+                            e.getWebSocketCode());
                     return;
                 }
 
                 // Do not start connection if tunnel does not exist
                 if (tunnel == null) {
-                    closeConnection(outbound, GuacamoleStatus.RESOURCE_NOT_FOUND, null);
+                    closeConnection(outbound, GuacamoleStatus.RESOURCE_NOT_FOUND.getGuacamoleStatusCode(),
+                            GuacamoleStatus.RESOURCE_NOT_FOUND.getWebSocketCode());
                     return;
                 }
 
@@ -190,7 +190,8 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                                 }
 
                                 // No more data
-                                closeConnection(outbound, GuacamoleStatus.SUCCESS, null);
+                                closeConnection(outbound, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
 
                             }
 
@@ -200,22 +201,26 @@ public abstract class GuacamoleWebSocketTunnelServlet extends WebSocketServlet {
                             catch (GuacamoleClientException e) {
                                 logger.info("WebSocket connection terminated: {}", e.getMessage());
                                 logger.debug("WebSocket connection terminated due to client error.", e);
-                                closeConnection(outbound, e.getStatus(), e.getWebSocketCode());
+                                closeConnection(outbound, e.getStatus().getGuacamoleStatusCode(),
+                                        e.getWebSocketCode());
                             }
                             catch (GuacamoleConnectionClosedException e) {
                                 logger.debug("Connection to guacd closed.", e);
-                                closeConnection(outbound, GuacamoleStatus.SUCCESS, null);
+                                closeConnection(outbound, GuacamoleStatus.SUCCESS.getGuacamoleStatusCode(),
+                                        GuacamoleStatus.SUCCESS.getWebSocketCode());
                             }
                             catch (GuacamoleException e) {
                                 logger.error("Connection to guacd terminated abnormally: {}", e.getMessage());
                                 logger.debug("Internal error during connection to guacd.", e);
-                                closeConnection(outbound, e.getStatus(), e.getWebSocketCode());
+                                closeConnection(outbound, e.getStatus().getGuacamoleStatusCode(),
+                                        e.getWebSocketCode());
                             }
 
                         }
                         catch (IOException e) {
                             logger.debug("I/O error prevents further reads.", e);
-                            closeConnection(outbound, GuacamoleStatus.SERVER_ERROR, null);
+                            closeConnection(outbound, GuacamoleStatus.SERVER_ERROR.getGuacamoleStatusCode(),
+                                    GuacamoleStatus.SERVER_ERROR.getWebSocketCode());
                         }
 
                     }


### PR DESCRIPTION
Adds the getHttpStatusCode() method to the GuacamoleException class, which will allow for exceptions to explicitly override the HTTP status code as required.