### PR TITLE
GUACAMOLE-542: Add AbstractUserContext and AbstractAuthenticationProvider base classes.

### DIFF
--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/CASAuthenticationProvider.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/CASAuthenticationProvider.java
@@ -22,10 +22,9 @@ package org.apache.guacamole.auth.cas;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
-import org.apache.guacamole.net.auth.UserContext;
 
 /**
  * Guacamole authentication backend which authenticates users using an
@@ -33,7 +32,7 @@ import org.apache.guacamole.net.auth.UserContext;
  * provided - only authentication. Storage must be provided by some other
  * extension.
  */
-public class CASAuthenticationProvider implements AuthenticationProvider {
+public class CASAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -64,11 +63,6 @@ public class CASAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public Object getResource() throws GuacamoleException {
-        return null;
-    }
-
-    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
 
@@ -76,54 +70,6 @@ public class CASAuthenticationProvider implements AuthenticationProvider {
         AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);
         return authProviderService.authenticateUser(credentials);
 
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // No update necessary
-        return authenticatedUser;
-
-    }
-
-    @Override
-    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
-            throws GuacamoleException {
-
-        // No associated data whatsoever
-        return null;
-
-    }
-
-    @Override
-    public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // No update necessary
-        return context;
-
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
     }
 
 }

--- a/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/DuoAuthenticationProvider.java
+++ b/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/DuoAuthenticationProvider.java
@@ -22,9 +22,8 @@ package org.apache.guacamole.auth.duo;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
-import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 
 /**
@@ -32,7 +31,7 @@ import org.apache.guacamole.net.auth.UserContext;
  * authentication factor for users which have already been authenticated by
  * some other AuthenticationProvider.
  */
-public class DuoAuthenticationProvider implements AuthenticationProvider {
+public class DuoAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -63,23 +62,6 @@ public class DuoAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public Object getResource() {
-        return null;
-    }
-
-    @Override
-    public AuthenticatedUser authenticateUser(Credentials credentials)
-            throws GuacamoleException {
-        return null;
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-        return authenticatedUser;
-    }
-
-    @Override
     public UserContext getUserContext(AuthenticatedUser authenticatedUser)
             throws GuacamoleException {
 
@@ -93,32 +75,6 @@ public class DuoAuthenticationProvider implements AuthenticationProvider {
         // continue
         return null;
 
-    }
-
-    @Override
-    public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-                throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
     }
 
 }

--- a/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/HTTPHeaderAuthenticationProvider.java
+++ b/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/HTTPHeaderAuthenticationProvider.java
@@ -22,10 +22,9 @@ package org.apache.guacamole.auth.header;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
-import org.apache.guacamole.net.auth.UserContext;
 
 /**
  * Guacamole authentication backend which authenticates users using an
@@ -33,7 +32,7 @@ import org.apache.guacamole.net.auth.UserContext;
  * provided - only authentication. Storage must be provided by some other
  * extension.
  */
-public class HTTPHeaderAuthenticationProvider implements AuthenticationProvider {
+public class HTTPHeaderAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -64,11 +63,6 @@ public class HTTPHeaderAuthenticationProvider implements AuthenticationProvider 
     }
 
     @Override
-    public Object getResource() {
-        return null;
-    }
-
-    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
 
@@ -76,54 +70,6 @@ public class HTTPHeaderAuthenticationProvider implements AuthenticationProvider 
         AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);
         return authProviderService.authenticateUser(credentials);
 
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // No update necessary
-        return authenticatedUser;
-
-    }
-
-    @Override
-    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
-            throws GuacamoleException {
-
-        // No associated data whatsoever
-        return null;
-
-    }
-
-    @Override
-    public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // No update necessary
-        return context;
-
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/InjectedAuthenticationProvider.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.auth.jdbc;
 
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
@@ -34,7 +34,7 @@ import org.apache.guacamole.net.auth.AuthenticatedUser;
  * AuthenticationProvider, even though it is the AuthenticationProvider that
  * serves as the entry point.
  */
-public abstract class InjectedAuthenticationProvider implements AuthenticationProvider {
+public abstract class InjectedAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * The AuthenticationProviderService to which all AuthenticationProvider
@@ -71,23 +71,9 @@ public abstract class InjectedAuthenticationProvider implements AuthenticationPr
     }
 
     @Override
-    public Object getResource() throws GuacamoleException {
-        return null;
-    }
-
-    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
         return authProviderService.authenticateUser(this, credentials);
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-
-        // No need to update authenticated users
-        return authenticatedUser;
-
     }
 
     @Override
