### PR TITLE
GUACAMOLE-470: Update "color-scheme" parameter for SSH and Telnet.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
@@ -43,8 +43,7 @@
             "fields" : [
                 {
                     "name"  : "color-scheme",
-                    "type"  : "ENUM",
-                    "options" : [ "", "black-white", "gray-black", "green-black", "white-black" ]
+                    "type"  : "TEXT"
                 },
                 {
                     "name"  : "font-name",

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
@@ -39,8 +39,7 @@
             "fields" : [
                 {
                     "name"  : "color-scheme",
-                    "type"  : "ENUM",
-                    "options" : [ "", "black-white", "gray-black", "green-black", "white-black" ]
+                    "type"  : "TEXT"
                 },
                 {
                     "name"  : "font-name",


### PR DESCRIPTION
apache/guacamole-server#132 changes the "color-scheme" parameter to be a configuration string instead of a simple enum, so update the protocol JSON accordingly.