### PR TITLE
GUACAMOLE-448: Fix typo in translation file.

### DIFF
--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -330,7 +330,7 @@
         "FIELD_HEADER_ENABLE_MENU_ANIMATIONS"     : "Enable menu animations:",
         "FIELD_HEADER_DISABLE_BITMAP_CACHING"     : "Disable bitmap caching:",
         "FIELD_HEADER_DISABLE_OFFSCREEN_CACHING"  : "Disable off-screen caching:",
-        "FIELD_HEADER_DISAbLE_GLYPH_CACHING"      : "Disable glyph caching:",
+        "FIELD_HEADER_DISABLE_GLYPH_CACHING"      : "Disable glyph caching:",
         "FIELD_HEADER_ENABLE_PRINTING"            : "Enable printing:",
         "FIELD_HEADER_ENABLE_SFTP"     : "Enable SFTP:",
         "FIELD_HEADER_ENABLE_THEMING"             : "Enable theming:",


### PR DESCRIPTION
Typo in translation file from previous commit - quick PR to fix that.