@@ -102,25 +88,6 @@ public abstract class InjectedAuthenticationProvider implements AuthenticationPr
             throws GuacamoleException {
         return authProviderService.updateUserContext(this, context,
                 authenticatedUser, credentials);
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUserContext.java
@@ -20,27 +20,16 @@
 package org.apache.guacamole.auth.jdbc.sharing.user;
 
 import com.google.inject.Inject;
-import java.util.Collection;
-import java.util.Collections;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.sharing.connection.SharedConnectionDirectory;
 import org.apache.guacamole.auth.jdbc.sharing.connectiongroup.SharedRootConnectionGroup;
 import org.apache.guacamole.auth.jdbc.user.RemoteAuthenticatedUser;
-import org.apache.guacamole.form.Form;
-import org.apache.guacamole.net.auth.ActiveConnection;
-import org.apache.guacamole.net.auth.ActivityRecord;
-import org.apache.guacamole.net.auth.ActivityRecordSet;
+import org.apache.guacamole.net.auth.AbstractUserContext;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
-import org.apache.guacamole.net.auth.ConnectionRecord;
 import org.apache.guacamole.net.auth.Directory;
-import org.apache.guacamole.net.auth.SharingProfile;
 import org.apache.guacamole.net.auth.User;
-import org.apache.guacamole.net.auth.UserContext;
-import org.apache.guacamole.net.auth.simple.SimpleActivityRecordSet;
-import org.apache.guacamole.net.auth.simple.SimpleConnectionGroupDirectory;
-import org.apache.guacamole.net.auth.simple.SimpleDirectory;
 
 /**
  * The user context of a SharedUser, providing access ONLY to the user
@@ -48,7 +37,7 @@ import org.apache.guacamole.net.auth.simple.SimpleDirectory;
  * keys, and an internal root connection group containing only those
  * connections.
  */
-public class SharedUserContext implements UserContext {
+public class SharedUserContext extends AbstractUserContext {
 
     /**
      * The AuthenticationProvider that created this SharedUserContext.
@@ -66,18 +55,6 @@ public class SharedUserContext implements UserContext {
      */
     @Inject
     private SharedConnectionDirectory connectionDirectory;
-
-    /**
-     * A directory of all connection groups visible to the user for whom this
-     * user context was created.
-     */
-    private Directory<ConnectionGroup> connectionGroupDirectory;
-
-    /**
-     * A directory of all users visible to the user for whom this user context
-     * was created.
-     */
-    private Directory<User> userDirectory;
 
     /**
      * The root connection group of the hierarchy containing all connections
@@ -110,14 +87,9 @@ public class SharedUserContext implements UserContext {
 
         // The connection group directory contains only the root group
         this.rootGroup = new SharedRootConnectionGroup(this);
-        this.connectionGroupDirectory = new SimpleConnectionGroupDirectory(
-                Collections.singletonList(this.rootGroup));
 
         // Create internal pseudo-account representing the authenticated user
         this.self = new SharedUser(user, this);
-
-        // Do not provide access to any user accounts via the directory
-        this.userDirectory = new SimpleDirectory<User>();
 
     }
 
@@ -139,18 +111,8 @@ public class SharedUserContext implements UserContext {
     }
 
     @Override
-    public Object getResource() throws GuacamoleException {
-        return null;
-    }
-
-    @Override
     public AuthenticationProvider getAuthenticationProvider() {
         return authProvider;
-    }
-
-    @Override
-    public Directory<User> getUserDirectory() {
-        return userDirectory;
     }
 
     @Override
@@ -160,61 +122,8 @@ public class SharedUserContext implements UserContext {
     }
 
     @Override
-    public Directory<ConnectionGroup> getConnectionGroupDirectory() {
-        return connectionGroupDirectory;
-    }
-
-    @Override
-    public Directory<ActiveConnection> getActiveConnectionDirectory()
-            throws GuacamoleException {
-        return new SimpleDirectory<ActiveConnection>();
-    }
-
-    @Override
-    public Directory<SharingProfile> getSharingProfileDirectory()
-            throws GuacamoleException {
-        return new SimpleDirectory<SharingProfile>();
-    }
-
-    @Override
-    public ActivityRecordSet<ConnectionRecord> getConnectionHistory() {
-        return new SimpleActivityRecordSet<ConnectionRecord>();
-    }
-
-    @Override
-    public ActivityRecordSet<ActivityRecord> getUserHistory()
-            throws GuacamoleException {
-        return new SimpleActivityRecordSet<ActivityRecord>();
-    }
-
-    @Override
     public ConnectionGroup getRootConnectionGroup() {
         return rootGroup;
-    }
-
-    @Override
-    public Collection<Form> getUserAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public Collection<Form> getConnectionAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public Collection<Form> getConnectionGroupAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public Collection<Form> getSharingProfileAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public void invalidate() {
-        // Nothing to invalidate
     }
 
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProvider.java
@@ -23,8 +23,8 @@ package org.apache.guacamole.auth.ldap;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 
@@ -33,7 +33,7 @@ import org.apache.guacamole.net.auth.UserContext;
  * any number of authorized configurations. Authorized configurations may be
  * shared.
  */
-public class LDAPAuthenticationProvider implements AuthenticationProvider {
+public class LDAPAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * The identifier reserved for the root connection group.
@@ -69,22 +69,11 @@ public class LDAPAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public String getResource() {
-        return null;
-    }
-
-    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials) throws GuacamoleException {
 
         AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);
         return authProviderService.authenticateUser(credentials);
 
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-        return authenticatedUser;
     }
 
     @Override
@@ -96,31 +85,4 @@ public class LDAPAuthenticationProvider implements AuthenticationProvider {
 
     }
 
-    @Override
-    public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
-    }
-
 }
