### PR TITLE
GUACAMOLE-526: Invoke logout() for the cached token BEFORE storing new token.

### DIFF
--- a/guacamole/src/main/webapp/app/auth/service/authenticationService.js
+++ b/guacamole/src/main/webapp/app/auth/service/authenticationService.js
@@ -168,7 +168,6 @@ angular.module('auth').factory('authenticationService', ['$injector',
         .then(function authenticationSuccessful(data) {
 
             var currentToken = service.getCurrentToken();
-            setAuthenticationResult(new AuthenticationResult(data));
 
             // If a new token was received, ensure the old token is invalidated,
             // if any, and notify listeners of the new token
@@ -180,9 +179,15 @@ angular.module('auth').factory('authenticationService', ['$injector',
                 }
 
                 // Notify of login and new token
+                setAuthenticationResult(new AuthenticationResult(data));
                 $rootScope.$broadcast('guacLogin', data.authToken);
 
             }
+
+            // Update cached authentication result, even if the token remains
+            // the same
+            else
+                setAuthenticationResult(new AuthenticationResult(data));
 
             // Authentication was successful
             return data;


### PR DESCRIPTION
The changes introduced via #278 incorrectly invalidate the cached auth token after having already updated it with the new auth result. This causes the user to be logged out immediately after logging in if they happen to have a stale auth token.

To reproduce the above:

1. Log into Guacamole and allow the session to expire *OR* manually set `GUAC_AUTH` within `localStorage` to an auth result that contains an old/invalid token.
2. Visit any page within Guacamole. As your token is invalid, the login screen should display.
3. Log in with correct credentials. Though login succeeds, you will be immediately logged out and kicked back to a login screen.

These changes correct the order in which the old token is invalidated and the new token is stored.