### PR TITLE
GUACAMOLE-220: Add base extension API support for user groups.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedAuthenticatedUser.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.auth.jdbc.sharing.user;
 
+import java.util.Collections;
+import java.util.Set;
 import org.apache.guacamole.auth.jdbc.user.RemoteAuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
@@ -98,6 +100,11 @@ public class SharedAuthenticatedUser extends RemoteAuthenticatedUser {
     @Override
     public void setIdentifier(String identifier) {
         throw new UnsupportedOperationException("Users authenticated via share keys are immutable.");
+    }
+
+    @Override
+    public Set<String> getEffectiveUserGroups() {
+        return Collections.<String>emptySet();
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUser.java
@@ -30,10 +30,13 @@ import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
+import org.apache.guacamole.net.auth.RelatedObjectSet;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 import org.apache.guacamole.net.auth.simple.SimpleObjectPermissionSet;
+import org.apache.guacamole.net.auth.simple.SimpleRelatedObjectSet;
 import org.apache.guacamole.net.auth.simple.SimpleSystemPermissionSet;
 
 /**
@@ -141,6 +144,11 @@ public class SharedUser implements User {
     }
 
     @Override
+    public ObjectPermissionSet getUserGroupPermissions() throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
     public ObjectPermissionSet getSharingProfilePermissions() throws GuacamoleException {
         return new SimpleObjectPermissionSet();
     }
@@ -148,6 +156,16 @@ public class SharedUser implements User {
     @Override
     public ObjectPermissionSet getActiveConnectionPermissions() throws GuacamoleException {
         return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public RelatedObjectSet getUserGroups() throws GuacamoleException {
+        return new SimpleRelatedObjectSet();
+    }
+
+    @Override
+    public Permissions getEffectivePermissions() throws GuacamoleException {
+        return this;
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -169,4 +169,9 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
         user.setIdentifier(identifier);
     }
 
+    @Override
+    public Set<String> getEffectiveUserGroups() {
+        return Collections.<String>emptySet();
+    }
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -52,10 +52,14 @@ import org.apache.guacamole.form.TextField;
 import org.apache.guacamole.form.TimeField;
 import org.apache.guacamole.form.TimeZoneField;
 import org.apache.guacamole.net.auth.ActivityRecord;
+import org.apache.guacamole.net.auth.Permissions;
+import org.apache.guacamole.net.auth.RelatedObjectSet;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermission;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
+import org.apache.guacamole.net.auth.simple.SimpleObjectPermissionSet;
+import org.apache.guacamole.net.auth.simple.SimpleRelatedObjectSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -377,6 +381,11 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     public ObjectPermissionSet getUserPermissions()
             throws GuacamoleException {
         return userPermissionService.getPermissionSet(getCurrentUser(), this);
+    }
+
+    @Override
+    public ObjectPermissionSet getUserGroupPermissions() throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
     }
 
     /**
@@ -837,6 +846,16 @@ public class ModeledUser extends ModeledDirectoryObject<UserModel> implements Us
     @Override
     public List<ActivityRecord> getHistory() throws GuacamoleException {
         return userService.retrieveHistory(getCurrentUser(), this);
+    }
+
+    @Override
+    public RelatedObjectSet getUserGroups() throws GuacamoleException {
+        return new SimpleRelatedObjectSet();
+    }
+
+    @Override
+    public Permissions getEffectivePermissions() throws GuacamoleException {
+        return this;
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
@@ -26,6 +26,7 @@ import org.apache.guacamole.auth.jdbc.connection.ConnectionDirectory;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.base.RestrictedObject;
@@ -46,6 +47,8 @@ import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.SharingProfile;
 import org.apache.guacamole.net.auth.User;
+import org.apache.guacamole.net.auth.UserGroup;
+import org.apache.guacamole.net.auth.simple.SimpleDirectory;
 
 /**
  * UserContext implementation which is driven by an arbitrary, underlying
@@ -162,6 +165,11 @@ public class ModeledUserContext extends RestrictedObject
     }
 
     @Override
+    public Directory<UserGroup> getUserGroupDirectory() throws GuacamoleException {
+        return new SimpleDirectory<UserGroup>();
+    }
+
+    @Override
     public Directory<Connection> getConnectionDirectory() throws GuacamoleException {
         return connectionDirectory;
     }
@@ -212,6 +220,11 @@ public class ModeledUserContext extends RestrictedObject
     @Override
     public Collection<Form> getUserAttributes() {
         return ModeledUser.ATTRIBUTES;
+    }
+
+    @Override
+    public Collection<Form> getUserGroupAttributes() {
+        return Collections.<Form>emptyList();
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
@@ -22,7 +22,6 @@ package org.apache.guacamole.net.auth;
 import java.util.Collections;
 import java.util.Set;
 
-
 /**
  * Basic implementation of an AuthenticatedUser which uses the username to
  * determine equality. Username comparison is case-sensitive.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
@@ -19,6 +19,9 @@
 
 package org.apache.guacamole.net.auth;
 
+import java.util.Collections;
+import java.util.Set;
+
 
 /**
  * Basic implementation of an AuthenticatedUser which uses the username to
@@ -28,6 +31,11 @@ public abstract class AbstractAuthenticatedUser extends AbstractIdentifiable
         implements AuthenticatedUser {
 
     // Prior functionality now resides within AbstractIdentifiable
+
+    @Override
+    public Set<String> getEffectiveUserGroups() {
+        return Collections.<String>emptySet();
+    }
 
     @Override
     public void invalidate() {

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
@@ -71,6 +71,19 @@ public abstract class AbstractUserContext implements UserContext {
      * {@inheritDoc}
      *
      * <p>This implementation simply returns an empty {@link Directory}.
+     * Implementations that wish to expose user groups should override this
+     * function.
+     */
+    @Override
+    public Directory<UserGroup> getUserGroupDirectory()
+            throws GuacamoleException {
+        return new SimpleDirectory<UserGroup>();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Directory}.
      * Implementations that wish to expose connections should override this
      * function.
      */
@@ -178,6 +191,18 @@ public abstract class AbstractUserContext implements UserContext {
      */
     @Override
     public Collection<Form> getUserAttributes() {
+        return Collections.<Form>emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns an empty {@link Collection}.
+     * Implementations that wish to expose custom user group attributes as
+     * fields within user group edit screens should override this function.
+     */
+    @Override
+    public Collection<Form> getUserGroupAttributes() {
         return Collections.<Form>emptyList();
     }
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.net.auth;
 
+import java.util.Set;
 
 /**
  * A user of the Guacamole web application who has been authenticated by an
@@ -48,6 +49,24 @@ public interface AuthenticatedUser extends Identifiable {
      *     The credentials provided by the user when they authenticated.
      */
     Credentials getCredentials();
+
+    /**
+     * Returns a read-only set of the identifiers of all user groups which
+     * apply to this authenticated user. The exact semantics of what user
+     * groups apply are up to the implementation, and the user groups within
+     * this set may be implied, derived dynamically, inherited through multiple
+     * levels of group membership, etc.
+     *
+     * Note that, as with user identifiers, user group identifiers form the
+     * basis of identity which applies across authentication providers. It is
+     * expected that any two user groups having the same identifier represent
+     * the same group, even if defined by different authentication providers
+     *
+     * @return
+     *     A read-only set of the identifiers of all user groups which apply
+     *     to this authenticated user.
+     */
+    Set<String> getEffectiveUserGroups();
 
     /**
      * Invalidates this authenticated user and their associated token such that

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
@@ -60,7 +60,7 @@ public interface AuthenticatedUser extends Identifiable {
      * Note that, as with user identifiers, user group identifiers form the
      * basis of identity which applies across authentication providers. It is
      * expected that any two user groups having the same identifier represent
-     * the same group, even if defined by different authentication providers
+     * the same group, even if defined by different authentication providers.
      *
      * @return
      *     A read-only set of the identifiers of all user groups which apply

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
@@ -66,6 +66,11 @@ public class DelegatingUserContext implements UserContext {
     }
 
     @Override
+    public Directory<UserGroup> getUserGroupDirectory() throws GuacamoleException {
+        return userContext.getUserGroupDirectory();
+    }
+
+    @Override
     public Directory<Connection> getConnectionDirectory()
             throws GuacamoleException {
         return userContext.getConnectionDirectory();
@@ -109,6 +114,11 @@ public class DelegatingUserContext implements UserContext {
     @Override
     public Collection<Form> getUserAttributes() {
         return userContext.getUserAttributes();
+    }
+
+    @Override
+    public Collection<Form> getUserGroupAttributes() {
+        return userContext.getUserGroupAttributes();
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserGroup.java
@@ -19,125 +19,107 @@
 
 package org.apache.guacamole.net.auth;
 
-import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 
 /**
- * User implementation which simply delegates all function calls to an
- * underlying User.
+ * UserGroup implementation which simply delegates all function calls to an
+ * underlying UserGroup.
  */
-public class DelegatingUser implements User {
+public class DelegatingUserGroup implements UserGroup {
 
     /**
-     * The wrapped User.
+     * The wrapped UserGroup.
      */
-    private final User user;
+    private final UserGroup userGroup;
 
     /**
-     * Wraps the given User such that all function calls against this
-     * DelegatingUser will be delegated to it.
+     * Wraps the given UserGroup such that all function calls against this
+     * DelegatingUserGroup will be delegated to it.
      *
-     * @param user
-     *     The User to wrap.
+     * @param userGroup
+     *     The UserGroup to wrap.
      */
-    public DelegatingUser(User user) {
-        this.user = user;
+    public DelegatingUserGroup(UserGroup userGroup) {
+        this.userGroup = userGroup;
     }
 
     @Override
     public String getIdentifier() {
-        return user.getIdentifier();
+        return userGroup.getIdentifier();
     }
 
     @Override
     public void setIdentifier(String identifier) {
-        user.setIdentifier(identifier);
-    }
-
-    @Override
-    public String getPassword() {
-        return user.getPassword();
-    }
-
-    @Override
-    public void setPassword(String password) {
-        user.setPassword(password);
+        userGroup.setIdentifier(identifier);
     }
 
     @Override
     public Map<String, String> getAttributes() {
-        return user.getAttributes();
+        return userGroup.getAttributes();
     }
 
     @Override
     public void setAttributes(Map<String, String> attributes) {
-        user.setAttributes(attributes);
-    }
-
-    @Override
-    public Date getLastActive() {
-        return user.getLastActive();
-    }
-
-    @Override
-    public List<? extends ActivityRecord> getHistory()
-            throws GuacamoleException {
-        return user.getHistory();
+        userGroup.setAttributes(attributes);
     }
 
     @Override
     public SystemPermissionSet getSystemPermissions()
             throws GuacamoleException {
-        return user.getSystemPermissions();
+        return userGroup.getSystemPermissions();
     }
 
     @Override
     public ObjectPermissionSet getConnectionPermissions()
             throws GuacamoleException {
-        return user.getConnectionPermissions();
+        return userGroup.getConnectionPermissions();
     }
 
     @Override
     public ObjectPermissionSet getConnectionGroupPermissions()
             throws GuacamoleException {
-        return user.getConnectionGroupPermissions();
+        return userGroup.getConnectionGroupPermissions();
     }
 
     @Override
     public ObjectPermissionSet getSharingProfilePermissions()
             throws GuacamoleException {
-        return user.getSharingProfilePermissions();
+        return userGroup.getSharingProfilePermissions();
     }
 
     @Override
     public ObjectPermissionSet getActiveConnectionPermissions()
             throws GuacamoleException {
-        return user.getActiveConnectionPermissions();
+        return userGroup.getActiveConnectionPermissions();
     }
 
     @Override
     public ObjectPermissionSet getUserPermissions() throws GuacamoleException {
-        return user.getUserPermissions();
+        return userGroup.getUserPermissions();
     }
 
     @Override
     public ObjectPermissionSet getUserGroupPermissions()
             throws GuacamoleException {
-        return user.getUserGroupPermissions();
+        return userGroup.getUserGroupPermissions();
     }
 
     @Override
     public RelatedObjectSet getUserGroups() throws GuacamoleException {
-        return user.getUserGroups();
+        return userGroup.getUserGroups();
     }
 
     @Override
-    public Permissions getEffectivePermissions() throws GuacamoleException {
-        return user.getEffectivePermissions();
+    public RelatedObjectSet getMemberUsers() throws GuacamoleException {
+        return userGroup.getMemberUsers();
+    }
+
+    @Override
+    public RelatedObjectSet getMemberUserGroups() throws GuacamoleException {
+        return userGroup.getMemberUserGroups();
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Permissions.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Permissions.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
+import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
+
+/**
+ * An object which may be granted permissions to access/manipulate various
+ * other objects or aspects of the system. The permissions granted are exposed
+ * through subclasses of PermissionSet, and may be mutable depending on the
+ * access level of the current user.
+ */
+public interface Permissions {
+
+    /**
+     * Returns all permissions given to this object regarding currently-active
+     * connections.
+     *
+     * @return
+     *     An ObjectPermissionSet of all active connection permissions granted
+     *     to this object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving permissions, or if reading all
+     *     permissions is not allowed.
+     */
+    ObjectPermissionSet getActiveConnectionPermissions()
+            throws GuacamoleException;
+
+    /**
+     * Returns all connection group permissions given to this object.
+     *
+     * @return
+     *     An ObjectPermissionSet of all connection group permissions granted
+     *     to this object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving permissions, or if reading all
+     *     permissions is not allowed.
+     */
+    ObjectPermissionSet getConnectionGroupPermissions()
+            throws GuacamoleException;
+
+    /**
+     * Returns all connection permissions given to this object.
+     *
+     * @return
+     *     An ObjectPermissionSet of all connection permissions granted to this
+     *     object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving permissions, or if reading all
+     *     permissions is not allowed.
+     */
+    ObjectPermissionSet getConnectionPermissions() throws GuacamoleException;
+
+    /**
+     * Returns all sharing profile permissions given to this object.
+     *
+     * @return
+     *     An ObjectPermissionSet of all sharing profile permissions granted to
+     *     this object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving permissions, or if reading all
+     *     permissions is not allowed.
+     */
+    ObjectPermissionSet getSharingProfilePermissions()
+            throws GuacamoleException;
+
+    /**
+     * Returns all system-level permissions given to this object.
+     *
+     * @return
+     *     A SystemPermissionSet of all system-level permissions granted to
+     *     this object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving permissions, or if reading all
+     *     permissions is not allowed.
+     */
+    SystemPermissionSet getSystemPermissions() throws GuacamoleException;
+
+    /**
+     * Returns all user permissions given to this object.
+     *
+     * @return
+     *     An ObjectPermissionSet of all user permissions granted to this
+     *     object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving permissions, or if reading all
+     *     permissions is not allowed.
+     */
+    ObjectPermissionSet getUserPermissions() throws GuacamoleException;
+
+    /**
+     * Returns all user group permissions given to this object.
+     *
+     * @return
+     *     An ObjectPermissionSet of all user group permissions granted to this
+     *     object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving permissions, or if reading all
+     *     permissions is not allowed.
+     */
+    ObjectPermissionSet getUserGroupPermissions() throws GuacamoleException;
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/RelatedObjectSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/RelatedObjectSet.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+import java.util.Set;
+import org.apache.guacamole.GuacamoleException;
+
+/**
+ * An arbitrary set of existing objects sharing some common relation. Unlike a
+ * Directory, which provides for maintaining the entire lifecycle of its
+ * objects, a RelatedObjectSet only maintains the relation between its
+ * containing object and the objects within the set. Adding/removing an object
+ * from a RelatedObjectSet affects only the status of the specific relationship
+ * represented by the RelatedObjectSet, not the existence of the objects
+ * themselves.
+ */
+public interface RelatedObjectSet {
+
+    /**
+     * Returns a Set which contains the identifiers of all objects contained
+     * within this RelatedObjectSet.
+     *
+     * @return
+     *     A Set which contains the identifiers of all objects contained
+     *     within this RelatedObjectSet.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the objects within the set, or
+     *     if objects cannot be retrieved due to lack of permissions to do so.
+     */
+    Set<String> getObjects() throws GuacamoleException;
+
+    /**
+     * Adds the objects having the given identifiers, if not already present.
+     * If a specified object is already present, no operation is performed
+     * regarding that object.
+     *
+     * @param identifiers
+     *     The identifiers of all objects being added.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while adding the objects, or if permission to add
+     *     objects is denied.
+     */
+    void addObjects(Set<String> identifiers) throws GuacamoleException;
+
+    /**
+     * Removes each of the objects having the specified identifiers, if
+     * present. If a specified object is not present, no operation is performed
+     * regarding that object.
+     *
+     * @param identifiers
+     *     The identifiers of all objects being removed.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while removing the objects, or if permission to
+     *     remove objects is denied.
+     */
+    void removeObjects(Set<String> identifiers) throws GuacamoleException;
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
@@ -122,7 +122,7 @@ public interface User extends Identifiable, Attributes, Permissions {
     /**
      * Returns a read-only view of all permissions granted to this user. The
      * exact semantics of what permissions are granted are up to the
-     * implementation, and the permissions within this view may implied,
+     * implementation, and the permissions within this view may be implied,
      * derived dynamically, inherited through multiple levels of group
      * membership, etc.
      *

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/User.java
@@ -22,14 +22,11 @@ package org.apache.guacamole.net.auth;
 import java.util.Date;
 import java.util.List;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
-import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
-
 
 /**
  * A user of the Guacamole web application.
  */
-public interface User extends Identifiable, Attributes {
+public interface User extends Identifiable, Attributes, Permissions {
 
     /**
      * All standard attribute names with semantics defined by the Guacamole web
@@ -109,85 +106,33 @@ public interface User extends Identifiable, Attributes {
     List<? extends ActivityRecord> getHistory() throws GuacamoleException;
 
     /**
-     * Returns all system-level permissions given to this user.
+     * Returns a set of all readable user groups of which this user is a member.
+     * If permission is granted for the current user to modify the membership of
+     * this user, then the returned set will be mutable, and any such
+     * modifications should be made through changes to the returned set.
      *
      * @return
-     *     A SystemPermissionSet of all system-level permissions granted to
-     *     this user.
+     *     The set of all readable user groups of which this user is a member.
      *
-     * @throws GuacamoleException 
-     *     If an error occurs while retrieving permissions, or if reading all
-     *     permissions is not allowed.
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the user groups.
      */
-    SystemPermissionSet getSystemPermissions() throws GuacamoleException;
+    RelatedObjectSet getUserGroups() throws GuacamoleException;
 
     /**
-     * Returns all connection permissions given to this user.
+     * Returns a read-only view of all permissions granted to this user. The
+     * exact semantics of what permissions are granted are up to the
+     * implementation, and the permissions within this view may implied,
+     * derived dynamically, inherited through multiple levels of group
+     * membership, etc.
      *
      * @return
-     *     An ObjectPermissionSet of all connection permissions granted to this
-     *     user.
-     *
-     * @throws GuacamoleException 
-     *     If an error occurs while retrieving permissions, or if reading all
-     *     permissions is not allowed.
-     */
-    ObjectPermissionSet getConnectionPermissions()
-            throws GuacamoleException;
-
-    /**
-     * Returns all connection group permissions given to this user.
-     *
-     * @return
-     *     An ObjectPermissionSet of all connection group permissions granted
-     *     to this user.
+     *     A read-only view of the permissions which are granted to this user.
      *
      * @throws GuacamoleException
      *     If an error occurs while retrieving permissions, or if reading all
      *     permissions is not allowed.
      */
-    ObjectPermissionSet getConnectionGroupPermissions()
-            throws GuacamoleException;
-
-    /**
-     * Returns all sharing profile permissions given to this user.
-     *
-     * @return
-     *     An ObjectPermissionSet of all sharing profile permissions granted to
-     *     this user.
-     *
-     * @throws GuacamoleException
-     *     If an error occurs while retrieving permissions, or if reading all
-     *     permissions is not allowed.
-     */
-    ObjectPermissionSet getSharingProfilePermissions()
-            throws GuacamoleException;
-
-    /**
-     * Returns all permissions given to this user regarding currently-active
-     * connections.
-     *
-     * @return
-     *     An ObjectPermissionSet of all active connection permissions granted
-     *     to this user.
-     *
-     * @throws GuacamoleException 
-     *     If an error occurs while retrieving permissions, or if reading all
-     *     permissions is not allowed.
-     */
-    ObjectPermissionSet getActiveConnectionPermissions()
-            throws GuacamoleException;
-
-    /**
-     * Returns all user permissions given to this user.
-     *
-     * @return
-     *     An ObjectPermissionSet of all user permissions granted to this user.
-     *
-     * @throws GuacamoleException
-     *     If an error occurs while retrieving permissions, or if reading all
-     *     permissions is not allowed.
-     */
-    ObjectPermissionSet getUserPermissions() throws GuacamoleException;
+    Permissions getEffectivePermissions() throws GuacamoleException;
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
@@ -85,6 +85,20 @@ public interface UserContext {
     Directory<User> getUserDirectory() throws GuacamoleException;
 
     /**
+     * Retrieves a Directory which can be used to view and manipulate user
+     * groups, but only as allowed by the permissions given to the user of this
+     * UserContext.
+     *
+     * @return
+     *     A Directory whose operations are bound by the restrictions
+     *     of this UserContext.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while creating the Directory.
+     */
+    Directory<UserGroup> getUserGroupDirectory() throws GuacamoleException;
+
+    /**
      * Retrieves a Directory which can be used to view and manipulate
      * connections and their configurations, but only as allowed by the
      * permissions given to the user.
@@ -196,6 +210,17 @@ public interface UserContext {
      *     A collection of all attributes applicable to users.
      */
     Collection<Form> getUserAttributes();
+
+    /**
+     * Retrieves a collection of all attributes applicable to user groups. This
+     * collection will contain only those attributes which the current user has
+     * general permission to view or modify. If there are no such attributes,
+     * this collection will be empty.
+     *
+     * @return
+     *     A collection of all attributes applicable to user groups.
+     */
+    Collection<Form> getUserGroupAttributes();
 
     /**
      * Retrieves a collection of all attributes applicable to connections. This

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserGroup.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+import org.apache.guacamole.GuacamoleException;
+
+/**
+ * A user group of the Guacamole web application. Each user group may contain
+ * any number of Guacamole users and other user groups, and defines the
+ * permissions implicitly granted to its members.
+ */
+public interface UserGroup extends Identifiable, Attributes, Permissions {
+
+    /**
+     * Returns a set of all readable user groups that are members of this user
+     * group. If permission is granted for the current user to modify the
+     * members of this group, then the returned set will be mutable, and any
+     * such modifications should be made through changes to the returned set.
+     *
+     * @return
+     *     The set of all readable user groups that are members of this user
+     *     group, which may be mutable.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the user groups.
+     */
+    RelatedObjectSet getUserGroups() throws GuacamoleException;
+
+    /**
+     * Returns a set of all readable users that are members of this user group.
+     * If permission is granted for the current user to modify the members of
+     * this group, then the returned set will be mutable, and any such
+     * modifications should be made through changes to the returned set.
+     *
+     * @return
+     *     The set all readable users that are members of this user group,
+     *     which may be mutable.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the users.
+     */
+    RelatedObjectSet getMemberUsers() throws GuacamoleException;
+
+    /**
+     * Returns a set of all readable user groups that are members of this user
+     * group. If permission is granted for the current user to modify the
+     * members of this group, then the returned set will be mutable, and any
+     * such modifications should be made through changes to the returned set.
+     *
+     * @return
+     *     The set of all readable user groups that are members of this user
+     *     group, which may be mutable.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the user groups.
+     */
+    RelatedObjectSet getMemberUserGroups() throws GuacamoleException;
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserGroup.java
@@ -29,14 +29,15 @@ import org.apache.guacamole.GuacamoleException;
 public interface UserGroup extends Identifiable, Attributes, Permissions {
 
     /**
-     * Returns a set of all readable user groups that are members of this user
-     * group. If permission is granted for the current user to modify the
-     * members of this group, then the returned set will be mutable, and any
-     * such modifications should be made through changes to the returned set.
+     * Returns a set of all readable user groups of which this user group is a
+     * member. If permission is granted for the current user to modify the
+     * membership of this user group, then the returned set will be mutable,
+     * and any such modifications should be made through changes to the
+     * returned set.
      *
      * @return
-     *     The set of all readable user groups that are members of this user
-     *     group, which may be mutable.
+     *     The set of all readable user groups of which this user group is a
+     *     member.
      *
      * @throws GuacamoleException
      *     If an error occurs while retrieving the user groups.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -19,7 +19,9 @@
 
 package org.apache.guacamole.net.auth.simple;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
@@ -129,6 +131,11 @@ public abstract class SimpleAuthenticationProvider
         @Override
         public Credentials getCredentials() {
             return credentials;
+        }
+
+        @Override
+        public Set<String> getEffectiveUserGroups() {
+            return Collections.<String>emptySet();
         }
 
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleRelatedObjectSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleRelatedObjectSet.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth.simple;
+
+import java.util.Collections;
+import java.util.Set;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleSecurityException;
+import org.apache.guacamole.net.auth.RelatedObjectSet;
+
+/**
+ * A read-only implementation of RelatedObjectSet which uses a backing Set
+ * of identifiers to determine which objects are present.
+ */
+public class SimpleRelatedObjectSet implements RelatedObjectSet {
+
+    /**
+     * A set containing the identifiers of all objects currently present.
+     */
+    private Set<String> identifiers = Collections.<String>emptySet();
+
+    /**
+     * Creates a new empty SimpleObjectPermissionSet.
+     */
+    public SimpleRelatedObjectSet() {
+    }
+
+    /**
+     * Creates a new SimpleRelatedObjectSet which contains the objects having
+     * the identifiers within the given Set. The given Set backs the contents
+     * of the new SimpleRelatedObjectSet. While the SimpleRelatedObjectSet is
+     * read-only, any changes to the underlying Set will be reflected in the
+     * SimpleRelatedObjectSet.
+     *
+     * @param identifiers
+     *     The Set containing the identifiers of all objects which should be
+     *     present within the new SimpleRelatedObjectSet.
+     */
+    public SimpleRelatedObjectSet(Set<String> identifiers) {
+        this.identifiers = identifiers;
+    }
+
+    /**
+     * Replaces the Set of object identifiers which backs this
+     * SimpleRelatedObjectSet. Future function calls on this
+     * SimpleRelatedObjectSet will instead use the provided Set.
+     *
+     * @param identifiers
+     *     The Set containing the identifiers of all objects which should be
+     *     present within this SimpleRelatedObjectSet.
+     */
+    protected void setObjects(Set<String> identifiers) {
+        this.identifiers = identifiers;
+    }
+
+    @Override
+    public Set<String> getObjects() {
+        return identifiers;
+    }
+
+    @Override
+    public void addObjects(Set<String> identifiers) throws GuacamoleException {
+        throw new GuacamoleSecurityException("Permission denied.");
+    }
+
+    @Override
+    public void removeObjects(Set<String> identifiers) throws GuacamoleException {
+        throw new GuacamoleSecurityException("Permission denied.");
+    }
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AbstractUser;
 import org.apache.guacamole.net.auth.ActivityRecord;
+import org.apache.guacamole.net.auth.Permissions;
+import org.apache.guacamole.net.auth.RelatedObjectSet;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
@@ -201,6 +203,12 @@ public class SimpleUser extends AbstractUser {
     }
 
     @Override
+    public ObjectPermissionSet getUserGroupPermissions()
+            throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
     public ObjectPermissionSet getActiveConnectionPermissions()
             throws GuacamoleException {
         return new SimpleObjectPermissionSet();
@@ -209,6 +217,16 @@ public class SimpleUser extends AbstractUser {
     @Override
     public ObjectPermissionSet getSharingProfilePermissions() {
         return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public RelatedObjectSet getUserGroups() throws GuacamoleException {
+        return new SimpleRelatedObjectSet();
+    }
+
+    @Override
+    public Permissions getEffectivePermissions() throws GuacamoleException {
+        return this;
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionResource.java
@@ -38,7 +38,6 @@ import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.rest.directory.DirectoryView;
 import org.apache.guacamole.net.auth.SharingProfile;
-import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -121,8 +120,7 @@ public class ConnectionResource extends DirectoryObjectResource<Connection, APIC
             throws GuacamoleException {
 
         // Pull effective permissions
-        User self = userContext.self();
-        Permissions effective = self.getEffectivePermissions();
+        Permissions effective = userContext.self().getEffectivePermissions();
 
         // Retrieve permission sets
         SystemPermissionSet systemPermissions = effective.getSystemPermissions();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionResource.java
@@ -35,6 +35,7 @@ import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionRecord;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.rest.directory.DirectoryView;
 import org.apache.guacamole.net.auth.SharingProfile;
 import org.apache.guacamole.net.auth.User;
@@ -119,11 +120,13 @@ public class ConnectionResource extends DirectoryObjectResource<Connection, APIC
     public Map<String, String> getConnectionParameters()
             throws GuacamoleException {
 
+        // Pull effective permissions
         User self = userContext.self();
+        Permissions effective = self.getEffectivePermissions();
 
         // Retrieve permission sets
-        SystemPermissionSet systemPermissions = self.getSystemPermissions();
-        ObjectPermissionSet connectionPermissions = self.getConnectionPermissions();
+        SystemPermissionSet systemPermissions = effective.getSystemPermissions();
+        ObjectPermissionSet connectionPermissions = effective.getConnectionPermissions();
 
         // Deny access if adminstrative or update permission is missing
         String identifier = connection.getIdentifier();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupTree.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupTree.java
@@ -29,8 +29,8 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.SharingProfile;
-import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -356,9 +356,9 @@ public class ConnectionGroupTree {
         retrievedGroups.put(root.getIdentifier(), this.rootAPIGroup);
 
         // Store user's current permissions
-        User self = userContext.self();
-        this.connectionPermissions = self.getConnectionPermissions();
-        this.sharingProfilePermissions = self.getSharingProfilePermissions();
+        Permissions effective = userContext.self().getEffectivePermissions();
+        this.connectionPermissions = effective.getConnectionPermissions();
+        this.sharingProfilePermissions = effective.getSharingProfilePermissions();
 
         // Store required directories
         this.connectionDirectory = userContext.getConnectionDirectory();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
@@ -37,6 +37,7 @@ import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.GuacamoleUnsupportedException;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Identifiable;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
@@ -143,13 +144,14 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
 
         // An admin user has access to all objects
         User self = userContext.self();
-        SystemPermissionSet systemPermissions = self.getSystemPermissions();
+        Permissions effective = self.getEffectivePermissions();
+        SystemPermissionSet systemPermissions = effective.getSystemPermissions();
         boolean isAdmin = systemPermissions.hasPermission(SystemPermission.Type.ADMINISTER);
 
         // Filter objects, if requested
         Collection<String> identifiers = directory.getIdentifiers();
         if (!isAdmin && permissions != null && !permissions.isEmpty()) {
-            ObjectPermissionSet objectPermissions = self.getUserPermissions();
+            ObjectPermissionSet objectPermissions = effective.getUserPermissions();
             identifiers = objectPermissions.getAccessibleObjects(permissions, identifiers);
         }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
@@ -38,7 +38,6 @@ import org.apache.guacamole.GuacamoleUnsupportedException;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Identifiable;
 import org.apache.guacamole.net.auth.Permissions;
-import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -143,8 +142,7 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
             throws GuacamoleException {
 
         // An admin user has access to all objects
-        User self = userContext.self();
-        Permissions effective = self.getEffectivePermissions();
+        Permissions effective = userContext.self().getEffectivePermissions();
         SystemPermissionSet systemPermissions = effective.getSystemPermissions();
         boolean isAdmin = systemPermissions.hasPermission(SystemPermission.Type.ADMINISTER);
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/permission/APIPermissionSet.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/permission/APIPermissionSet.java
@@ -24,20 +24,20 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.net.auth.User;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermission;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 
 /**
- * The set of permissions which are granted to a specific user, organized by
- * object type and, if applicable, identifier. This object can be constructed
- * with arbitrary permissions present, or manipulated after creation through
- * the manipulation or replacement of its collections of permissions, but is
- * otherwise not intended for internal use as a data structure for permissions.
- * Its primary purpose is as a hierarchical format for exchanging granted
- * permissions with REST clients.
+ * The set of permissions which are granted to a specific user or user group,
+ * organized by object type and, if applicable, identifier. This object can be
+ * constructed with arbitrary permissions present, or manipulated after creation
+ * through the manipulation or replacement of its collections of permissions,
+ * but is otherwise not intended for internal use as a data structure for
+ * permissions. Its primary purpose is as a hierarchical format for exchanging
+ * granted permissions with REST clients.
  */
 public class APIPermissionSet {
 
@@ -146,24 +146,23 @@ public class APIPermissionSet {
     
     /**
      * Creates a new permission set containing all permissions currently
-     * granted to the given user.
+     * granted within the given Permissions object.
      *
-     * @param user
-     *     The user whose permissions should be stored within this permission
-     *     set.
+     * @param permissions
+     *     The permissions that should be stored within this permission set.
      *
      * @throws GuacamoleException
-     *     If an error occurs while retrieving the user's permissions.
+     *     If an error occurs while retrieving the permissions.
      */
-    public APIPermissionSet(User user) throws GuacamoleException {
+    public APIPermissionSet(Permissions permissions) throws GuacamoleException {
 
         // Add all permissions from the provided user
-        addSystemPermissions(systemPermissions,           user.getSystemPermissions());
-        addObjectPermissions(connectionPermissions,       user.getConnectionPermissions());
-        addObjectPermissions(connectionGroupPermissions,  user.getConnectionGroupPermissions());
-        addObjectPermissions(sharingProfilePermissions,   user.getSharingProfilePermissions());
-        addObjectPermissions(activeConnectionPermissions, user.getActiveConnectionPermissions());
-        addObjectPermissions(userPermissions,             user.getUserPermissions());
+        addSystemPermissions(systemPermissions,           permissions.getSystemPermissions());
+        addObjectPermissions(connectionPermissions,       permissions.getConnectionPermissions());
+        addObjectPermissions(connectionGroupPermissions,  permissions.getConnectionGroupPermissions());
+        addObjectPermissions(sharingProfilePermissions,   permissions.getSharingProfilePermissions());
+        addObjectPermissions(activeConnectionPermissions, permissions.getActiveConnectionPermissions());
+        addObjectPermissions(userPermissions,             permissions.getUserPermissions());
         
     }
 
@@ -229,7 +228,7 @@ public class APIPermissionSet {
 
     /**
      * Returns a map of user IDs to the set of permissions granted for that
-     * user. If no permissions are granted to a particular user, its ID will
+     * user. If no permissions are granted for a particular user, its ID will
      * not be present as a key in the map. This map is mutable, and changes to
      * to this map will affect the permission set directly.
      *

--- a/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.SharingProfile;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserContext;
@@ -103,11 +104,13 @@ public class SharingProfileResource
     public Map<String, String> getParameters()
             throws GuacamoleException {
 
+        // Pull effective permissions
         User self = userContext.self();
+        Permissions effective = self.getEffectivePermissions();
 
         // Retrieve permission sets
-        SystemPermissionSet systemPermissions = self.getSystemPermissions();
-        ObjectPermissionSet sharingProfilePermissions = self.getSharingProfilePermissions();
+        SystemPermissionSet systemPermissions = effective.getSystemPermissions();
+        ObjectPermissionSet sharingProfilePermissions = effective.getSharingProfilePermissions();
 
         // Deny access if adminstrative or update permission is missing
         String identifier = sharingProfile.getIdentifier();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileResource.java
@@ -32,7 +32,6 @@ import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.SharingProfile;
-import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -105,8 +104,7 @@ public class SharingProfileResource
             throws GuacamoleException {
 
         // Pull effective permissions
-        User self = userContext.self();
-        Permissions effective = self.getEffectivePermissions();
+        Permissions effective = userContext.self().getEffectivePermissions();
 
         // Retrieve permission sets
         SystemPermissionSet systemPermissions = effective.getSystemPermissions();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/APIUserWrapper.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/APIUserWrapper.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleUnsupportedException;
 import org.apache.guacamole.net.auth.ActivityRecord;
+import org.apache.guacamole.net.auth.Permissions;
+import org.apache.guacamole.net.auth.RelatedObjectSet;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
@@ -111,9 +113,25 @@ public class APIUserWrapper implements User {
     }
 
     @Override
+    public ObjectPermissionSet getUserGroupPermissions()
+            throws GuacamoleException {
+        throw new GuacamoleUnsupportedException("APIUserWrapper does not provide permission access.");
+    }
+
+    @Override
     public ObjectPermissionSet getActiveConnectionPermissions()
             throws GuacamoleException {
         throw new GuacamoleUnsupportedException("APIUserWrapper does not provide permission access.");
+    }
+
+    @Override
+    public Permissions getEffectivePermissions() throws GuacamoleException {
+        throw new GuacamoleUnsupportedException("APIUserWrapper does not provide permission access.");
+    }
+
+    @Override
+    public RelatedObjectSet getUserGroups() throws GuacamoleException {
+        throw new GuacamoleUnsupportedException("APIUserWrapper does not provide group access.");
     }
 
     @Override

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
@@ -43,6 +43,7 @@ import org.apache.guacamole.net.auth.credentials.GuacamoleCredentialsException;
 import org.apache.guacamole.rest.directory.DirectoryObjectResource;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
 import org.apache.guacamole.rest.history.APIActivityRecord;
+import org.apache.guacamole.rest.permission.APIPermissionSet;
 import org.apache.guacamole.rest.permission.PermissionSetResource;
 
 /**
@@ -181,7 +182,8 @@ public class UserResource
 
     /**
      * Returns a resource which abstracts operations available on the overall
-     * permissions granted to the User represented by this UserResource.
+     * permissions granted directly to the User represented by this
+     * UserResource.
      *
      * @return
      *     A resource which representing the permissions granted to the User
@@ -190,6 +192,23 @@ public class UserResource
     @Path("permissions")
     public PermissionSetResource getPermissions() {
         return new PermissionSetResource(user);
+    }
+
+    /**
+     * Returns a read-only view of the permissions effectively granted to this
+     * user, including permissions which may be inherited or implied.
+     *
+     * @return
+     *     A read-only view of the permissions effectively granted to this
+     *     user.
+     *
+     * @throws GuacamoleException
+     *     If the effective permissions for this user cannot be retrieved.
+     */
+    @GET
+    @Path("effectivePermissions")
+    public APIPermissionSet getEffectivePermissions() throws GuacamoleException {
+        return new APIPermissionSet(user.getEffectivePermissions());
     }
 
 }

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -199,7 +199,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     });
     
     // Query the user's permissions for the current connection
-    permissionService.getPermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
+    permissionService.getEffectivePermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
     .success(function permissionsReceived(permissions) {
                 
         $scope.permissions = permissions;

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -134,7 +134,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     });
 
     // Query the user's permissions for the current connection group
-    permissionService.getPermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
+    permissionService.getEffectivePermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
     .success(function permissionsReceived(permissions) {
                 
         $scope.permissions = permissions;

--- a/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
@@ -175,7 +175,7 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
     });
 
     // Query the user's permissions for the current sharing profile
-    permissionService.getPermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
+    permissionService.getEffectivePermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
     .success(function permissionsReceived(permissions) {
 
         $scope.permissions = permissions;

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -680,7 +680,7 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
     
     // Query the user's permissions for the current user
     dataSourceService.apply(
-        permissionService.getPermissions,
+        permissionService.getEffectivePermissions,
         dataSources,
         currentUsername
     )

--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -329,7 +329,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
 
         // Retrieve current permissions
         dataSourceService.apply(
-            permissionService.getPermissions,
+            permissionService.getEffectivePermissions,
             authenticationService.getAvailableDataSources(),
             authenticationService.getCurrentUsername() 
         )
@@ -422,7 +422,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
 
         // Retrieve current permissions
         dataSourceService.apply(
-            permissionService.getPermissions,
+            permissionService.getEffectivePermissions,
             authenticationService.getAvailableDataSources(),
             authenticationService.getCurrentUsername()
         )

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnections.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnections.js
@@ -404,7 +404,7 @@ angular.module('settings').directive('guacSettingsConnections', [function guacSe
             };
 
             // Retrieve current permissions
-            permissionService.getPermissions($scope.dataSource, currentUsername)
+            permissionService.getEffectivePermissions($scope.dataSource, currentUsername)
             .success(function permissionsRetrieved(permissions) {
 
                 // Store retrieved permissions

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
@@ -185,7 +185,7 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
             });
 
             // Retrieve current permissions
-            permissionService.getPermissions(dataSource, username)
+            permissionService.getEffectivePermissions(dataSource, username)
             .success(function permissionsRetrieved(permissions) {
 
                 // Add action for changing password if permission is granted

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsUsers.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsUsers.js
@@ -232,7 +232,7 @@ angular.module('settings').directive('guacSettingsUsers', [function guacSettings
 
             // Retrieve current permissions
             dataSourceService.apply(
-                permissionService.getPermissions,
+                permissionService.getEffectivePermissions,
                 dataSources,
                 currentUsername
             )


### PR DESCRIPTION
This change adds the base classes necessary for exposing user groups via extensions, and for declaring the permissions which apply to a user *but are not necessarily directly granted to that user*.

Overall, this involves:

* A new `UserGroup` interface, as well as the usual `DelegatingUserGroup`, and `Directory<UserGroup>` on `UserContext`.
* A new base interface, `Permissions`, which `User` and `UserGroup` share, defining the interface common to any object which can be granted permissions.
* A new `getEffectivePermissions()` function on `User` which returns a `Permissions` that represents all permissions which apply to the user, even if those permissions are inherited through some arbitrary means (such as user groups). The traditional `getUserPermissions()`, `getConnectionPermissions()`, etc. directly on the `User` return permission sets which describe permissions which are directly granted only.
* A new `getEffectiveUserGroups()` function on `AuthenticatedUser` which allows implementations to expose the identity of a user's group memberships in addition to the user's own identity. This forms the means by which membership in groups can be shared across extensions (for example, LDAP group membership can affect a user in MySQL so long as an identical MySQL group exists, even if that user does not exist in MySQL).
* A new `RelatedObjectSet` interface, similar to `PermissionSet`, which abstracts batch add/remove operations on a group of objects sharing some arbitrary relation, such as the member users of a user group, the parent user groups of a user, etc. This allows relations between specific objects to be established or removed without affecting the existence of those objects (as `Directory` would require) nor necessarily other relations to those objects.

The user groups themselves are exposed via a `Directory<UserGroup>` at the `UserContext` level, like all other objects. A new `ObjectPermissionSet` for user group permissions is exposed within `Permissions`. User membership within groups, group membership within groups, the set of groups containing a particular user, and the set of groups containing a particular group can all be maintained through the various getters returning `RelatedObjectSet` instances.

Other than (1) updating the REST services and JavaScript to use *effective* permissions rather than directly-granted permissions and (2) any stubs necessary to allow the database auth to continue working, no changes outside the API are made here.

Assuming these changes move forward, I will open further pull requests for the REST API changes, interface changes, and finally database auth changes.