-

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
@@ -21,26 +21,18 @@ package org.apache.guacamole.auth.ldap.user;
 
 import com.google.inject.Inject;
 import com.novell.ldap.LDAPConnection;
-import java.util.Collection;
 import java.util.Collections;
-import org.apache.guacamole.auth.ldap.LDAPAuthenticationProvider;
 import org.apache.guacamole.auth.ldap.connection.ConnectionService;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.form.Form;
-import org.apache.guacamole.net.auth.ActiveConnection;
-import org.apache.guacamole.net.auth.ActivityRecord;
-import org.apache.guacamole.net.auth.ActivityRecordSet;
+import org.apache.guacamole.auth.ldap.LDAPAuthenticationProvider;
+import org.apache.guacamole.net.auth.AbstractUserContext;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
-import org.apache.guacamole.net.auth.ConnectionRecord;
 import org.apache.guacamole.net.auth.Directory;
-import org.apache.guacamole.net.auth.SharingProfile;
 import org.apache.guacamole.net.auth.User;
-import org.apache.guacamole.net.auth.simple.SimpleActivityRecordSet;
 import org.apache.guacamole.net.auth.simple.SimpleConnectionGroup;
-import org.apache.guacamole.net.auth.simple.SimpleConnectionGroupDirectory;
 import org.apache.guacamole.net.auth.simple.SimpleDirectory;
 import org.apache.guacamole.net.auth.simple.SimpleUser;
 import org.slf4j.Logger;
@@ -50,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * An LDAP-specific implementation of UserContext which queries all Guacamole
  * connections and users from the LDAP directory.
  */
-public class UserContext implements org.apache.guacamole.net.auth.UserContext {
+public class UserContext extends AbstractUserContext {
 
     /**
      * Logger for this class.
@@ -95,12 +87,6 @@ public class UserContext implements org.apache.guacamole.net.auth.UserContext {
     private Directory<Connection> connectionDirectory;
 
     /**
-     * Directory containing all ConnectionGroup objects accessible to the user
-     * associated with this UserContext.
-     */
-    private Directory<ConnectionGroup> connectionGroupDirectory;
-
-    /**
      * Reference to the root connection group.
      */
     private ConnectionGroup rootGroup;
@@ -143,15 +129,12 @@ public class UserContext implements org.apache.guacamole.net.auth.UserContext {
             Collections.<String>emptyList()
         );
 
-        // Expose only the root group in the connection group directory
-        connectionGroupDirectory = new SimpleConnectionGroupDirectory(Collections.singleton(rootGroup));
-
         // Init self with basic permissions
         self = new SimpleUser(
             user.getIdentifier(),
             userDirectory.getIdentifiers(),
             connectionDirectory.getIdentifiers(),
-            connectionGroupDirectory.getIdentifiers()
+            Collections.singleton(LDAPAuthenticationProvider.ROOT_CONNECTION_GROUP)
         );
 
     }
@@ -159,11 +142,6 @@ public class UserContext implements org.apache.guacamole.net.auth.UserContext {
     @Override
     public User self() {
         return self;
-    }
-
-    @Override
-    public String getResource() {
-        return null;
     }
 
     @Override
@@ -183,63 +161,8 @@ public class UserContext implements org.apache.guacamole.net.auth.UserContext {
     }
 
     @Override
-    public Directory<ConnectionGroup> getConnectionGroupDirectory()
-            throws GuacamoleException {
-        return connectionGroupDirectory;
-    }
-
-    @Override
     public ConnectionGroup getRootConnectionGroup() throws GuacamoleException {
         return rootGroup;
-    }
-
-    @Override
-    public Directory<ActiveConnection> getActiveConnectionDirectory()
-            throws GuacamoleException {
-        return new SimpleDirectory<ActiveConnection>();
-    }
-
-    @Override
-    public Directory<SharingProfile> getSharingProfileDirectory()
-            throws GuacamoleException {
-        return new SimpleDirectory<SharingProfile>();
-    }
-
-    @Override
-    public ActivityRecordSet<ConnectionRecord> getConnectionHistory()
-            throws GuacamoleException {
-        return new SimpleActivityRecordSet<ConnectionRecord>();
-    }
-
-    @Override
-    public ActivityRecordSet<ActivityRecord> getUserHistory()
-            throws GuacamoleException {
-        return new SimpleActivityRecordSet<ActivityRecord>();
-    }
-
-    @Override
-    public Collection<Form> getUserAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public Collection<Form> getConnectionAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public Collection<Form> getConnectionGroupAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public Collection<Form> getSharingProfileAttributes() {
-        return Collections.<Form>emptyList();
-    }
-
-    @Override
-    public void invalidate() {
-        // Nothing to invalidate
     }
 
 }

--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/OpenIDAuthenticationProvider.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/OpenIDAuthenticationProvider.java
@@ -22,10 +22,9 @@ package org.apache.guacamole.auth.openid;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
-import org.apache.guacamole.net.auth.UserContext;
 
 /**
  * Guacamole authentication backend which authenticates users using an
@@ -33,7 +32,7 @@ import org.apache.guacamole.net.auth.UserContext;
  * provided - only authentication. Storage must be provided by some other
  * extension.
  */
-public class OpenIDAuthenticationProvider implements AuthenticationProvider {
+public class OpenIDAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -64,11 +63,6 @@ public class OpenIDAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public Object getResource() throws GuacamoleException {
-        return null;
-    }
-
-    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
 
@@ -76,54 +70,6 @@ public class OpenIDAuthenticationProvider implements AuthenticationProvider {
         AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);
         return authProviderService.authenticateUser(credentials);
 
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // No update necessary
-        return authenticatedUser;
-
-    }
-
-    @Override
-    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
-            throws GuacamoleException {
-
-        // No associated data whatsoever
-        return null;
-
-    }
-
-    @Override
-    public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // No update necessary
-        return context;
-
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
     }
 
 }

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProvider.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProvider.java
@@ -23,17 +23,16 @@ package org.apache.guacamole.auth.radius;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
-import org.apache.guacamole.net.auth.UserContext;
 
 /**
  * Allows users to be authenticated against an RADIUS server. Each user may have
  * any number of authorized configurations. Authorized configurations may be
  * shared.
  */
