### PR TITLE
GUACAMOLE-517: Correct keysym definition of "Print Screen" key.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -561,7 +561,7 @@ Guacamole.Keyboard = function Keyboard(element) {
         "Pause": [0xFF13],
         "Play": [0xFD16],
         "PreviousCandidate": [0xFF3E],
-        "PrintScreen": [0xFD1D],
+        "PrintScreen": [0xFF61],
         "Redo": [0xFF66],
         "Right": [0xFF53],
         "RomanCharacters": null,


### PR DESCRIPTION
The "Print Screen" key is currently assigned to keysym 0xFD1D, which is `XK_3270_PrintScreen` and is technically incorrect. This should instead be 0xFF61 (`XK_Print`).