### PR TITLE
GUACAMOLE-304: Expand connection link to encompass entire hover area.

### DIFF
--- a/guacamole/src/main/webapp/app/home/styles/home.css
+++ b/guacamole/src/main/webapp/app/home/styles/home.css
@@ -50,3 +50,7 @@ div.recent-connections div.connection {
     max-width: 75%;
     overflow: hidden;
 }
+
+a.home-connection {
+    display: block;
+}


### PR DESCRIPTION
This PR expands the <a> tag for the connections on the home page such that it can be clicked anywhere that the hover region exists.