### PR TITLE
GUACAMOLE-445: Add client-side changes for configuring RDP Printer Name

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -170,6 +170,10 @@
                     "options" : [ "true" ]
                 },
                 {
+                    "name"   : "printer-name",
+                    "type"   : "TEXT"
+                },
+                {
                     "name"    : "enable-drive",
                     "type"    : "BOOLEAN",
                     "options" : [ "true" ]

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -349,6 +349,7 @@
         "FIELD_HEADER_LOAD_BALANCE_INFO" : "Load balance info/cookie:",
         "FIELD_HEADER_PASSWORD"        : "Password:",
         "FIELD_HEADER_PORT"            : "Port:",
+        "FIELD_HEADER_PRINTER_NAME"    : "Redirected printer name:",
         "FIELD_HEADER_PRECONNECTION_BLOB" : "Preconnection BLOB (VM ID):",
         "FIELD_HEADER_PRECONNECTION_ID"   : "RDP source ID:",
         "FIELD_HEADER_READ_ONLY"      : "Read-only:",


### PR DESCRIPTION
This adds the client-side changes that correspond to the changes in guacamole-server to configure the name of the printer passed through in RDP connections.