### PR TITLE
GUACAMOLE-152: Allow zoom/scale to be manually entered.

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -731,10 +731,6 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
     });
 
-    $scope.formattedScale = function formattedScale() {
-        return Math.round($scope.client.clientProperties.scale * 100);
-    };
-    
     $scope.zoomIn = function zoomIn() {
         $scope.menu.autoFit = false;
         $scope.client.clientProperties.autoFit = false;

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -741,6 +741,16 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         $scope.client.clientProperties.autoFit = false;
         $scope.client.clientProperties.scale -= 0.1;
     };
+
+    /**
+     * When zoom is manually set by entering a value
+     * into the controller, this method turns off autoFit,
+     * both in the menu and the clientProperties.
+     */
+    $scope.zoomSet = function zoomSet() {
+        $scope.menu.autoFit = false;
+        $scope.client.clientProperties.autoFit = false;
+    };
     
     $scope.changeAutoFit = function changeAutoFit() {
         if ($scope.menu.autoFit && $scope.client.clientProperties.minScale) {

--- a/guacamole/src/main/webapp/app/client/directives/guacZoomCtrl.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacZoomCtrl.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A directive which converts between human-readable zoom
+ * percentage and display scale.
+ */
+angular.module('client').directive('guacZoomCtrl', function guacZoomCtrl() {
+    return {
+        restrict: 'A',
+        require: 'ngModel',
+        priority: 101,
+        link: function(scope, element, attr, ngModel) {
+
+            // When pushing to the menu, mutiply by 100.
+            ngModel.$formatters.push(function(value) {
+                return Math.round(value * 100);
+            });
+           
+            // When parsing value from menu, divide by 100.
+            ngModel.$parsers.push(function(value) {
+                return Math.round(value) / 100;
+            });
+        }
+    }
+});

--- a/guacamole/src/main/webapp/app/client/directives/guacZoomCtrl.js
+++ b/guacamole/src/main/webapp/app/client/directives/guacZoomCtrl.js
@@ -26,7 +26,13 @@ angular.module('client').directive('guacZoomCtrl', function guacZoomCtrl() {
         restrict: 'A',
         require: 'ngModel',
         priority: 101,
-        link: function(scope, element, attr, ngModel) {
+        link: function(scope, element, attrs, ngModel) {
+
+            // Evaluate the ngChange attribute when the model
+            // changes.
+            ngModel.$viewChangeListeners.push(function() {
+                scope.$eval(attrs.ngChange);
+            });
 
             // When pushing to the menu, mutiply by 100.
             ngModel.$formatters.push(function(value) {

--- a/guacamole/src/main/webapp/app/client/styles/menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/menu.css
@@ -134,6 +134,16 @@
     padding-top: 1em;
 }
 
+.menu-section .zoom-ctrl {
+    width: 4em;
+}
+
+.menu-section .zoom-ctrl::-webkit-inner-spin-button,
+.menu-section .zoom-ctrl::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
 .menu,
 .menu.closed {
     left: -480px;

--- a/guacamole/src/main/webapp/app/client/styles/menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/menu.css
@@ -134,8 +134,19 @@
     padding-top: 1em;
 }
 
-.menu-section .zoom-ctrl {
-    width: 4em;
+.menu-section input.zoom-ctrl {
+    width: 2em;
+    font-size: 1em;
+    padding: 0;
+    background: transparent;
+    border-color: rgba(0, 0, 0, 0.125);
+}
+
+.menu-section div.zoom-ctrl {
+    font-size: 1.5em;
+    display: inline;
+    align-content: center;
+    vertical-align: middle;
 }
 
 .menu-section .zoom-ctrl::-webkit-inner-spin-button,

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -151,9 +151,11 @@
                     <div class="content">
                         <div id="zoom-settings">
                             <div ng-click="zoomOut()" id="zoom-out"><img src="images/settings/zoom-out.png" alt="-"/></div>
-                            <input type="number" class="zoom-ctrl" guac-zoom-ctrl
-                                    ng-model="client.clientProperties.scale"
-                                    ng-model-options="{ updateOn: 'blur submit' }" />%
+                            <div class="zoom-ctrl">
+                                <input type="number" class="zoom-ctrl" guac-zoom-ctrl
+                                        ng-model="client.clientProperties.scale"
+                                        ng-model-options="{ updateOn: 'blur submit' }" />%
+                            </div>
                             <div ng-click="zoomIn()" id="zoom-in"><img src="images/settings/zoom-in.png" alt="+"/></div>
                         </div>
                         <div><label><input ng-model="menu.autoFit" ng-change="changeAutoFit()" ng-disabled="autoFitDisabled()" type="checkbox" id="auto-fit"/> {{'CLIENT.TEXT_ZOOM_AUTO_FIT' | translate}}</label></div>

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -155,7 +155,7 @@
                                 <input type="number" class="zoom-ctrl" guac-zoom-ctrl
                                         ng-model="client.clientProperties.scale"
                                         ng-model-options="{ updateOn: 'blur submit' }"
-                                        ng-change="zoomSet();" />%
+                                        ng-change="zoomSet()" />%
                             </div>
                             <div ng-click="zoomIn()" id="zoom-in"><img src="images/settings/zoom-in.png" alt="+"/></div>
                         </div>

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -151,7 +151,9 @@
                     <div class="content">
                         <div id="zoom-settings">
                             <div ng-click="zoomOut()" id="zoom-out"><img src="images/settings/zoom-out.png" alt="-"/></div>
-                            <input type="number" class="zoom-ctrl" guac-zoom-ctrl ng-model="client.clientProperties.scale" ng-model-options="{ debounce: 500 }" />%
+                            <input type="number" class="zoom-ctrl" guac-zoom-ctrl
+                                    ng-model="client.clientProperties.scale"
+                                    ng-model-options="{ updateOn: 'blur submit' }" />%
                             <div ng-click="zoomIn()" id="zoom-in"><img src="images/settings/zoom-in.png" alt="+"/></div>
                         </div>
                         <div><label><input ng-model="menu.autoFit" ng-change="changeAutoFit()" ng-disabled="autoFitDisabled()" type="checkbox" id="auto-fit"/> {{'CLIENT.TEXT_ZOOM_AUTO_FIT' | translate}}</label></div>

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -151,7 +151,7 @@
                     <div class="content">
                         <div id="zoom-settings">
                             <div ng-click="zoomOut()" id="zoom-out"><img src="images/settings/zoom-out.png" alt="-"/></div>
-                            <div id="zoom-state">{{formattedScale()}}%</div>
+                            <input type="number" class="zoom-ctrl" guac-zoom-ctrl ng-model="client.clientProperties.scale" ng-model-options="{ debounce: 500 }" />%
                             <div ng-click="zoomIn()" id="zoom-in"><img src="images/settings/zoom-in.png" alt="+"/></div>
                         </div>
                         <div><label><input ng-model="menu.autoFit" ng-change="changeAutoFit()" ng-disabled="autoFitDisabled()" type="checkbox" id="auto-fit"/> {{'CLIENT.TEXT_ZOOM_AUTO_FIT' | translate}}</label></div>

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -154,7 +154,8 @@
                             <div class="zoom-ctrl">
                                 <input type="number" class="zoom-ctrl" guac-zoom-ctrl
                                         ng-model="client.clientProperties.scale"
-                                        ng-model-options="{ updateOn: 'blur submit' }" />%
+                                        ng-model-options="{ updateOn: 'blur submit' }"
+                                        ng-change="zoomSet();" />%
                             </div>
                             <div ng-click="zoomIn()" id="zoom-in"><img src="images/settings/zoom-in.png" alt="+"/></div>
                         </div>


### PR DESCRIPTION
This change allows the zoom level (display scale) to be manually entered in addition to using the -/+ controls in the menu so that additional zoom levels can be reached that aren't currently possible with the 0.10 (10%) scale stepping.

Not sure if this is the right approach or not, but thought I'd give it a try!