-public class RadiusAuthenticationProvider implements AuthenticationProvider {
+public class RadiusAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -64,30 +63,6 @@ public class RadiusAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public Object getResource() throws GuacamoleException {
-        return null;
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return context;
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
-    }
-
-    @Override
     public AuthenticatedUser authenticateUser(Credentials credentials) throws GuacamoleException {
 
         AuthenticationProviderService authProviderService = injector.getInstance(AuthenticationProviderService.class);
@@ -95,26 +70,4 @@ public class RadiusAuthenticationProvider implements AuthenticationProvider {
 
     }
 
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-        return authenticatedUser;
-    }
-
-    @Override
-    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
-            throws GuacamoleException {
-
-        return null;
-
-    }
-
-    @Override
-    public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-        return context;
-    }
-
 }
-

--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/TOTPAuthenticationProvider.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/TOTPAuthenticationProvider.java
@@ -25,8 +25,8 @@ import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.totp.user.CodeUsageTrackingService;
 import org.apache.guacamole.auth.totp.user.TOTPUserContext;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 
@@ -35,7 +35,7 @@ import org.apache.guacamole.net.auth.UserContext;
  * authentication factor for users which have already been authenticated by
  * some other AuthenticationProvider.
  */
-public class TOTPAuthenticationProvider implements AuthenticationProvider {
+public class TOTPAuthenticationProvider extends AbstractAuthenticationProvider {
 
     /**
      * Injector which will manage the object graph of this authentication
@@ -62,36 +62,6 @@ public class TOTPAuthenticationProvider implements AuthenticationProvider {
     @Override
     public String getIdentifier() {
         return "totp";
-    }
-
-    @Override
-    public Object getResource() {
-        return null;
-    }
-
-    @Override
-    public AuthenticatedUser authenticateUser(Credentials credentials)
-            throws GuacamoleException {
-        return null;
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-        return authenticatedUser;
-    }
-
-    @Override
-    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
-            throws GuacamoleException {
-        return null;
-    }
-
-    @Override
-    public UserContext updateUserContext(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-                throws GuacamoleException {
-        return context;
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticationProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+import org.apache.guacamole.GuacamoleException;
+
+/**
+ * Base implementation of AuthenticationProvider which provides default
+ * implementations of most functions. Implementations must provide their
+ * own {@link getIdentifier()}, but otherwise need only override an implemented
+ * function if they wish to actually implement the functionality defined for
+ * that function by the AuthenticationProvider interface.
+ */
+public abstract class AbstractAuthenticationProvider implements AuthenticationProvider {
+
+    @Override
+    public Object getResource() throws GuacamoleException {
+        return null;
+    }
+
+    @Override
+    public AuthenticatedUser authenticateUser(Credentials credentials)
+            throws GuacamoleException {
+        return null;
+    }
+
+    @Override
+    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
+            Credentials credentials) throws GuacamoleException {
+        return authenticatedUser;
+    }
+
+    @Override
+    public UserContext getUserContext(AuthenticatedUser authenticatedUser)
+            throws GuacamoleException {
+        return null;
+    }
+
+    @Override
+    public UserContext updateUserContext(UserContext context,
+            AuthenticatedUser authenticatedUser,
+            Credentials credentials) throws GuacamoleException {
+        return context;
+    }
+
+    @Override
+    public UserContext decorate(UserContext context,
+            AuthenticatedUser authenticatedUser,
+            Credentials credentials) throws GuacamoleException {
+        return context;
+    }
+
+    @Override
+    public UserContext redecorate(UserContext decorated, UserContext context,
+            AuthenticatedUser authenticatedUser,
+            Credentials credentials) throws GuacamoleException {
+        return decorate(context, authenticatedUser, credentials);
+    }
+
+    @Override
+    public void shutdown() {
+    }
+    
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticationProvider.java
@@ -24,35 +24,82 @@ import org.apache.guacamole.GuacamoleException;
 /**
  * Base implementation of AuthenticationProvider which provides default
  * implementations of most functions. Implementations must provide their
- * own {@link getIdentifier()}, but otherwise need only override an implemented
+ * own {@link #getIdentifier()}, but otherwise need only override an implemented
  * function if they wish to actually implement the functionality defined for
  * that function by the AuthenticationProvider interface.
  */
 public abstract class AbstractAuthenticationProvider implements AuthenticationProvider {
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns {@code null}. Implementations that
+     * wish to expose REST resources which are not specific to a user's session
+     * should override this function.
+     */
     @Override
     public Object getResource() throws GuacamoleException {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation performs no authentication whatsoever, ignoring
+     * the provided {@code credentials} and simply returning {@code null}. Any
+     * authentication attempt will thus fall through to other
+     * {@link AuthenticationProvider} implementations, perhaps within other
+     * installed extensions, with this {@code AuthenticationProvider} making no
+     * claim regarding the user's identity nor whether the user should be
+     * allowed or disallowed from accessing Guacamole. Implementations that wish
+     * to authenticate users should override this function.
+     */
     @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns the provided
+     * {@code authenticatedUser} without modification. Implementations that
+     * wish to update a user's {@link AuthenticatedUser} object with respect to
+     * new {@link Credentials} received in requests which follow the initial,
+     * successful authentication attempt should override this function.
+     */
     @Override
     public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
             Credentials credentials) throws GuacamoleException {
         return authenticatedUser;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns {@code null}, effectively allowing
+     * authentication to continue but refusing to provide data for the given
+     * user. Implementations that wish to veto the authentication results of
+     * other {@link AuthenticationProvider} implementations or provide data for
+     * authenticated users should override this function.
+     */
     @Override
     public UserContext getUserContext(AuthenticatedUser authenticatedUser)
             throws GuacamoleException {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns the provided {@code context}
+     * without modification. Implementations that wish to update a user's
+     * {@link UserContext} object with respect to newly-updated
+     * {@link AuthenticatedUser} or {@link Credentials} (such as those received
+     * in requests which follow the initial, successful authentication attempt)
+     * should override this function.
+     */
     @Override
     public UserContext updateUserContext(UserContext context,
             AuthenticatedUser authenticatedUser,
@@ -60,6 +107,15 @@ public abstract class AbstractAuthenticationProvider implements AuthenticationPr
         return context;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns the provided {@code context}
+     * without performing any decoration. Implementations that wish to augment
+     * the functionality or data provided by other
+     * {@link AuthenticationProvider} implementations should override this
+     * function.
+     */
     @Override
     public UserContext decorate(UserContext context,
             AuthenticatedUser authenticatedUser,
@@ -67,6 +123,19 @@ public abstract class AbstractAuthenticationProvider implements AuthenticationPr
         return context;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply invokes
+     * {@link #decorate(UserContext,AuthenticatedUser,Credentials)} with the
+     * provided {@code context}, {@code authenticatedUser}, and
+     * {@code credentials}. Implementations which override
+     * {@link #decorate(UserContext,AuthenticatedUser,Credentials)} and which
+     * need to update their existing decorated object following possible
+     * updates to the {@link UserContext} or {@link AuthenticatedUser} (rather
+     * than generate an entirely new decorated object) should override this
+     * function.
+     */
     @Override
     public UserContext redecorate(UserContext decorated, UserContext context,
             AuthenticatedUser authenticatedUser,
@@ -74,6 +143,13 @@ public abstract class AbstractAuthenticationProvider implements AuthenticationPr
         return decorate(context, authenticatedUser, credentials);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation does nothing. Implementations that wish to perform
+     * cleanup tasks when the {@link AuthenticationProvider} is being unloaded
+     * should override this function.
+     */
     @Override
     public void shutdown() {
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.form.Form;
+import org.apache.guacamole.net.auth.simple.SimpleActivityRecordSet;
+import org.apache.guacamole.net.auth.simple.SimpleConnectionGroup;
+import org.apache.guacamole.net.auth.simple.SimpleDirectory;
+
+/**
+ * Base implementation of UserContext which provides default implementations of
+ * most functions. Implementations must provide their own {@link self()} and
+ * {@link getAuthenticationProvider()}, but otherwise need only override an
+ * implemented function if they wish to actually implement the functionality
+ * defined for that function by the UserContext interface.
+ */
+public abstract class AbstractUserContext implements UserContext {
+
+    /**
+     * The unique identifier that will be used for the root connection group if
+     * {@link #getRootConnectionGroup()} is not overridden.
+     */
+    protected static final String DEFAULT_ROOT_CONNECTION_GROUP = "ROOT";
+
+    @Override
+    public Object getResource() throws GuacamoleException {
+        return null;
+    }
+
+    @Override
+    public Directory<User> getUserDirectory() throws GuacamoleException {
+        return new SimpleDirectory<User>(self());
+    }
+
+    @Override
+    public Directory<Connection> getConnectionDirectory()
+            throws GuacamoleException {
+        return new SimpleDirectory<Connection>();
+    }
+
+    @Override
+    public Directory<ConnectionGroup> getConnectionGroupDirectory()
+            throws GuacamoleException {
+        return new SimpleDirectory<ConnectionGroup>(getRootConnectionGroup());
+    }
+
+    @Override
+    public Directory<ActiveConnection> getActiveConnectionDirectory()
+            throws GuacamoleException {
+        return new SimpleDirectory<ActiveConnection>();
+    }
+
+    @Override
+    public Directory<SharingProfile> getSharingProfileDirectory()
+            throws GuacamoleException {
+        return new SimpleDirectory<SharingProfile>();
+    }
+
+    @Override
+    public ActivityRecordSet<ConnectionRecord> getConnectionHistory()
+            throws GuacamoleException {
+        return new SimpleActivityRecordSet<ConnectionRecord>();
+    }
+
+    @Override
+    public ActivityRecordSet<ActivityRecord> getUserHistory()
+            throws GuacamoleException {
+        return new SimpleActivityRecordSet<ActivityRecord>();
+    }
+
+    @Override
+    public ConnectionGroup getRootConnectionGroup()
+            throws GuacamoleException {
+        return new SimpleConnectionGroup(
+            DEFAULT_ROOT_CONNECTION_GROUP,
+            DEFAULT_ROOT_CONNECTION_GROUP,
+            getConnectionDirectory().getIdentifiers(),
+            Collections.<String>emptySet()
+        );
+    }
+
+    @Override
+    public Collection<Form> getUserAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    @Override
+    public Collection<Form> getConnectionAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    @Override
+    public Collection<Form> getConnectionGroupAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    @Override
+    public Collection<Form> getSharingProfileAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    @Override
+    public void invalidate() {
+    }
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
@@ -29,8 +29,8 @@ import org.apache.guacamole.net.auth.simple.SimpleDirectory;
 
 /**
  * Base implementation of UserContext which provides default implementations of
- * most functions. Implementations must provide their own {@link self()} and
- * {@link getAuthenticationProvider()}, but otherwise need only override an
+ * most functions. Implementations must provide their own {@link #self()} and
+ * {@link #getAuthenticationProvider()}, but otherwise need only override an
  * implemented function if they wish to actually implement the functionality
  * defined for that function by the UserContext interface.
  */
@@ -42,52 +42,122 @@ public abstract class AbstractUserContext implements UserContext {
      */
     protected static final String DEFAULT_ROOT_CONNECTION_GROUP = "ROOT";
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns {@code null}. Implementations that
+     * wish to expose REST resources specific to a user's session should
+     * override this function.
+     */
     @Override
     public Object getResource() throws GuacamoleException {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation returns a {@link Directory} which contains only
+     * the {@link User} returned by {@link #self()} (the current user
+     * associated with this {@link UserContext}. Implementations that wish to
+     * expose the existence of other users should override this function.
+     */
     @Override
     public Directory<User> getUserDirectory() throws GuacamoleException {
         return new SimpleDirectory<User>(self());
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Directory}.
+     * Implementations that wish to expose connections should override this
+     * function.
+     */
     @Override
     public Directory<Connection> getConnectionDirectory()
             throws GuacamoleException {
         return new SimpleDirectory<Connection>();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation returns a {@link Directory} which contains only
+     * the root connection group returned by {@link #getRootConnectionGroup()}.
+     * Implementations that wish to provide a structured connection hierarchy
+     * should override this function. If only a flat list of connections will
+     * be used, only {@link #getConnectionDirectory()} needs to be overridden.
+     */
     @Override
     public Directory<ConnectionGroup> getConnectionGroupDirectory()
             throws GuacamoleException {
         return new SimpleDirectory<ConnectionGroup>(getRootConnectionGroup());
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Directory}.
+     * Implementations that wish to expose the status of active connections
+     * should override this function.
+     */
     @Override
     public Directory<ActiveConnection> getActiveConnectionDirectory()
             throws GuacamoleException {
         return new SimpleDirectory<ActiveConnection>();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Directory}.
+     * Implementations that wish to provide screen sharing functionality
+     * through the use of sharing profiles should override this function.
+     */
     @Override
     public Directory<SharingProfile> getSharingProfileDirectory()
             throws GuacamoleException {
         return new SimpleDirectory<SharingProfile>();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link ActivityRecordSet}.
+     * Implementations that wish to expose connection usage history should
+     * override this function.
+     */
     @Override
     public ActivityRecordSet<ConnectionRecord> getConnectionHistory()
             throws GuacamoleException {
         return new SimpleActivityRecordSet<ConnectionRecord>();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link ActivityRecordSet}.
+     * Implementations that wish to expose user login/logout history should
+     * override this function.
+     */
     @Override
     public ActivityRecordSet<ActivityRecord> getUserHistory()
             throws GuacamoleException {
         return new SimpleActivityRecordSet<ActivityRecord>();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation returns a new {@link ConnectionGroup} with the
+     * identifier defined by {@link #DEFAULT_ROOT_CONNECTION_GROUP} and
+     * containing all connections exposed by the {@link Directory} returned by
+     * {@link #getConnectionDirectory()}. Implementations that wish to provide
+     * a structured connection hierarchy should override this function. If only
+     * a flat list of connections will be used, only
+     * {@link #getConnectionDirectory()} needs to be overridden.
+     */
     @Override
     public ConnectionGroup getRootConnectionGroup()
             throws GuacamoleException {
@@ -99,26 +169,62 @@ public abstract class AbstractUserContext implements UserContext {
         );
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Collection}.
+     * Implementations that wish to expose custom user attributes as fields
+     * within user edit screens should override this function.
+     */
     @Override
     public Collection<Form> getUserAttributes() {
         return Collections.<Form>emptyList();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Collection}.
+     * Implementations that wish to expose custom connection attributes as
+     * fields within connection edit screens should override this function.
+     */
     @Override
     public Collection<Form> getConnectionAttributes() {
         return Collections.<Form>emptyList();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Collection}.
+     * Implementations that wish to expose custom connection group attributes
+     * as fields within connection group edit screens should override this
+     * function.
+     */
     @Override
     public Collection<Form> getConnectionGroupAttributes() {
         return Collections.<Form>emptyList();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Collection}.
+     * Implementations that wish to expose custom sharing profile attributes as
+     * fields within sharing profile edit screens should override this function.
+     */
     @Override
     public Collection<Form> getSharingProfileAttributes() {
         return Collections.<Form>emptyList();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation does nothing. Implementations that wish to perform
+     * cleanup tasks when the user associated with this {@link UserContext} is
+     * being logged out should override this function.
+     */
     @Override
     public void invalidate() {
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
@@ -42,7 +43,7 @@ import org.apache.guacamole.token.TokenFilter;
  * the AuthenticationProvider interface of older Guacamole releases.
  */
 public abstract class SimpleAuthenticationProvider
-    implements AuthenticationProvider {
+    extends AbstractAuthenticationProvider {
 
     /**
      * Given an arbitrary credentials object, returns a Map containing all
@@ -204,11 +205,6 @@ public abstract class SimpleAuthenticationProvider
     }
 
     @Override
-    public Object getResource() throws GuacamoleException {
-        return null;
-    }
-
-    @Override
     public AuthenticatedUser authenticateUser(final Credentials credentials)
             throws GuacamoleException {
 
@@ -239,47 +235,6 @@ public abstract class SimpleAuthenticationProvider
         // Return user context restricted to authorized configs
         return new SimpleUserContext(this, authenticatedUser.getIdentifier(), configs);
 
-    }
-
-    @Override
-    public AuthenticatedUser updateAuthenticatedUser(AuthenticatedUser authenticatedUser,
-            Credentials credentials) throws GuacamoleException {
-
-        // Simply return the given user, updating nothing
-        return authenticatedUser;
-
-    }
-
-    @Override
-    public UserContext updateUserContext(UserContext context,
-        AuthenticatedUser authorizedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // Simply return the given context, updating nothing
-        return context;
-        
-    }
-
-    @Override
-    public UserContext decorate(UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-
-        // Simply return the given context, decorating nothing
-        return context;
-
-    }
-
-    @Override
-    public UserContext redecorate(UserContext decorated, UserContext context,
-            AuthenticatedUser authenticatedUser, Credentials credentials)
-            throws GuacamoleException {
-        return decorate(context, authenticatedUser, credentials);
-    }
-
-    @Override
-    public void shutdown() {
-        // Do nothing
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnectionDirectory.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnectionDirectory.java
@@ -28,7 +28,10 @@ import org.apache.guacamole.net.auth.Connection;
  * An extremely simple read-only implementation of a Directory of
  * GuacamoleConfigurations which provides access to a pre-defined Map of
  * GuacamoleConfigurations.
+ *
+ * @deprecated Use {@link SimpleDirectory} instead.
  */
+@Deprecated
 public class SimpleConnectionDirectory extends SimpleDirectory<Connection> {
 
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnectionGroupDirectory.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnectionGroupDirectory.java
@@ -28,7 +28,10 @@ import org.apache.guacamole.net.auth.ConnectionGroup;
  * An extremely simple read-only implementation of a Directory of
  * ConnectionGroup which provides which provides access to a pre-defined
  * Collection of ConnectionGroups.
+ *
+ * @deprecated Use {@link SimpleDirectory} instead.
  */
+@Deprecated
 public class SimpleConnectionGroupDirectory
     extends SimpleDirectory<ConnectionGroup> {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleDirectory.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleDirectory.java
@@ -23,9 +23,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.net.auth.Directory;
@@ -57,7 +57,7 @@ public class SimpleDirectory<ObjectType extends Identifiable>
     /**
      * Creates a new SimpleDirectory which provides access to the objects
      * contained within the given Map. The given Map will be used to back all
-     * operations on the SimpleDirectory, and must be threadsafe.
+     * operations on the SimpleDirectory.
      *
      * @param objects
      *     The Map of objects to provide access to.
@@ -66,10 +66,25 @@ public class SimpleDirectory<ObjectType extends Identifiable>
         this.objects = objects;
     }
 
+    /**
+     * Creates a new SimpleDirectory which provides access to the given object.
+     *
+     * @param object
+     *     The object to provide access to.
+     */
     public SimpleDirectory(ObjectType object) {
         this(Collections.singletonMap(object.getIdentifier(), object));
     }
 
+    /**
+     * Creates a new SimpleDirectory which provides access to the given
+     * objects. Note that a new Map will be created to store the given objects.
+     * If the objects are already available in Map form, it is more efficient
+     * to use the {@link #SimpleDirectory(java.util.Map)} constructor.
+     *
+     * @param objects
+     *     The objects that should be present in this directory.
+     */
     public SimpleDirectory(ObjectType... objects) {
         this(Arrays.asList(objects));
     }
@@ -85,7 +100,7 @@ public class SimpleDirectory<ObjectType extends Identifiable>
      *     A Collection of all objects that should be present in this directory.
      */
     public SimpleDirectory(Collection<ObjectType> objects) {
-        this.objects = new ConcurrentHashMap<String, ObjectType>(objects.size());
+        this.objects = new HashMap<String, ObjectType>(objects.size());
         for (ObjectType object : objects)
             this.objects.put(object.getIdentifier(), object);
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleDirectory.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleDirectory.java
@@ -20,10 +20,12 @@
 package org.apache.guacamole.net.auth.simple;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.net.auth.Directory;
@@ -54,13 +56,38 @@ public class SimpleDirectory<ObjectType extends Identifiable>
 
     /**
      * Creates a new SimpleDirectory which provides access to the objects
-     * contained within the given Map.
+     * contained within the given Map. The given Map will be used to back all
+     * operations on the SimpleDirectory, and must be threadsafe.
      *
      * @param objects
      *     The Map of objects to provide access to.
      */
     public SimpleDirectory(Map<String, ObjectType> objects) {
         this.objects = objects;
+    }
+
+    public SimpleDirectory(ObjectType object) {
+        this(Collections.singletonMap(object.getIdentifier(), object));
+    }
+
+    public SimpleDirectory(ObjectType... objects) {
+        this(Arrays.asList(objects));
+    }
+
+    /**
+     * Creates a new SimpleDirectory which provides access to the
+     * objects contained within the Collection. Note that a new Map will be
+     * created to store the given objects. If the objects are already available
+     * in Map form, it is more efficient to use the
+     * {@link #SimpleDirectory(java.util.Map)} constructor.
+     *
+     * @param objects
+     *     A Collection of all objects that should be present in this directory.
+     */
+    public SimpleDirectory(Collection<ObjectType> objects) {
+        this.objects = new ConcurrentHashMap<String, ObjectType>(objects.size());
+        for (ObjectType object : objects)
+            this.objects.put(object.getIdentifier(), object);
     }
 
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserDirectory.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserDirectory.java
@@ -25,7 +25,10 @@ import org.apache.guacamole.net.auth.User;
 /**
  * An extremely simple read-only implementation of a Directory of Users which
  * provides access to a single pre-defined User.
+ *
+ * @deprecated Use {@link SimpleDirectory} instead.
  */
+@Deprecated
 public class SimpleUserDirectory extends SimpleDirectory<User> {
 
     /**


### PR DESCRIPTION
Note that these changes also involved improving `SimpleDirectory` and, as a result, deprecating the `SimpleConnectionDirectory`, `SimpleUserDirectory`, etc. classes (as the `SimpleDirectory` now accomplishes everything necessary while being cleaner and more generic).