### PR TITLE
GUACAMOLE-549: Do not automatically create HttpSession.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
@@ -121,7 +121,7 @@ public class TokenRESTService {
         credentials.setUsername(username);
         credentials.setPassword(password);
         credentials.setRequest(request);
-        credentials.setSession(request.getSession(true));
+        credentials.setSession(request.getSession(false));
         credentials.setRemoteAddress(request.getRemoteAddr());
         credentials.setRemoteHostname(request.getRemoteHost());
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
@@ -158,7 +158,7 @@ public class UserResource
         credentials.setUsername(user.getIdentifier());
         credentials.setPassword(userPasswordUpdate.getOldPassword());
         credentials.setRequest(request);
-        credentials.setSession(request.getSession(true));
+        credentials.setSession(request.getSession(false));
         credentials.setRemoteAddress(request.getRemoteAddr());
         credentials.setRemoteHostname(request.getRemoteHost());
 


### PR DESCRIPTION
If an extension truly needs an `HttpSession`, it should create it manually via the `HttpServletRequest`.