### PR TITLE
GUACAMOLE-526: Handle absolutely all promise rejections.

### DIFF
--- a/guacamole/src/main/webapp/app/auth/authModule.js
+++ b/guacamole/src/main/webapp/app/auth/authModule.js
@@ -21,5 +21,6 @@
  * The module for authentication and management of tokens.
  */
 angular.module('auth', [
+    'rest',
     'storage'
 ]);

--- a/guacamole/src/main/webapp/app/auth/service/authenticationService.js
+++ b/guacamole/src/main/webapp/app/auth/service/authenticationService.js
@@ -190,7 +190,7 @@ angular.module('auth').factory('authenticationService', ['$injector',
         })
 
         // If authentication fails, propogate failure to returned promise
-        ['catch'](function authenticationFailed(error) {
+        ['catch'](requestService.createErrorCallback(function authenticationFailed(error) {
 
             // Request credentials if provided credentials were invalid
             if (error.type === Error.Type.INVALID_CREDENTIALS)
@@ -203,7 +203,7 @@ angular.module('auth').factory('authenticationService', ['$injector',
             // Authentication failed
             throw error;
 
-        });
+        }));
 
     };
 

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -37,6 +37,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     var guacNotification      = $injector.get('guacNotification');
     var iconService           = $injector.get('iconService');
     var preferenceService     = $injector.get('preferenceService');
+    var requestService        = $injector.get('requestService');
     var tunnelService         = $injector.get('tunnelService');
     var userPageService       = $injector.get('userPageService');
 
@@ -161,7 +162,9 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         name      : "CLIENT.ACTION_LOGOUT",
         className : "logout button",
         callback  : function logoutCallback() {
-            authenticationService.logout()['finally'](function logoutComplete() {
+            authenticationService.logout()
+            ['catch'](requestService.IGNORE)
+            ['finally'](function logoutComplete() {
                 $location.url('/');
             });
         }
@@ -188,7 +191,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             };
         }
 
-    });
+    }, requestService.WARN);
 
     /**
      * Action which replaces the current client with a newly-connected client.
@@ -466,7 +469,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         tunnelService.getSharingProfiles(uuid)
         .then(function sharingProfilesRetrieved(sharingProfiles) {
             $scope.sharingProfiles = sharingProfiles;
-        });
+        }, requestService.WARN);
 
     });
 
@@ -614,6 +617,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
         // Re-authenticate to verify auth status at end of connection
         authenticationService.updateCurrentToken($location.search())
+        ['catch'](requestService.IGNORE)
 
         // Show the requested status once the authentication check has finished
         ['finally'](function authenticationCheckComplete() {
@@ -714,7 +718,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             // Sync with local clipboard
             clipboardService.getLocalClipboard().then(function clipboardRead(data) {
                 $scope.$broadcast('guacClipboard', data);
-            })['catch'](angular.noop);
+            }, angular.noop);
 
             // Hide status notification
             guacNotification.showStatus(false);

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -447,7 +447,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
         // Sync local clipboard as long as the menu is not open
         if (!$scope.menu.shown)
-            clipboardService.setLocalClipboard(data);
+            clipboardService.setLocalClipboard(data)['catch'](angular.noop);
 
         // Associate new clipboard data with any currently-pressed key
         for (var keysym in keysCurrentlyPressed)
@@ -576,7 +576,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         // key was pressed (if any) as long as the menu is not open
         var clipboardData = clipboardDataFromKey[keysym];
         if (clipboardData && !$scope.menu.shown)
-            clipboardService.setLocalClipboard(clipboardData);
+            clipboardService.setLocalClipboard(clipboardData)['catch'](angular.noop);
 
         // Deal with substitute key presses
         if (substituteKeysPressed[keysym]) {
@@ -714,7 +714,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             // Sync with local clipboard
             clipboardService.getLocalClipboard().then(function clipboardRead(data) {
                 $scope.$broadcast('guacClipboard', data);
-            });
+            })['catch'](angular.noop);
 
             // Hide status notification
             guacNotification.showStatus(false);

--- a/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacFileBrowser.js
@@ -272,7 +272,7 @@ angular.module('client').directive('guacFileBrowser', [function guacFileBrowser(
 
                 });
 
-            }); // end retrieve file template
+            }, angular.noop); // end retrieve file template
 
             // Refresh file browser when any upload completes
             $scope.$on('guacUploadComplete', function uploadComplete(event, filename) {

--- a/guacamole/src/main/webapp/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/webapp/app/client/types/ManagedClient.js
@@ -42,6 +42,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     var authenticationService  = $injector.get('authenticationService');
     var connectionGroupService = $injector.get('connectionGroupService');
     var connectionService      = $injector.get('connectionService');
+    var requestService         = $injector.get('requestService');
     var tunnelService          = $injector.get('tunnelService');
     var guacAudio              = $injector.get('guacAudio');
     var guacHistory            = $injector.get('guacHistory');
@@ -514,7 +515,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             connectionService.getConnection(clientIdentifier.dataSource, clientIdentifier.id)
             .then(function connectionRetrieved(connection) {
                 managedClient.name = managedClient.title = connection.name;
-            });
+            }, requestService.WARN);
         }
         
         // If using a connection group, pull connection name
@@ -522,7 +523,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             connectionGroupService.getConnectionGroup(clientIdentifier.dataSource, clientIdentifier.id)
             .then(function connectionGroupRetrieved(group) {
                 managedClient.name = managedClient.title = group.name;
-            });
+            }, requestService.WARN);
         }
 
         return managedClient;
@@ -634,7 +635,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         credentialRequest.then(function sharingCredentialsReceived(sharingCredentials) {
             client.shareLinks[sharingProfile.identifier] =
                 ManagedShareLink.getInstance(sharingProfile, sharingCredentials);
-        });
+        }, requestService.WARN);
 
         return credentialRequest;
 

--- a/guacamole/src/main/webapp/app/client/types/ManagedFileUpload.js
+++ b/guacamole/src/main/webapp/app/client/types/ManagedFileUpload.js
@@ -28,7 +28,8 @@ angular.module('client').factory('ManagedFileUpload', ['$rootScope', '$injector'
     var ManagedFileTransferState = $injector.get('ManagedFileTransferState');
 
     // Required services
-    var tunnelService = $injector.get('tunnelService');
+    var requestService = $injector.get('requestService');
+    var tunnelService  = $injector.get('tunnelService');
 
     /**
      * Object which serves as a surrogate interface, encapsulating a Guacamole
@@ -171,7 +172,7 @@ angular.module('client').factory('ManagedFileUpload', ['$rootScope', '$injector'
             },
 
             // Notify if upload fails
-            function uploadFailed(error) {
+            requestService.createErrorCallback(function uploadFailed(error) {
 
                 // Use provide status code if the error is coming from the stream
                 if (error.type === Error.Type.STREAM_ERROR)
@@ -185,7 +186,7 @@ angular.module('client').factory('ManagedFileUpload', ['$rootScope', '$injector'
                         ManagedFileTransferState.StreamState.ERROR,
                         Guacamole.Status.Code.INTERNAL_ERROR);
 
-            });
+            }));
 
             // Ignore all further acks
             stream.onack = null;

--- a/guacamole/src/main/webapp/app/form/directives/formField.js
+++ b/guacamole/src/main/webapp/app/form/directives/formField.js
@@ -60,6 +60,7 @@ angular.module('form').directive('guacFormField', [function formField() {
         controller: ['$scope', '$injector', '$element', function formFieldController($scope, $injector, $element) {
 
             // Required services
+            var $log                     = $injector.get('$log');
             var formService              = $injector.get('formService');
             var translationStringService = $injector.get('translationStringService');
 
@@ -116,7 +117,9 @@ angular.module('form').directive('guacFormField', [function formField() {
                 // Append field content
                 if (field) {
                     formService.insertFieldElement(fieldContent[0],
-                        field.type, $scope);
+                        field.type, $scope)['catch'](function fieldCreationFailed() {
+                            $log.warn('Failed to retrieve field with type "' + field.type + '"');
+                    });
                 }
 
             });

--- a/guacamole/src/main/webapp/app/groupList/directives/guacGroupList.js
+++ b/guacamole/src/main/webapp/app/groupList/directives/guacGroupList.js
@@ -94,6 +94,7 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
             // Required services
             var activeConnectionService = $injector.get('activeConnectionService');
             var dataSourceService       = $injector.get('dataSourceService');
+            var requestService          = $injector.get('requestService');
 
             // Required types
             var GroupListItem = $injector.get('GroupListItem');
@@ -221,7 +222,7 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
                             });
                         });
 
-                    });
+                    }, requestService.WARN);
 
                 }
 

--- a/guacamole/src/main/webapp/app/home/controllers/homeController.js
+++ b/guacamole/src/main/webapp/app/home/controllers/homeController.js
@@ -32,6 +32,7 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
     var authenticationService  = $injector.get('authenticationService');
     var connectionGroupService = $injector.get('connectionGroupService');
     var dataSourceService      = $injector.get('dataSourceService');
+    var requestService         = $injector.get('requestService');
 
     /**
      * Map of data source identifier to the root connection group of that data
@@ -126,6 +127,6 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
     )
     .then(function rootGroupsRetrieved(rootConnectionGroups) {
         $scope.rootConnectionGroups = rootConnectionGroups;
-    });
+    }, requestService.WARN);
 
 }]);

--- a/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
+++ b/guacamole/src/main/webapp/app/index/config/indexRouteConfig.js
@@ -102,6 +102,10 @@ angular.module('index').config(['$routeProvider', '$locationProvider',
                 route.resolve();
             });
 
+        })
+
+        ['catch'](function tokenUpdateFailed() {
+            route.reject();
         });
 
         // Return promise that will resolve only if the requested page is the

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -137,7 +137,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     var checkClipboard = function checkClipboard() {
         clipboardService.getLocalClipboard().then(function clipboardRead(data) {
             $scope.$broadcast('guacClipboard', data);
-        })['catch'](angular.noop);
+        }, angular.noop);
     };
 
     // Attempt to read the clipboard if it may have changed

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -137,7 +137,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     var checkClipboard = function checkClipboard() {
         clipboardService.getLocalClipboard().then(function clipboardRead(data) {
             $scope.$broadcast('guacClipboard', data);
-        });
+        })['catch'](angular.noop);
     };
 
     // Attempt to read the clipboard if it may have changed

--- a/guacamole/src/main/webapp/app/index/filters/arrayFilter.js
+++ b/guacamole/src/main/webapp/app/index/filters/arrayFilter.js
@@ -25,9 +25,6 @@ angular.module('index').filter('toArray', [function toArrayFactory() {
 
     return function toArrayFiter(input) {
 
-
-        console.log(input)
-
         // If no object is available, just return an empty array
         if (!input) {
             return [];

--- a/guacamole/src/main/webapp/app/list/directives/guacUserItem.js
+++ b/guacamole/src/main/webapp/app/list/directives/guacUserItem.js
@@ -77,7 +77,7 @@ angular.module('list').directive('guacUserItem', [function guacUserItem() {
                     $translate('LIST.TEXT_ANONYMOUS_USER')
                     .then(function retrieveAnonymousDisplayName(anonymousDisplayName) {
                         $scope.displayName = anonymousDisplayName;
-                    });
+                    }, angular.noop);
                 }
 
                 // For all other users, use the username verbatim

--- a/guacamole/src/main/webapp/app/login/directives/login.js
+++ b/guacamole/src/main/webapp/app/login/directives/login.js
@@ -68,6 +68,7 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
         // Required services
         var $route                = $injector.get('$route');
         var authenticationService = $injector.get('authenticationService');
+        var requestService        = $injector.get('requestService');
 
         /**
          * A description of the error that occurred during login, if any.
@@ -153,7 +154,7 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
             })
 
             // Reset upon failure
-            ['catch'](function loginFailed(error) {
+            ['catch'](requestService.createErrorCallback(function loginFailed(error) {
 
                 // Clear out passwords if the credentials were rejected for any reason
                 if (error.type !== Error.Type.INSUFFICIENT_CREDENTIALS) {
@@ -178,7 +179,7 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
                     });
                 }
 
-            });
+            }));
 
         };
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -38,20 +38,9 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     var connectionService        = $injector.get('connectionService');
     var connectionGroupService   = $injector.get('connectionGroupService');
     var permissionService        = $injector.get('permissionService');
+    var requestService           = $injector.get('requestService');
     var schemaService            = $injector.get('schemaService');
     var translationStringService = $injector.get('translationStringService');
-
-    /**
-     * An action to be provided along with the object sent to showStatus which
-     * closes the currently-shown status dialog.
-     */
-    var ACKNOWLEDGE_ACTION = {
-        name        : "MANAGE_CONNECTION.ACTION_ACKNOWLEDGE",
-        // Handle action
-        callback    : function acknowledgeCallback() {
-            guacNotification.showStatus(false);
-        }
-    };
 
     /**
      * The unique identifier of the data source containing the connection being
@@ -186,7 +175,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     schemaService.getConnectionAttributes($scope.selectedDataSource)
     .then(function attributesReceived(attributes) {
         $scope.attributes = attributes;
-    });
+    }, requestService.WARN);
 
     // Pull connection group hierarchy
     connectionGroupService.getConnectionGroupTree(
@@ -196,7 +185,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
     )
     .then(function connectionGroupReceived(rootGroup) {
         $scope.rootGroup = rootGroup;
-    });
+    }, requestService.WARN);
     
     // Query the user's permissions for the current connection
     permissionService.getEffectivePermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
@@ -226,18 +215,18 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
                )
             );
     
-    });
+    }, requestService.WARN);
    
     // Get protocol metadata
     schemaService.getProtocols($scope.selectedDataSource)
     .then(function protocolsReceived(protocols) {
         $scope.protocols = protocols;
-    });
+    }, requestService.WARN);
 
     // Get history date format
     $translate('MANAGE_CONNECTION.FORMAT_HISTORY_START').then(function historyDateFormatReceived(historyDateFormat) {
         $scope.historyDateFormat = historyDateFormat;
-    });
+    }, angular.noop);
 
     // If we are editing an existing connection, pull its data
     if (identifier) {
@@ -246,7 +235,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         connectionService.getConnection($scope.selectedDataSource, identifier)
         .then(function connectionRetrieved(connection) {
             $scope.connection = connection;
-        });
+        }, requestService.WARN);
 
         // Pull connection history
         connectionService.getConnectionHistory($scope.selectedDataSource, identifier)
@@ -258,13 +247,13 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
                $scope.historyEntryWrappers.push(new HistoryEntryWrapper(historyEntry)); 
             });
 
-        });
+        }, requestService.WARN);
 
         // Pull connection parameters
         connectionService.getConnectionParameters($scope.selectedDataSource, identifier)
         .then(function parametersReceived(parameters) {
             $scope.parameters = parameters;
-        });
+        }, requestService.WARN);
     }
     
     // If we are cloning an existing connection, pull its data instead
@@ -277,7 +266,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
             
             // Clear the identifier field because this connection is new
             delete $scope.connection.identifier;
-        });
+        }, requestService.WARN);
 
         // Do not pull connection history
         $scope.historyEntryWrappers = [];
@@ -286,7 +275,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         connectionService.getConnectionParameters($scope.selectedDataSource, cloneSourceIdentifier)
         .then(function parametersReceived(parameters) {
             $scope.parameters = parameters;
-        });
+        }, requestService.WARN);
     }
 
     // If we are creating a new connection, populate skeleton connection data
@@ -390,17 +379,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         connectionService.saveConnection($scope.selectedDataSource, $scope.connection)
         .then(function savedConnection() {
             $location.url('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        })
-
-        // Notify of any errors
-        .error(function connectionSaveFailed(error) {
-            guacNotification.showStatus({
-                'className'  : 'error',
-                'title'      : 'MANAGE_CONNECTION.DIALOG_HEADER_ERROR',
-                'text'       : error.translatableMessage,
-                'actions'    : [ ACKNOWLEDGE_ACTION ]
-            });
-        });
+        }, requestService.SHOW_NOTIFICATION);
 
     };
     
@@ -440,17 +419,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         connectionService.deleteConnection($scope.selectedDataSource, $scope.connection)
         .then(function deletedConnection() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        })
-
-        // Notify of any errors
-        .error(function connectionDeletionFailed(error) {
-            guacNotification.showStatus({
-                'className'  : 'error',
-                'title'      : 'MANAGE_CONNECTION.DIALOG_HEADER_ERROR',
-                'text'       : error.translatableMessage,
-                'actions'    : [ ACKNOWLEDGE_ACTION ]
-            });
-        });
+        }, requestService.SHOW_NOTIFICATION);
 
     };
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionController.js
@@ -379,7 +379,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         connectionService.saveConnection($scope.selectedDataSource, $scope.connection)
         .then(function savedConnection() {
             $location.url('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
     
@@ -419,7 +419,7 @@ angular.module('manage').controller('manageConnectionController', ['$scope', '$i
         connectionService.deleteConnection($scope.selectedDataSource, $scope.connection)
         .then(function deletedConnection() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -34,20 +34,9 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     var connectionGroupService = $injector.get('connectionGroupService');
     var guacNotification       = $injector.get('guacNotification');
     var permissionService      = $injector.get('permissionService');
+    var requestService         = $injector.get('requestService');
     var schemaService          = $injector.get('schemaService');
     
-    /**
-     * An action to be provided along with the object sent to showStatus which
-     * closes the currently-shown status dialog.
-     */
-    var ACKNOWLEDGE_ACTION = {
-        name        : "MANAGE_CONNECTION_GROUP.ACTION_ACKNOWLEDGE",
-        // Handle action
-        callback    : function acknowledgeCallback() {
-            guacNotification.showStatus(false);
-        }
-    };
-
     /**
      * The unique identifier of the data source containing the connection group
      * being edited.
@@ -131,7 +120,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     schemaService.getConnectionGroupAttributes($scope.selectedDataSource)
     .then(function attributesReceived(attributes) {
         $scope.attributes = attributes;
-    });
+    }, requestService.WARN);
 
     // Query the user's permissions for the current connection group
     permissionService.getEffectivePermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
@@ -152,7 +141,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
               ||  PermissionSet.hasConnectionGroupPermission(permissions, PermissionSet.ObjectPermissionType.DELETE, identifier)
            );
     
-    });
+    }, requestService.WARN);
 
 
     // Pull connection group hierarchy
@@ -163,14 +152,14 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
     )
     .then(function connectionGroupReceived(rootGroup) {
         $scope.rootGroup = rootGroup;
-    });
+    }, requestService.WARN);
 
     // If we are editing an existing connection group, pull its data
     if (identifier) {
         connectionGroupService.getConnectionGroup($scope.selectedDataSource, identifier)
         .then(function connectionGroupReceived(connectionGroup) {
             $scope.connectionGroup = connectionGroup;
-        });
+        }, requestService.WARN);
     }
 
     // If we are creating a new connection group, populate skeleton connection group data
@@ -232,17 +221,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
         connectionGroupService.saveConnectionGroup($scope.selectedDataSource, $scope.connectionGroup)
         .then(function savedConnectionGroup() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        })
-
-        // Notify of any errors
-        ['catch'](function connectionGroupSaveFailed(error) {
-            guacNotification.showStatus({
-                'className'  : 'error',
-                'title'      : 'MANAGE_CONNECTION_GROUP.DIALOG_HEADER_ERROR',
-                'text'       : error.translatableMessage,
-                'actions'    : [ ACKNOWLEDGE_ACTION ]
-            });
-        });
+        }, requestService.SHOW_NOTIFICATION);
 
     };
     
@@ -282,17 +261,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
         connectionGroupService.deleteConnectionGroup($scope.selectedDataSource, $scope.connectionGroup)
         .then(function deletedConnectionGroup() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        })
-
-        // Notify of any errors
-        ['catch'](function connectionGroupDeletionFailed(error) {
-            guacNotification.showStatus({
-                'className'  : 'error',
-                'title'      : 'MANAGE_CONNECTION_GROUP.DIALOG_HEADER_ERROR',
-                'text'       : error.translatableMessage,
-                'actions'    : [ ACKNOWLEDGE_ACTION ]
-            });
-        });
+        }, requestService.SHOW_NOTIFICATION);
 
     };
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -221,7 +221,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
         connectionGroupService.saveConnectionGroup($scope.selectedDataSource, $scope.connectionGroup)
         .then(function savedConnectionGroup() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
     
@@ -261,7 +261,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
         connectionGroupService.deleteConnectionGroup($scope.selectedDataSource, $scope.connectionGroup)
         .then(function deletedConnectionGroup() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
@@ -342,7 +342,7 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
         sharingProfileService.saveSharingProfile($scope.selectedDataSource, $scope.sharingProfile)
         .then(function savedSharingProfile() {
             $location.url('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
 
@@ -370,7 +370,7 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
         sharingProfileService.deleteSharingProfile($scope.selectedDataSource, $scope.sharingProfile)
         .then(function deletedSharingProfile() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
@@ -261,11 +261,12 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
     $scope.$watch('sharingProfile.primaryConnectionIdentifier',
         function retrievePrimaryConnection(identifier) {
 
-        // Pull data from existing sharing profile
-        connectionService.getConnection($scope.selectedDataSource, identifier)
-        .then(function connectionRetrieved(connection) {
-            $scope.primaryConnection = connection;
-        }, requestService.WARN);
+        if (identifier) {
+            connectionService.getConnection($scope.selectedDataSource, identifier)
+            .then(function connectionRetrieved(connection) {
+                $scope.primaryConnection = connection;
+            }, requestService.WARN);
+        }
 
     });
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageSharingProfileController.js
@@ -34,21 +34,10 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
     var connectionService        = $injector.get('connectionService');
     var guacNotification         = $injector.get('guacNotification');
     var permissionService        = $injector.get('permissionService');
+    var requestService           = $injector.get('requestService');
     var schemaService            = $injector.get('schemaService');
     var sharingProfileService    = $injector.get('sharingProfileService');
     var translationStringService = $injector.get('translationStringService');
-
-    /**
-     * An action which can be provided along with the object sent to showStatus
-     * to allow the user to acknowledge (and close) the currently-shown status
-     * dialog.
-     */
-    var ACKNOWLEDGE_ACTION = {
-        name        : "MANAGE_SHARING_PROFILE.ACTION_ACKNOWLEDGE",
-        callback    : function acknowledgeCallback() {
-            guacNotification.showStatus(false);
-        }
-    };
 
     /**
      * An action to be provided along with the object sent to showStatus which
@@ -172,7 +161,7 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
     schemaService.getSharingProfileAttributes($scope.selectedDataSource)
     .then(function attributesReceived(attributes) {
         $scope.attributes = attributes;
-    });
+    }, requestService.WARN);
 
     // Query the user's permissions for the current sharing profile
     permissionService.getEffectivePermissions($scope.selectedDataSource, authenticationService.getCurrentUsername())
@@ -208,13 +197,13 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
                )
             );
 
-    });
+    }, requestService.WARN);
 
     // Get protocol metadata
     schemaService.getProtocols($scope.selectedDataSource)
     .then(function protocolsReceived(protocols) {
         $scope.protocols = protocols;
-    });
+    }, requestService.WARN);
 
     // If we are editing an existing sharing profile, pull its data
     if (identifier) {
@@ -223,13 +212,13 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
         sharingProfileService.getSharingProfile($scope.selectedDataSource, identifier)
         .then(function sharingProfileRetrieved(sharingProfile) {
             $scope.sharingProfile = sharingProfile;
-        });
+        }, requestService.WARN);
 
         // Pull sharing profile parameters
         sharingProfileService.getSharingProfileParameters($scope.selectedDataSource, identifier)
         .then(function parametersReceived(parameters) {
             $scope.parameters = parameters;
-        });
+        }, requestService.WARN);
 
     }
 
@@ -246,13 +235,13 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
             // Clear the identifier field because this sharing profile is new
             delete $scope.sharingProfile.identifier;
 
-        });
+        }, requestService.WARN);
 
         // Pull sharing profile parameters from cloned sharing profile
         sharingProfileService.getSharingProfileParameters($scope.selectedDataSource, cloneSourceIdentifier)
         .then(function parametersReceived(parameters) {
             $scope.parameters = parameters;
-        });
+        }, requestService.WARN);
 
     }
 
@@ -276,7 +265,7 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
         connectionService.getConnection($scope.selectedDataSource, identifier)
         .then(function connectionRetrieved(connection) {
             $scope.primaryConnection = connection;
-        });
+        }, requestService.WARN);
 
     });
 
@@ -353,17 +342,7 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
         sharingProfileService.saveSharingProfile($scope.selectedDataSource, $scope.sharingProfile)
         .then(function savedSharingProfile() {
             $location.url('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        })
-
-        // Notify of any errors
-        ['catch'](function sharingProfileSaveFailed(error) {
-            guacNotification.showStatus({
-                'className'  : 'error',
-                'title'      : 'MANAGE_SHARING_PROFILE.DIALOG_HEADER_ERROR',
-                'text'       : error.translatableMessage,
-                'actions'    : [ ACKNOWLEDGE_ACTION ]
-            });
-        });
+        }, requestService.SHOW_NOTIFICATION);
 
     };
 
@@ -391,17 +370,7 @@ angular.module('manage').controller('manageSharingProfileController', ['$scope',
         sharingProfileService.deleteSharingProfile($scope.selectedDataSource, $scope.sharingProfile)
         .then(function deletedSharingProfile() {
             $location.path('/settings/' + encodeURIComponent($scope.selectedDataSource) + '/connections');
-        })
-
-        // Notify of any errors
-        ['catch'](function sharingProfileDeletionFailed(error) {
-            guacNotification.showStatus({
-                'className'  : 'error',
-                'title'      : 'MANAGE_SHARING_PROFILE.DIALOG_HEADER_ERROR',
-                'text'       : error.translatableMessage,
-                'actions'    : [ ACKNOWLEDGE_ACTION ]
-            });
-        });
+        }, requestService.SHOW_NOTIFICATION);
 
     };
 

--- a/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageUserController.js
@@ -1141,9 +1141,9 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
             permissionService.patchPermissions(selectedDataSource, $scope.user.username, permissionsAdded, permissionsRemoved)
             .then(function patchedUserPermissions() {
                 $location.url('/settings/users');
-            }, requestService.SHOW_NOTIFICATION);
+            }, guacNotification.SHOW_REQUEST_ERROR);
 
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
     
@@ -1183,7 +1183,7 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         userService.deleteUser(selectedDataSource, $scope.user)
         .then(function deletedUser() {
             $location.path('/settings/users');
-        }, requestService.SHOW_NOTIFICATION);
+        }, guacNotification.SHOW_REQUEST_ERROR);
 
     };
 

--- a/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
@@ -50,6 +50,7 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
             var $location             = $injector.get('$location');
             var $route                = $injector.get('$route');
             var authenticationService = $injector.get('authenticationService');
+            var requestService        = $injector.get('requestService');
             var userService           = $injector.get('userService');
             var userPageService       = $injector.get('userPageService');
 
@@ -110,7 +111,7 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
                 var email = user.attributes[User.Attributes.EMAIL_ADDRESS];
                 $scope.userURL = email ? 'mailto:' + email : null;
 
-            });
+            }, requestService.WARN);
 
             /**
              * The available main pages for the current user.
@@ -141,7 +142,9 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
              * after logout completes.
              */
             $scope.logout = function logout() {
-                authenticationService.logout()['finally'](function logoutComplete() {
+                authenticationService.logout()
+                ['catch'](requestService.IGNORE)
+                ['finally'](function logoutComplete() {
                     if ($location.path() !== '/')
                         $location.url('/');
                     else

--- a/guacamole/src/main/webapp/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/webapp/app/navigation/services/userPageService.js
@@ -35,6 +35,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
     var connectionGroupService   = $injector.get('connectionGroupService');
     var dataSourceService        = $injector.get('dataSourceService');
     var permissionService        = $injector.get('permissionService');
+    var requestService           = $injector.get('requestService');
     var translationStringService = $injector.get('translationStringService');
     
     var service = {};
@@ -142,7 +143,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
 
     /**
      * Returns a promise which resolves with an appropriate home page for the
-     * current user.
+     * current user. The promise will not be rejected.
      *
      * @returns {Promise.<Page>}
      *     A promise which resolves with the user's default home page.
@@ -169,7 +170,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
         })
         .then(function rootConnectionGroupsPermissionsRetrieved(data) {
             deferred.resolve(generateHomePage(data.rootGroups,data.permissionsSets));
-        });
+        }, requestService.WARN);
 
         return deferred.promise;
 
@@ -317,7 +318,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
     /**
      * Returns a promise which resolves to an array of all settings pages that
      * the current user can visit. This can include any of the various manage
-     * pages.
+     * pages. The promise will not be rejected.
      *
      * @returns {Promise.<Page[]>} 
      *     A promise which resolves to an array of all settings pages that the
@@ -337,7 +338,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
         // Resolve promise using settings pages derived from permissions
         .then(function permissionsRetrieved(permissions) {
             deferred.resolve(generateSettingsPages(permissions));
-        });
+        }, requestService.WARN);
         
         return deferred.promise;
 
@@ -387,7 +388,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
      * Returns a promise which resolves to an array of all main pages that the
      * current user can visit. This can include the home page, manage pages,
      * etc. In the case that there are no applicable pages of this sort, it may
-     * return a client page.
+     * return a client page. The promise will not be rejected.
      *
      * @returns {Promise.<Page[]>} 
      *     A promise which resolves to an array of all main pages that the
@@ -418,7 +419,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
         .then(function rootConnectionGroupsRetrieved(retrievedRootGroups) {
             rootGroups = retrievedRootGroups;
             resolveMainPages();
-        });
+        }, requestService.WARN);
 
         // Retrieve current permissions
         dataSourceService.apply(
@@ -431,7 +432,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
         .then(function permissionsRetrieved(retrievedPermissions) {
             permissions = retrievedPermissions;
             resolveMainPages();
-        });
+        }, requestService.WARN);
         
         return deferred.promise;
 

--- a/guacamole/src/main/webapp/app/notification/notificationModule.js
+++ b/guacamole/src/main/webapp/app/notification/notificationModule.js
@@ -21,5 +21,6 @@
  * The module for code used to display arbitrary notifications.
  */
 angular.module('notification', [
+    'rest',
     'storage'
 ]);

--- a/guacamole/src/main/webapp/app/notification/services/guacNotification.js
+++ b/guacamole/src/main/webapp/app/notification/services/guacNotification.js
@@ -25,6 +25,7 @@ angular.module('notification').factory('guacNotification', ['$injector',
 
     // Required services
     var $rootScope            = $injector.get('$rootScope');
+    var requestService        = $injector.get('requestService');
     var sessionStorageFactory = $injector.get('sessionStorageFactory');
 
     var service = {};
@@ -93,26 +94,24 @@ angular.module('notification').factory('guacNotification', ['$injector',
     };
 
     /**
-     * Shows the given REST error response as a modal status. If a status
-     * notification is already currently shown, this function will have no
-     * effect.
+     * Promise error callback which displays a modal notification for all
+     * rejections due to REST errors. The message displayed to the user within
+     * the notification is provided by the contents of the @link{Error} object
+     * within the REST response. All other rejections, such as those due to
+     * JavaScript errors, are logged to the browser console without displaying
+     * any notification.
      *
-     * @param {Error} error
-     *     The error object returned from the failed REST request.
-     *
-     * @example
-     *
-     * someService.updateObject(object)
-     * ['catch'](guacNotification.showRequestError);
+     * @constant
+     * @type Function
      */
-    service.showRequestError = function showRequestError(error) {
+    service.SHOW_REQUEST_ERROR = requestService.createErrorCallback(function showRequestError(error) {
         service.showStatus({
             className  : 'error',
             title      : 'APP.DIALOG_HEADER_ERROR',
             text       : error.translatableMessage,
             actions    : [ service.ACKNOWLEDGE_ACTION ]
         });
-    };
+    });
 
     // Hide status upon navigation
     $rootScope.$on('$routeChangeSuccess', function() {

--- a/guacamole/src/main/webapp/app/notification/services/guacNotification.js
+++ b/guacamole/src/main/webapp/app/notification/services/guacNotification.js
@@ -38,6 +38,19 @@ angular.module('notification').factory('guacNotification', ['$injector',
     var storedStatus = sessionStorageFactory.create(false);
 
     /**
+     * An action to be provided along with the object sent to showStatus which
+     * closes the currently-shown status dialog.
+     *
+     * @type NotificationAction
+     */
+    service.ACKNOWLEDGE_ACTION = {
+        name        : 'APP.ACTION_ACKNOWLEDGE',
+        callback    : function acknowledgeCallback() {
+            service.showStatus(false);
+        }
+    };
+
+    /**
      * Retrieves the current status notification, which may simply be false if
      * no status is currently shown.
      * 
@@ -77,6 +90,28 @@ angular.module('notification').factory('guacNotification', ['$injector',
     service.showStatus = function showStatus(status) {
         if (!storedStatus() || !status)
             storedStatus(status);
+    };
+
+    /**
+     * Shows the given REST error response as a modal status. If a status
+     * notification is already currently shown, this function will have no
+     * effect.
+     *
+     * @param {Error} error
+     *     The error object returned from the failed REST request.
+     *
+     * @example
+     *
+     * someService.updateObject(object)
+     * ['catch'](guacNotification.showRequestError);
+     */
+    service.showRequestError = function showRequestError(error) {
+        service.showStatus({
+            className  : 'error',
+            title      : 'APP.DIALOG_HEADER_ERROR',
+            text       : error.translatableMessage,
+            actions    : [ service.ACKNOWLEDGE_ACTION ]
+        });
     };
 
     // Hide status upon navigation

--- a/guacamole/src/main/webapp/app/osk/directives/guacOsk.js
+++ b/guacamole/src/main/webapp/app/osk/directives/guacOsk.js
@@ -113,7 +113,7 @@ angular.module('osk').directive('guacOsk', [function guacOsk() {
                             $rootScope.$broadcast('guacSyntheticKeyup', keysym);
                         };
 
-                    });
+                    }, angular.noop);
 
                 }
 

--- a/guacamole/src/main/webapp/app/rest/restModule.js
+++ b/guacamole/src/main/webapp/app/rest/restModule.js
@@ -21,4 +21,7 @@
  * The module for code relating to communication with the REST API of the
  * Guacamole web application.
  */
-angular.module('rest', ['auth']);
+angular.module('rest', [
+    'auth',
+    'notification'
+]);

--- a/guacamole/src/main/webapp/app/rest/restModule.js
+++ b/guacamole/src/main/webapp/app/rest/restModule.js
@@ -22,6 +22,5 @@
  * Guacamole web application.
  */
 angular.module('rest', [
-    'auth',
-    'notification'
+    'auth'
 ]);

--- a/guacamole/src/main/webapp/app/rest/services/activeConnectionService.js
+++ b/guacamole/src/main/webapp/app/rest/services/activeConnectionService.js
@@ -25,7 +25,6 @@ angular.module('rest').factory('activeConnectionService', ['$injector',
 
     // Required services
     var requestService        = $injector.get('requestService');
-    var $q                    = $injector.get('$q');
     var authenticationService = $injector.get('authenticationService');
 
     var service = {};
@@ -63,68 +62,6 @@ angular.module('rest').factory('activeConnectionService', ['$injector',
             url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/activeConnections',
             params  : httpParameters
         });
-
-    };
-
-    /**
-     * Returns a promise which resolves with all active connections accessible
-     * by the current user, as a map of @link{ActiveConnection} maps, as would
-     * be returned by getActiveConnections(), grouped by the identifier of
-     * their corresponding data source. All given data sources are queried. If
-     * an error occurs while retrieving any ActiveConnection map, the promise
-     * will be rejected.
-     *
-     * @param {String[]} dataSources
-     *     The unique identifier of the data sources containing the active
-     *     connections to be retrieved. These identifiers correspond to
-     *     AuthenticationProviders within the Guacamole web application.
-     *
-     * @param {String[]} [permissionTypes]
-     *     The set of permissions to filter with. A user must have one or more
-     *     of these permissions for an active connection to appear in the
-     *     result.  If null, no filtering will be performed. Valid values are
-     *     listed within PermissionSet.ObjectType.
-     *
-     * @returns {Promise.<Object.<String, Object.<String, ActiveConnection>>>}
-     *     A promise which resolves with all active connections available to
-     *     the current user, as a map of ActiveConnection maps, as would be
-     *     returned by getActiveConnections(), grouped by the identifier of
-     *     their corresponding data source.
-     */
-    service.getAllActiveConnections = function getAllActiveConnections(dataSources, permissionTypes) {
-
-        var deferred = $q.defer();
-
-        var activeConnectionRequests = [];
-        var activeConnectionMaps = {};
-
-        // Retrieve all active connections from all data sources
-        angular.forEach(dataSources, function retrieveActiveConnections(dataSource) {
-            activeConnectionRequests.push(
-                service.getActiveConnections(dataSource, permissionTypes)
-                .then(function activeConnectionsRetrieved(activeConnections) {
-                    activeConnectionMaps[dataSource] = activeConnections;
-                })
-            );
-        });
-
-        // Resolve when all requests are completed
-        $q.all(activeConnectionRequests)
-        .then(
-
-            // All requests completed successfully
-            function allActiveConnectionsRetrieved() {
-                deferred.resolve(userArrays);
-            },
-
-            // At least one request failed
-            function activeConnectionRetrievalFailed(e) {
-                deferred.reject(e);
-            }
-
-        );
-
-        return deferred.promise;
 
     };
 

--- a/guacamole/src/main/webapp/app/rest/services/connectionGroupService.js
+++ b/guacamole/src/main/webapp/app/rest/services/connectionGroupService.js
@@ -25,7 +25,6 @@ angular.module('rest').factory('connectionGroupService', ['$injector',
 
     // Required services
     var requestService        = $injector.get('requestService');
-    var $q                    = $injector.get('$q');
     var authenticationService = $injector.get('authenticationService');
     var cacheService          = $injector.get('cacheService');
     

--- a/guacamole/src/main/webapp/app/rest/services/dataSourceService.js
+++ b/guacamole/src/main/webapp/app/rest/services/dataSourceService.js
@@ -27,7 +27,8 @@ angular.module('rest').factory('dataSourceService', ['$injector',
     var Error = $injector.get('Error');
 
     // Required services
-    var $q = $injector.get('$q');
+    var $q             = $injector.get('$q');
+    var requestService = $injector.get('requestService');
 
     // Service containing all caches
     var service = {};
@@ -92,7 +93,7 @@ angular.module('rest').factory('dataSourceService', ['$injector',
             },
 
             // Fail on any errors (except "NOT FOUND")
-            function immediateRequestFailed(error) {
+            requestService.createErrorCallback(function immediateRequestFailed(error) {
 
                 if (error.type === Error.Type.NOT_FOUND)
                     deferredRequest.resolve();
@@ -101,7 +102,7 @@ angular.module('rest').factory('dataSourceService', ['$injector',
                 else
                     deferredRequest.reject(error);
 
-            });
+            }));
 
         });
 
@@ -111,9 +112,9 @@ angular.module('rest').factory('dataSourceService', ['$injector',
         },
 
         // Reject if at least one request fails
-        function requestFailed(response) {
-            deferred.reject(response);
-        });
+        requestService.createErrorCallback(function requestFailed(error) {
+            deferred.reject(error);
+        }));
 
         return deferred.promise;
 

--- a/guacamole/src/main/webapp/app/rest/services/permissionService.js
+++ b/guacamole/src/main/webapp/app/rest/services/permissionService.js
@@ -25,7 +25,6 @@ angular.module('rest').factory('permissionService', ['$injector',
 
     // Required services
     var requestService        = $injector.get('requestService');
-    var $q                    = $injector.get('$q');
     var authenticationService = $injector.get('authenticationService');
     var cacheService          = $injector.get('cacheService');
     

--- a/guacamole/src/main/webapp/app/rest/services/requestService.js
+++ b/guacamole/src/main/webapp/app/rest/services/requestService.js
@@ -26,6 +26,7 @@ angular.module('rest').factory('requestService', ['$injector',
 
     // Required services
     var $http = $injector.get('$http');
+    var $log  = $injector.get('$log');
 
     // Required types
     var Error = $injector.get('Error');
@@ -62,6 +63,34 @@ angular.module('rest').factory('requestService', ['$injector',
         );
     };
 
-    return service;
+    /**
+     * Creates a promise error callback which invokes the given callback only
+     * if the promise was rejected with a REST @link{Error} object. If the
+     * promise is rejected without an @link{Error} object, such as when a
+     * JavaScript error occurs within a callback earlier in the promise chain,
+     * the rejection is logged without invoking the given callback.
+     *
+     * @param {Function} callback
+     *     The callback to invoke if the promise is rejected with an
+     *     @link{Error} object.
+     *
+     * @returns {Function}
+     *     A function which can be provided as the error callback for a
+     *     promise.
+     */
+    service.createErrorCallback = function createErrorCallback(callback) {
+        return (function generatedErrorCallback(error) {
+
+            // Invoke given callback ONLY if due to a legitimate REST error
+            if (error instanceof Error)
+                return callback(error);
+
+            // Log all other errors
+            $log.error(error);
+
+        });
+    };
+
+   return service;
 
 }]);

--- a/guacamole/src/main/webapp/app/rest/services/requestService.js
+++ b/guacamole/src/main/webapp/app/rest/services/requestService.js
@@ -25,9 +25,8 @@ angular.module('rest').factory('requestService', ['$injector',
         function requestService($injector) {
 
     // Required services
-    var $http            = $injector.get('$http');
-    var $log             = $injector.get('$log');
-    var guacNotification = $injector.get('guacNotification');
+    var $http = $injector.get('$http');
+    var $log  = $injector.get('$log');
 
     // Required types
     var Error = $injector.get('Error');
@@ -115,19 +114,6 @@ angular.module('rest').factory('requestService', ['$injector',
     service.WARN = service.createErrorCallback(function warnRequestFailed(error) {
         $log.warn(error.type, error.message || error.translatableMessage);
     });
-
-    /**
-     * Promise error callback which displays a modal notification for all
-     * rejections due to REST errors. The message displayed to the user within
-     * the notification is provided by the contents of the @link{Error} object
-     * within the REST response. All other rejections, such as those due to
-     * JavaScript errors, are logged to the browser console without displaying
-     * any notification.
-     *
-     * @constant
-     * @type Function
-     */
-    service.SHOW_NOTIFICATION = service.createErrorCallback(guacNotification.showRequestError);
 
     return service;
 

--- a/guacamole/src/main/webapp/app/rest/services/requestService.js
+++ b/guacamole/src/main/webapp/app/rest/services/requestService.js
@@ -41,7 +41,7 @@ angular.module('rest').factory('requestService', ['$q', '$http', 'Error',
             function success(request) { return request.data; },
             function failure(request) { throw new Error(request.data); }
         );
-    }
+    };
 
     return wrappedHttpCall;
 }]);

--- a/guacamole/src/main/webapp/app/rest/services/requestService.js
+++ b/guacamole/src/main/webapp/app/rest/services/requestService.js
@@ -91,6 +91,30 @@ angular.module('rest').factory('requestService', ['$injector',
         });
     };
 
-   return service;
+    /**
+     * Promise error callback which ignores all rejections due to REST errors,
+     * but logs all other rejections, such as those due to JavaScript errors.
+     * This callback should be used in favor of angular.noop in cases where
+     * a REST response is being handled but REST errors should be ignored.
+     *
+     * @constant
+     * @type Function
+     */
+    service.IGNORE = service.createErrorCallback(angular.noop);
+
+    /**
+     * Promise error callback which logs all rejections due to REST errors as
+     * warnings to the browser console, and logs all other rejections as
+     * errors. This callback should be used in favor of angular.noop or
+     * @link{IGNORE} if REST errors are simply not expected.
+     *
+     * @constant
+     * @type Function
+     */
+    service.WARN = service.createErrorCallback(function warnRequestFailed(error) {
+        $log.warn(error.type, error.message || error.translatableMessage);
+    });
+
+    return service;
 
 }]);

--- a/guacamole/src/main/webapp/app/rest/services/requestService.js
+++ b/guacamole/src/main/webapp/app/rest/services/requestService.js
@@ -25,8 +25,9 @@ angular.module('rest').factory('requestService', ['$injector',
         function requestService($injector) {
 
     // Required services
-    var $http = $injector.get('$http');
-    var $log  = $injector.get('$log');
+    var $http            = $injector.get('$http');
+    var $log             = $injector.get('$log');
+    var guacNotification = $injector.get('guacNotification');
 
     // Required types
     var Error = $injector.get('Error');
@@ -114,6 +115,19 @@ angular.module('rest').factory('requestService', ['$injector',
     service.WARN = service.createErrorCallback(function warnRequestFailed(error) {
         $log.warn(error.type, error.message || error.translatableMessage);
     });
+
+    /**
+     * Promise error callback which displays a modal notification for all
+     * rejections due to REST errors. The message displayed to the user within
+     * the notification is provided by the contents of the @link{Error} object
+     * within the REST response. All other rejections, such as those due to
+     * JavaScript errors, are logged to the browser console without displaying
+     * any notification.
+     *
+     * @constant
+     * @type Function
+     */
+    service.SHOW_NOTIFICATION = service.createErrorCallback(guacNotification.showRequestError);
 
     return service;
 

--- a/guacamole/src/main/webapp/app/rest/services/userService.js
+++ b/guacamole/src/main/webapp/app/rest/services/userService.js
@@ -25,7 +25,6 @@ angular.module('rest').factory('userService', ['$injector',
 
     // Required services
     var requestService        = $injector.get('requestService');
-    var $q                    = $injector.get('$q');
     var authenticationService = $injector.get('authenticationService');
     var cacheService          = $injector.get('cacheService');
 

--- a/guacamole/src/main/webapp/app/rest/services/userService.js
+++ b/guacamole/src/main/webapp/app/rest/services/userService.js
@@ -264,7 +264,7 @@ angular.module('rest').factory('userService', ['$injector',
         })
 
         // Clear the cache
-        .success(function passwordChanged(){
+        .then(function passwordChanged(){
             cacheService.users.removeAll();
         });
 

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnectionHistory.js
@@ -44,6 +44,7 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
             var $translate     = $injector.get('$translate');
             var csvService     = $injector.get('csvService');
             var historyService = $injector.get('historyService');
+            var requestService = $injector.get('requestService');
 
             /**
              * The identifier of the currently-selected data source.
@@ -95,7 +96,7 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                 // Store received date format
                 $scope.dateFormat = retrievedDateFormat;
 
-            });
+            }, angular.noop);
             
             /**
              * Returns true if the connection history records have been loaded,
@@ -177,7 +178,7 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                        $scope.historyEntryWrappers.push(new ConnectionHistoryEntryWrapper(historyEntry)); 
                     });
 
-                });
+                }, requestService.WARN);
 
             };
             
@@ -227,7 +228,7 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                     // Save the result
                     saveAs(csvService.toBlob(records), translations['SETTINGS_CONNECTION_HISTORY.FILENAME_HISTORY_CSV']);
 
-                });
+                }, angular.noop);
 
             };
 

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnections.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsConnections.js
@@ -46,6 +46,7 @@ angular.module('settings').directive('guacSettingsConnections', [function guacSe
             var dataSourceService      = $injector.get('dataSourceService');
             var guacNotification       = $injector.get('guacNotification');
             var permissionService      = $injector.get('permissionService');
+            var requestService         = $injector.get('requestService');
 
             /**
              * The identifier of the current user.
@@ -53,18 +54,6 @@ angular.module('settings').directive('guacSettingsConnections', [function guacSe
              * @type String
              */
             var currentUsername = authenticationService.getCurrentUsername();
-
-            /**
-             * An action to be provided along with the object sent to
-             * showStatus which closes the currently-shown status dialog.
-             */
-            var ACKNOWLEDGE_ACTION = {
-                name        : "SETTINGS_CONNECTIONS.ACTION_ACKNOWLEDGE",
-                // Handle action
-                callback    : function acknowledgeCallback() {
-                    guacNotification.showStatus(false);
-                }
-            };
 
             /**
              * The identifier of the currently-selected data source.
@@ -426,9 +415,9 @@ angular.module('settings').directive('guacSettingsConnections', [function guacSe
                 )
                 .then(function connectionGroupsReceived(rootGroups) {
                     $scope.rootGroups = rootGroups;
-                });
+                }, requestService.WARN);
 
-            }); // end retrieve permissions
+            }, requestService.WARN); // end retrieve permissions
 
         }]
     };

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
@@ -42,6 +42,7 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
             var languageService       = $injector.get('languageService');
             var permissionService     = $injector.get('permissionService');
             var preferenceService     = $injector.get('preferenceService');
+            var requestService        = $injector.get('requestService');
             var userService           = $injector.get('userService');
 
             /**
@@ -164,17 +165,7 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
                         },
                         actions : [ ACKNOWLEDGE_ACTION ]
                     });
-                })
-                
-                // Notify of any errors
-                ['catch'](function passwordUpdateFailed(error) {
-                    guacNotification.showStatus({
-                        className  : 'error',
-                        title      : 'SETTINGS_PREFERENCES.DIALOG_HEADER_ERROR',
-                        text       : error.translatableMessage,
-                        actions    : [ ACKNOWLEDGE_ACTION ]
-                    });
-                });
+                }, requestService.SHOW_NOTIFICATION);
                 
             };
 
@@ -186,8 +177,8 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
                         key: key,
                         value: languages[key]
                     };
-                })
-            });
+                });
+            }, requestService.WARN);
 
             // Retrieve current permissions
             permissionService.getEffectivePermissions(dataSource, username)
@@ -198,9 +189,9 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
                         PermissionSet.ObjectPermissionType.UPDATE, username);
                         
             })
-            ['catch'](function permissionsFailed(error) {
+            ['catch'](requestService.createErrorCallback(function permissionsFailed(error) {
                 $scope.canChangePassword = false;
-            });
+            }));
 
             /**
              * Returns whether critical data has completed being loaded.

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsPreferences.js
@@ -165,7 +165,7 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
                         },
                         actions : [ ACKNOWLEDGE_ACTION ]
                     });
-                }, requestService.SHOW_NOTIFICATION);
+                }, guacNotification.SHOW_REQUEST_ERROR);
                 
             };
 

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsSessions.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsSessions.js
@@ -316,7 +316,7 @@ angular.module('settings').directive('guacSettingsSessions', [function guacSetti
                     // Clear selection
                     allSelectedWrappers = {};
 
-                }, requestService.SHOW_NOTIFICATION);
+                }, guacNotification.SHOW_REQUEST_ERROR);
 
             }; 
             

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsSessions.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsSessions.js
@@ -47,6 +47,7 @@ angular.module('settings').directive('guacSettingsSessions', [function guacSetti
             var connectionGroupService  = $injector.get('connectionGroupService');
             var dataSourceService       = $injector.get('dataSourceService');
             var guacNotification        = $injector.get('guacNotification');
+            var requestService          = $injector.get('requestService');
 
             /**
              * The identifiers of all data sources accessible by the current
@@ -219,7 +220,7 @@ angular.module('settings').directive('guacSettingsSessions', [function guacSetti
                 // Attempt to produce wrapped list of active connections
                 wrapAllActiveConnections();
 
-            });
+            }, requestService.WARN);
             
             // Query active sessions
             dataSourceService.apply(
@@ -234,7 +235,7 @@ angular.module('settings').directive('guacSettingsSessions', [function guacSetti
                 // Attempt to produce wrapped list of active connections
                 wrapAllActiveConnections();
 
-            });
+            }, requestService.WARN);
 
             // Get session date format
             $translate('SETTINGS_SESSIONS.FORMAT_STARTDATE').then(function sessionDateFormatReceived(retrievedSessionDateFormat) {
@@ -245,7 +246,7 @@ angular.module('settings').directive('guacSettingsSessions', [function guacSetti
                 // Attempt to produce wrapped list of active connections
                 wrapAllActiveConnections();
 
-            });
+            }, angular.noop);
 
             /**
              * Returns whether critical data has completed being loaded.
@@ -256,18 +257,6 @@ angular.module('settings').directive('guacSettingsSessions', [function guacSetti
              */
             $scope.isLoaded = function isLoaded() {
                 return $scope.wrappers !== null;
-            };
-
-            /**
-             * An action to be provided along with the object sent to
-             * showStatus which closes the currently-shown status dialog.
-             */
-            var ACKNOWLEDGE_ACTION = {
-                name        : "SETTINGS_SESSIONS.ACTION_ACKNOWLEDGE",
-                // Handle action
-                callback    : function acknowledgeCallback() {
-                    guacNotification.showStatus(false);
-                }
             };
 
             /**
@@ -327,17 +316,7 @@ angular.module('settings').directive('guacSettingsSessions', [function guacSetti
                     // Clear selection
                     allSelectedWrappers = {};
 
-                },
-
-                // Notify of any errors
-                function activeConnectionDeletionFailed(error) {
-                    guacNotification.showStatus({
-                        'className'  : 'error',
-                        'title'      : 'SETTINGS_SESSIONS.DIALOG_HEADER_ERROR',
-                        'text'       : error.translatableMessage,
-                        'actions'    : [ ACKNOWLEDGE_ACTION ]
-                    });
-                });
+                }, requestService.SHOW_NOTIFICATION);
 
             }; 
             

--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsUsers.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsUsers.js
@@ -43,24 +43,12 @@ angular.module('settings').directive('guacSettingsUsers', [function guacSettings
             var $translate             = $injector.get('$translate');
             var authenticationService  = $injector.get('authenticationService');
             var dataSourceService      = $injector.get('dataSourceService');
-            var guacNotification       = $injector.get('guacNotification');
             var permissionService      = $injector.get('permissionService');
+            var requestService         = $injector.get('requestService');
             var userService            = $injector.get('userService');
 
             // Identifier of the current user
             var currentUsername = authenticationService.getCurrentUsername();
-
-            /**
-             * An action to be provided along with the object sent to
-             * showStatus which closes the currently-shown status dialog.
-             */
-            var ACKNOWLEDGE_ACTION = {
-                name        : "SETTINGS_USERS.ACTION_ACKNOWLEDGE",
-                // Handle action
-                callback    : function acknowledgeCallback() {
-                    guacNotification.showStatus(false);
-                }
-            };
 
             /**
              * The identifiers of all data sources accessible by the current
@@ -129,7 +117,7 @@ angular.module('settings').directive('guacSettingsUsers', [function guacSettings
                 // Store received date format
                 $scope.dateFormat = retrievedDateFormat;
 
-            });
+            }, angular.noop);
 
             /**
              * Returns whether critical data has completed being loaded.
@@ -287,9 +275,9 @@ angular.module('settings').directive('guacSettingsUsers', [function guacSettings
                         });
                     });
 
-                });
+                }, requestService.WARN);
 
-            });
+            }, requestService.WARN);
             
         }]
     };


### PR DESCRIPTION
This change addresses the new "possibly unhandled rejection" error by adding handling for absolutely *all* promise rejections. Each rejection is handled through one of the following mechanisms:

* Ignored via `angular.noop` (if the promise is not REST-related and failure of the promise is expected)
* Ignored via `requestService.IGNORE` (if the promise is REST-related and failure is expected)
* Warning via `requestService.WARN` (if the promise is REST-related and failure of the promise is generally *not* expected, but such failures are better quietly logged to the console than displayed in a modal notification)
* Notification via `guacNotification.SHOW_REQUEST_ERROR` (if the promise is REST-related and any failure should be exposed to the user as a modal notification)
* Handled in some custom fashon via `requestService.createErrorCallback()` (if the promise is REST-related)

The `IGNORE`, `WARN`, and `SHOW_REQUEST_ERROR` constants mentioned above are pre-defined callbacks generated through `requestService.createErrorCallback()`. The `requestService.createErrorCallback()` function produces a new callback function which invokes a given callback *only of the rejection is an instance of the REST `Error` object*. This allows JavaScript failures within the handling of a promise to still result in an error logged to the console.

In addition to the above, I noticed the following issues during my regression testing which had to be addressed:

* A `console.log()` debug statement snuck into the new `toArray` filter.
* An old-style `success()` call (used by the old AngularJS `$http` service) within the password update function.