### PR TITLE
GUACAMOLE-508: Take user to home page when Settings pages are available.

### DIFF
--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -57,14 +57,22 @@ angular.module('navigation').factory('userPageService', ['$injector',
      *     A map of all root connection groups visible to the current user,
      *     where each key is the identifier of the corresponding data source.
      *
+     * @param {Object.<String, PermissionSet>} permissions
+     *     A map of all permissions granted to the current user, where each
+     *     key is the identifier of the corresponding data source.
+     *
+     * @param {Object.<String,
+     *
      * @returns {PageDefinition}
      *     The user's home page.
      */
-    var generateHomePage = function generateHomePage(rootGroups,permissions) {
+    var generateHomePage = function generateHomePage(rootGroups, permissions) {
 
         var homePage = null;
         var settingsPages = generateSettingsPages(permissions);
 
+        // If we have more than one setting page, return the main home page
+        // and don't worry about checking for a single connection.
         if (settingsPages.length > 1)
             return SYSTEM_HOME_PAGE;
 

--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -163,9 +163,12 @@ angular.module('navigation').factory('userPageService', ['$injector',
             authenticationService.getCurrentUsername()
         );
 
-        $q.all([getRootGroups,getPermissionSets])
+        $q.all({
+            rootGroups : getRootGroups,
+            permissionsSets : getPermissionSets
+        })
         .then(function rootConnectionGroupsPermissionsRetrieved(data) {
-            deferred.resolve(generateHomePage(data[0],data[1]));
+            deferred.resolve(generateHomePage(data.rootGroups,data.permissionsSets));
         });
 
         return deferred.promise;

--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -61,8 +61,6 @@ angular.module('navigation').factory('userPageService', ['$injector',
      *     A map of all permissions granted to the current user, where each
      *     key is the identifier of the corresponding data source.
      *
-     * @param {Object.<String,
-     *
      * @returns {PageDefinition}
      *     The user's home page.
      */
@@ -71,8 +69,10 @@ angular.module('navigation').factory('userPageService', ['$injector',
         var homePage = null;
         var settingsPages = generateSettingsPages(permissions);
 
-        // If we have more than one setting page, return the main home page
-        // and don't worry about checking for a single connection.
+        // If user has access to settings pages, return home page and skip
+        // evaluation for automatic connections.  The Preferences page is
+        // a Settings page and is always visible, so we look for more than
+        // one to indicate access to administrative pages.
         if (settingsPages.length > 1)
             return SYSTEM_HOME_PAGE;
 


### PR DESCRIPTION
Took a stab at an implementation of the improvement for 508, taking user to home screen when Settings pages are available.  It's worth noting that the "Preferences" page for users is pretty much always available, so this only does it if there is more than one Settings page available.

Not sure it's the most efficient route...open to suggestions.