### PR TITLE
GUACAMOLE-450: Update Tomcat to version 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Use args for Tomcat image label to allow image builder to choose alternatives
 # such as `--build-arg TOMCAT_JRE=jre8-alpine`
 #
-ARG TOMCAT_VERSION=8.5
+ARG TOMCAT_VERSION=9
 ARG TOMCAT_JRE=jre8
 
 # Use official maven image for the build


### PR DESCRIPTION
GUACAMOLE-450

Guacamole works fine wiht Version:  tomcat:9.0.7-jre8

all guacamole connections work without problems, I test it with :
Duo-Auth, RDP, SSH, telnet and VNC

