### PR TITLE
GUACAMOLE-565: Add terminal-type parameter for SSH and Telnet.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
@@ -83,6 +83,11 @@
                     "name"    : "backspace",
                     "type"    : "ENUM",
                     "options" : [ "", "127", "8" ]
+                },
+                {
+                    "name"  : "terminal-type",
+                    "type"    : "ENUM",
+                    "options" : [ "xterm", "xterm-256color", "vt220", "vt100", "ansi", "linux" ]
                 }
             ]
         },

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
@@ -66,6 +66,11 @@
                     "name"    : "backspace",
                     "type"    : "ENUM",
                     "options" : [ "", "127", "8" ]
+                },
+                {
+                    "name"  : "terminal-type",
+                    "type"    : "ENUM",
+                    "options" : [ "xterm", "xterm-256color", "vt220", "vt100", "ansi", "linux" ]
                 }
             ]
         },


### PR DESCRIPTION
Add the new terminal-type parameter (apache/guacamole-server#167) to the protocol JSON files.