### PR TITLE
GUACAMOLE-526: Use toArray as necessary for orderBy.

### DIFF
--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -64,9 +64,9 @@
                            translate="CLIENT.HELP_SHARE_LINK"
                            translate-values="{LINKS : getShareLinkCount()}"></p>
                         <table>
-                            <tr ng-repeat="link in client.shareLinks | orderBy: name">
-                                <th>{{link.name}}</th>
-                                <td><a href="{{link.href}}" target="_blank">{{link.href}}</a></td>
+                            <tr ng-repeat="link in client.shareLinks | toArray | orderBy: value.name">
+                                <th>{{link.value.name}}</th>
+                                <td><a href="{{link.value.href}}" target="_blank">{{link.value.href}}</a></td>
                             </tr>
                         </table>
                     </div>

--- a/guacamole/src/main/webapp/app/form/templates/timeZoneField.html
+++ b/guacamole/src/main/webapp/app/form/templates/timeZoneField.html
@@ -9,6 +9,6 @@
     <select class="time-zone"
             ng-disabled="!region"
             ng-model="model"
-            ng-options="name for (name, value) in timeZones[region] | orderBy: name"></select>
+            ng-options="timeZone.value as timeZone.key for timeZone in timeZones[region] | toArray | orderBy: key"></select>
 
 </div>

--- a/guacamole/src/main/webapp/app/index/filters/arrayFilter.js
+++ b/guacamole/src/main/webapp/app/index/filters/arrayFilter.js
@@ -19,20 +19,62 @@
 
 /**
  * A filter for transforming an object into an array of all non-inherited
- * property values.
+ * property key/value pairs. The resulting array contains one object for each
+ * property in the original object, where the "key" property contains the
+ * original property key and the "value" property contains the original
+ * property value.
  */
 angular.module('index').filter('toArray', [function toArrayFactory() {
 
-    return function toArrayFiter(input) {
+    /**
+     * The name of the property to use to store the cached result of converting
+     * an object to an array. This property is added to each object converted,
+     * such that the same array is returned each time unless the original
+     * object has changed.
+     *
+     * @type String
+     */
+    var CACHE_KEY = '_guac_toArray';
+
+    return function toArrayFilter(input) {
 
         // If no object is available, just return an empty array
         if (!input) {
             return [];
         }
 
-        return Object.keys(input).map(function fetchValueByKey(key) {
-            return input[key];
+        // Translate object into array of key/value pairs
+        var array = [];
+        angular.forEach(input, function fetchValueByKey(value, key) {
+            array.push({
+                key   : key,
+                value : value
+            });
         });
+
+        // Sort consistently by key
+        array.sort(function compareKeys(a, b) {
+            if (a.key < b.key) return -1;
+            if (a.key > b.key) return 1;
+            return 0;
+        });
+
+        // Define non-enumerable property for holding cached array
+        if (!input[CACHE_KEY]) {
+            Object.defineProperty(input, CACHE_KEY, {
+                value        : [],
+                enumerable   : false,
+                configurable : true,
+                writable     : true
+            });
+        }
+
+        // Update cache if resulting array is different
+        if (!angular.equals(input[CACHE_KEY], array))
+            input[CACHE_KEY] = array;
+
+        return input[CACHE_KEY];
+
     };
 
 }]);

--- a/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageConnection.html
@@ -32,7 +32,7 @@
             <tr>
                 <th>{{'MANAGE_CONNECTION.FIELD_HEADER_PROTOCOL' | translate}}</th>
                 <td>
-                    <select ng-model="connection.protocol" ng-options="protocol.name as getProtocolName(protocol.name) | translate for protocol in protocols | toArray | orderBy: name"></select>
+                    <select ng-model="connection.protocol" ng-options="protocol.value.name as getProtocolName(protocol.value.name) | translate for protocol in protocols | toArray | orderBy: value.name"></select>
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
The `toArray` filter is necessary wherever `orderBy` is being used to iterate over an object, as iterating over an object is not possible with AngularJS 1.6.x. This filter is already being correctly used for the list of available protocols in the connection edit screen, but is missing from:

1. The list of share links in the Guacamole menu.
2. The timezone field (on the user edit screen for users from the JDBC auth).

These changes add `toArray` to the above locations.

Additionally, as cases like the timezone field require both the key and value of each property to be available, these changes modify the `toArray` filter to produce an array of key/value pairs rather than just an array of values.
 
Further, to avoid [infdig](https://docs.angularjs.org/error/$rootScope/infdig) due to constantly changing results, the `toArray` filter has been modified to cache the result of the previous run within the object converted. A new array is returned only if its contents differ from the previous run.