### PR TITLE
GUACAMOLE-540: Make remote address processing consistent

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
@@ -137,7 +137,7 @@ public class ModeledUserContext extends RestrictedObject
         userRecord = new ActivityRecordModel();
         userRecord.setUsername(currentUser.getIdentifier());
         userRecord.setStartDate(new Date());
-        userRecord.setRemoteHost(currentUser.getCredentials().getRemoteHostname());
+        userRecord.setRemoteHost(currentUser.getCredentials().getRemoteAddress());
 
         // Insert record representing login
         userRecordMapper.insert(userRecord);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
@@ -42,7 +42,7 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
      * The host from which this user authenticated.
      */
     private final String remoteHost;
- 
+
     /**
      * Creates a new RemoteAuthenticatedUser, deriving the associated remote
      * host from the given credentials.

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
@@ -19,9 +19,6 @@
 
 package org.apache.guacamole.auth.jdbc.user;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.servlet.http.HttpServletRequest;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
@@ -45,60 +42,7 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
      * The host from which this user authenticated.
      */
     private final String remoteHost;
-
-    /**
-     * Regular expression which matches any IPv4 address.
-     */
-    private static final String IPV4_ADDRESS_REGEX = "([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})";
-
-    /**
-     * Regular expression which matches any IPv6 address.
-     */
-    private static final String IPV6_ADDRESS_REGEX = "([0-9a-fA-F]*(:[0-9a-fA-F]*){0,7})";
-
-    /**
-     * Regular expression which matches any IP address, regardless of version.
-     */
-    private static final String IP_ADDRESS_REGEX = "(" + IPV4_ADDRESS_REGEX + "|" + IPV6_ADDRESS_REGEX + ")";
-
-    /**
-     * Pattern which matches valid values of the de-facto standard
-     * "X-Forwarded-For" header.
-     */
-    private static final Pattern X_FORWARDED_FOR = Pattern.compile("^" + IP_ADDRESS_REGEX + "(, " + IP_ADDRESS_REGEX + ")*$");
-
-    /**
-     * Derives the remote host of the authenticating user from the given
-     * credentials object. The remote host is derived from X-Forwarded-For
-     * in addition to the actual source IP of the request, and thus is not
-     * trusted. The derived remote host is really only useful for logging,
-     * unless the server is configured such that X-Forwarded-For is guaranteed
-     * to be trustworthy.
-     *
-     * @param credentials
-     *     The credentials to derive the remote host from.
-     *
-     * @return
-     *     The remote host from which the user with the given credentials is
-     *     authenticating.
-     */
-    private static String getRemoteHost(Credentials credentials) {
-
-        HttpServletRequest request = credentials.getRequest();
-
-        // Use X-Forwarded-For, if present and valid
-        String header = request.getHeader("X-Forwarded-For");
-        if (header != null) {
-            Matcher matcher = X_FORWARDED_FOR.matcher(header);
-            if (matcher.matches())
-                return matcher.group(1);
-        }
-
-        // If header absent or invalid, just use source IP
-        return request.getRemoteAddr();
-
-    }
-    
+ 
     /**
      * Creates a new RemoteAuthenticatedUser, deriving the associated remote
      * host from the given credentials.
@@ -113,7 +57,7 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
             Credentials credentials) {
         this.authenticationProvider = authenticationProvider;
         this.credentials = credentials;
-        this.remoteHost = getRemoteHost(credentials);
+        this.remoteHost = credentials.getRemoteAddress();
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -96,6 +96,45 @@ public class Credentials implements Serializable {
     private transient HttpSession session;
 
     /**
+     * Construct a Credentials object with the given username, password,
+     * and HTTP request.  The information is assigned to the various
+     * storage objects, and the remote hostname and address is parsed out
+     * of the request object.
+     * 
+     * @param username
+     *     The username that was provided for authentication.
+     * 
+     * @param password
+     *     The password that was provided for authentication.
+     * 
+     * @param request 
+     *     The HTTP request associated with the authentication
+     *     request.
+     */
+    public Credentials(String username, String password, HttpServletRequest request) {
+        this.username = username;
+        this.password = password;
+        this.request = request;
+        
+        // Use X-Forwarded-For to get remote address, if present and valid
+        String header = request.getHeader("X-Forwarded-For");
+        if (header != null) {
+            Matcher matcher = X_FORWARDED_FOR.matcher(header);
+            if (matcher.matches())
+                this.remoteAddress = matcher.group(1);
+        }
+        // Header not present, just use remote address
+        else {
+            this.remoteAddress = request.getRemoteAddr();
+        }
+        
+        this.remoteHostname = request.getRemoteHost();
+        
+        this.session = request.getSession(false);
+        
+    }
+    
+    /**
      * Returns the password associated with this set of credentials.
      * @return The password associated with this username/password pair, or
      *         null if no password has been set.
@@ -150,21 +189,6 @@ public class Credentials implements Serializable {
      */
     public void setRequest(HttpServletRequest request) {
         this.request = request;
-        
-        // Use X-Forwarded-For to get remote address, if present and valid
-        String header = request.getHeader("X-Forwarded-For");
-        if (header != null) {
-            Matcher matcher = X_FORWARDED_FOR.matcher(header);
-            if (matcher.matches())
-                this.remoteAddress = matcher.group(1);
-        }
-        // Header not present, just use remote address
-        else {
-            this.remoteAddress = request.getRemoteAddr();
-        }
-        
-        this.remoteHostname = request.getRemoteHost();
-        
     }
 
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -227,6 +227,18 @@ public class Credentials implements Serializable {
     public String getRemoteAddress() {
         return remoteAddress;
     }
+    
+    /**
+     * Sets the address of the client end of the connection which provided
+     * these credentials.
+     *
+     * @param remoteAddress
+     *     The address of the client end of the connection which provided these
+     *     credentials, or null if the address is not known.
+     */
+    public void setRemoteAddress(String remoteAddress) {
+        this.remoteAddress = remoteAddress;
+    }
 
     /**
      * Returns the hostname of the client end of the connection which provided
@@ -240,6 +252,20 @@ public class Credentials implements Serializable {
      */
     public String getRemoteHostname() {
         return remoteHostname;
+    }
+    
+    /**
+     * Sets the hostname of the client end of the connection which provided
+     * these credentials, if known. If the hostname of the client cannot be
+     * determined, but the address is known, the address may be specified
+     * instead.
+     *
+     * @param remoteHostname
+     *     The hostname or address of the client end of the connection which
+     *     provided these credentials, or null if the hostname is not known.
+     */
+    public void setRemoteHostname(String remoteHostname) {
+        this.remoteHostname = remoteHostname;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -40,27 +40,6 @@ public class Credentials implements Serializable {
      * Unique identifier associated with this specific version of Credentials.
      */
     private static final long serialVersionUID = 1L;
-    
-    /**
-     * Regular expression which matches any IPv4 address.
-     */
-    private static final String IPV4_ADDRESS_REGEX = "([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})";
-
-    /**
-     * Regular expression which matches any IPv6 address.
-     */
-    private static final String IPV6_ADDRESS_REGEX = "([0-9a-fA-F]*(:[0-9a-fA-F]*){0,7})";
-    
-    /**
-     * Regular expression which matches any IP address, regardless of version.
-     */
-    private static final String IP_ADDRESS_REGEX = "(" + IPV4_ADDRESS_REGEX + "|" + IPV6_ADDRESS_REGEX + ")";
-    
-    /**
-     * Pattern which matches valid values of the de-facto standard
-     * "X-Forwarded-For" header.
-     */
-    private static final Pattern X_FORWARDED_FOR = Pattern.compile("^" + IP_ADDRESS_REGEX + "(, " + IP_ADDRESS_REGEX + ")*$");
 
     /**
      * An arbitrary username.
@@ -115,25 +94,16 @@ public class Credentials implements Serializable {
         this.username = username;
         this.password = password;
         this.request = request;
-        
-        // Use X-Forwarded-For to get remote address, if present and valid
-        String header = request.getHeader("X-Forwarded-For");
-        if (header != null) {
-            Matcher matcher = X_FORWARDED_FOR.matcher(header);
-            if (matcher.matches())
-                this.remoteAddress = matcher.group(1);
-        }
-        
-        // Header not present, just use remote address
-        else
-            this.remoteAddress = request.getRemoteAddr();
-        
+
+        // Set the remote address
+        this.remoteAddress = request.getRemoteAddr();
+
         // Get the remote hostname
         this.remoteHostname = request.getRemoteHost();
-        
+
         // If session exists get it, but don't create a new one.
         this.session = request.getSession(false);
-        
+
     }
     
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -20,8 +20,6 @@
 package org.apache.guacamole.net.auth;
 
 import java.io.Serializable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -123,19 +123,22 @@ public class Credentials implements Serializable {
             if (matcher.matches())
                 this.remoteAddress = matcher.group(1);
         }
-        // Header not present, just use remote address
-        else {
-            this.remoteAddress = request.getRemoteAddr();
-        }
         
+        // Header not present, just use remote address
+        else
+            this.remoteAddress = request.getRemoteAddr();
+        
+        // Get the remote hostname
         this.remoteHostname = request.getRemoteHost();
         
+        // If session exists get it, but don't create a new one.
         this.session = request.getSession(false);
         
     }
     
     /**
      * Returns the password associated with this set of credentials.
+     *
      * @return The password associated with this username/password pair, or
      *         null if no password has been set.
      */
@@ -145,6 +148,7 @@ public class Credentials implements Serializable {
 
     /**
      * Sets the password associated with this set of credentials.
+     *
      * @param password The password to associate with this username/password
      *                 pair.
      */
@@ -154,6 +158,7 @@ public class Credentials implements Serializable {
 
     /**
      * Returns the username associated with this set of credentials.
+     *
      * @return The username associated with this username/password pair, or
      *         null if no username has been set.
      */
@@ -163,6 +168,7 @@ public class Credentials implements Serializable {
 
     /**
      * Sets the username associated with this set of credentials.
+     *
      * @param username The username to associate with this username/password
      *                 pair.
      */
@@ -172,6 +178,7 @@ public class Credentials implements Serializable {
 
     /**
      * Returns the HttpServletRequest associated with this set of credentials.
+     *
      * @return The HttpServletRequest associated with this set of credentials,
      *         or null if no such request exists.
      */
@@ -181,9 +188,7 @@ public class Credentials implements Serializable {
 
     /**
      * Sets the HttpServletRequest associated with this set of credentials.
-     * Also sets the remoteAddress and remoteHostname objects, checking the
-     * request for X-Forwarded-For or falling back to provided remote address.
-     * 
+     *
      * @param request  The HttpServletRequest to associated with this set of
      *                 credentials.
      */
@@ -193,6 +198,7 @@ public class Credentials implements Serializable {
 
     /**
      * Returns the HttpSession associated with this set of credentials.
+     *
      * @return The HttpSession associated with this set of credentials, or null
      *         if no such request exists.
      */
@@ -202,6 +208,7 @@ public class Credentials implements Serializable {
 
     /**
      * Sets the HttpSession associated with this set of credentials.
+     *
      * @param session The HttpSession to associated with this set of
      *                credentials.
      */

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -142,6 +142,9 @@ public class Credentials implements Serializable {
 
     /**
      * Sets the HttpServletRequest associated with this set of credentials.
+     * Also sets the remoteAddress and remoteHostname objects, checking the
+     * request for X-Forwarded-For or falling back to provided remote address.
+     * 
      * @param request  The HttpServletRequest to associated with this set of
      *                 credentials.
      */
@@ -153,14 +156,14 @@ public class Credentials implements Serializable {
         if (header != null) {
             Matcher matcher = X_FORWARDED_FOR.matcher(header);
             if (matcher.matches())
-                setRemoteAddress(matcher.group(1));
+                this.remoteAddress = matcher.group(1);
         }
         // Header not present, just use remote address
         else {
-            setRemoteAddress(request.getRemoteAddr());
+            this.remoteAddress = request.getRemoteAddr();
         }
         
-        setRemoteHostname(request.getRemoteHost());
+        this.remoteHostname = request.getRemoteHost();
         
     }
 
@@ -195,18 +198,6 @@ public class Credentials implements Serializable {
     }
 
     /**
-     * Sets the address of the client end of the connection which provided
-     * these credentials.
-     *
-     * @param remoteAddress
-     *     The address of the client end of the connection which provided these
-     *     credentials, or null if the address is not known.
-     */
-    public void setRemoteAddress(String remoteAddress) {
-        this.remoteAddress = remoteAddress;
-    }
-
-    /**
      * Returns the hostname of the client end of the connection which provided
      * these credentials, if known. If the hostname of the client cannot be
      * determined, but the address is known, the address may be returned
@@ -218,20 +209,6 @@ public class Credentials implements Serializable {
      */
     public String getRemoteHostname() {
         return remoteHostname;
-    }
-
-    /**
-     * Sets the hostname of the client end of the connection which provided
-     * these credentials, if known. If the hostname of the client cannot be
-     * determined, but the address is known, the address may be specified
-     * instead.
-     *
-     * @param remoteHostname
-     *     The hostname or address of the client end of the connection which
-     *     provided these credentials, or null if the hostname is not known.
-     */
-    public void setRemoteHostname(String remoteHostname) {
-        this.remoteHostname = remoteHostname;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -227,7 +227,7 @@ public class Credentials implements Serializable {
     public String getRemoteAddress() {
         return remoteAddress;
     }
-    
+
     /**
      * Sets the address of the client end of the connection which provided
      * these credentials.
@@ -253,7 +253,7 @@ public class Credentials implements Serializable {
     public String getRemoteHostname() {
         return remoteHostname;
     }
-    
+
     /**
      * Sets the hostname of the client end of the connection which provided
      * these credentials, if known. If the hostname of the client cannot be

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
@@ -55,7 +55,7 @@ public class TokenRESTService {
      * Logger for this class.
      */
     private static final Logger logger = LoggerFactory.getLogger(TokenRESTService.class);
-
+    
     /**
      * Service for authenticating users and managing their Guacamole sessions.
      */
@@ -122,8 +122,6 @@ public class TokenRESTService {
         credentials.setPassword(password);
         credentials.setRequest(request);
         credentials.setSession(request.getSession(false));
-        credentials.setRemoteAddress(request.getRemoteAddr());
-        credentials.setRemoteHostname(request.getRemoteHost());
 
         return credentials;
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/TokenRESTService.java
@@ -55,7 +55,7 @@ public class TokenRESTService {
      * Logger for this class.
      */
     private static final Logger logger = LoggerFactory.getLogger(TokenRESTService.class);
-    
+
     /**
      * Service for authenticating users and managing their Guacamole sessions.
      */
@@ -117,13 +117,7 @@ public class TokenRESTService {
         } // end Authorization header fallback
 
         // Build credentials
-        Credentials credentials = new Credentials();
-        credentials.setUsername(username);
-        credentials.setPassword(password);
-        credentials.setRequest(request);
-        credentials.setSession(request.getSession(false));
-
-        return credentials;
+        return new Credentials(username, password, request);
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
@@ -155,11 +155,8 @@ public class UserResource
             @Context HttpServletRequest request) throws GuacamoleException {
 
         // Build credentials
-        Credentials credentials = new Credentials();
-        credentials.setUsername(user.getIdentifier());
-        credentials.setPassword(userPasswordUpdate.getOldPassword());
-        credentials.setRequest(request);
-        credentials.setSession(request.getSession(false));
+        Credentials credentials = new Credentials(user.getIdentifier(),
+                userPasswordUpdate.getOldPassword(), request);
 
         // Verify that the old password was correct
         try {

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
@@ -160,8 +160,6 @@ public class UserResource
         credentials.setPassword(userPasswordUpdate.getOldPassword());
         credentials.setRequest(request);
         credentials.setSession(request.getSession(false));
-        credentials.setRemoteAddress(request.getRemoteAddr());
-        credentials.setRemoteHostname(request.getRemoteHost());
 
         // Verify that the old password was correct
         try {


### PR DESCRIPTION
This PR moves the setting of the remote address and remote hostname processing into the `Credentials` class and removes it from the client classes.  This should resolve the issue in GUACAMOLE-540, making determination of remote address more consistent across connection and user objects.