### PR TITLE
GUACAMOLE-446: Allow redirected drive name to be configured

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -175,6 +175,10 @@
                     "options" : [ "true" ]
                 },
                 {
+                    "name"    : "drive-name",
+                    "type"    : "TEXT"
+                },
+                {
                     "name"  : "drive-path",
                     "type"  : "TEXT"
                 },

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -323,6 +323,7 @@
         "FIELD_HEADER_DISABLE_AUTH"    : "Disable authentication:",
         "FIELD_HEADER_DOMAIN"          : "Domain:",
         "FIELD_HEADER_DPI"             : "Resolution (DPI):",
+        "FIELD_HEADER_DRIVE_NAME"      : "Drive name:",
         "FIELD_HEADER_DRIVE_PATH"      : "Drive path:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Enable audio input (microphone):",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Enable desktop composition (Aero):",


### PR DESCRIPTION
Client-side changes to allow the drive name to be configured when redirecting a filesystem using RDP device redirection.