### PR TITLE
GUACAMOLE-524: Add attributes to credentials and token filter

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.net.auth;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -76,7 +77,7 @@ public class Credentials implements Serializable {
     /**
      * Arbitrary attributes associated with this Credential object.
      */
-    private Map<String, String> attributes;
+    private Map<String, String> attributes = new HashMap<String, String>();
 
     /**
      * Returns the password associated with this set of credentials.
@@ -224,6 +225,19 @@ public class Credentials implements Serializable {
     }
     
     /**
+     * Add the Map of attributes to the current set, without completely
+     * replacing the existing set.  However, if duplicate keys exist the new
+     * values will replace any existing ones.
+     * 
+     * @param attributes
+     *     A Map of attributes to add to the existing attributes, without
+     *     completely overwriting them.
+     */
+    public void addAttributes(Map<String, String> attributes) {
+        this.attributes.putAll(attributes);
+    }
+    
+    /**
      * Retrieve a single attribute value from the map of arbitrary attributes
      * stored in this Credential object.
      * 
@@ -238,7 +252,9 @@ public class Credentials implements Serializable {
     }
     
     /**
-     * Set the attribute of the given key to the given value.
+     * Set the attribute of the given key to the given value, either adding
+     * a new value if the specified key does not exist, or replacing an existing
+     * value.
      * 
      * @param key
      *     The key name of the attribute to set (or overwrite, if it

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.net.auth;
 
 import java.io.Serializable;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -71,6 +72,11 @@ public class Credentials implements Serializable {
      * The HttpSession carrying additional credentials, if any.
      */
     private transient HttpSession session;
+    
+    /**
+     * Arbitrary attributes associated with this Credential object.
+     */
+    private Map<String, String> attributes;
 
     /**
      * Returns the password associated with this set of credentials.
@@ -194,6 +200,55 @@ public class Credentials implements Serializable {
      */
     public void setRemoteHostname(String remoteHostname) {
         this.remoteHostname = remoteHostname;
+    }
+    
+    /**
+     * Get the map of attributes associated with this Credential object.
+     * 
+     * @return
+     *     The Map of arbitrary attributes associated with this Credential
+     *     object.
+     */
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+    
+    /**
+     * Set a map of attributes associated with this Credential object.
+     * 
+     * @param attributes
+     *     A Map of attribute key/value pairs to add to these credentials.
+     */
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+    
+    /**
+     * Retrieve a single attribute value from the map of arbitrary attributes
+     * stored in this Credential object.
+     * 
+     * @param key
+     *     The key of the attribute to retrieve.
+     * 
+     * @return
+     *     The value of the attribute with the specified key. 
+     */
+    public String getAttribute(String key) {
+        return attributes.get(key);
+    }
+    
+    /**
+     * Set the attribute of the given key to the given value.
+     * 
+     * @param key
+     *     The key name of the attribute to set (or overwrite, if it
+     *     already exists).
+     * 
+     * @param value
+     *     The value of the attribute to set or overwrite.
+     */
+    public void setAttribute(String key, String value) {
+        attributes.put(key, value);
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -79,7 +79,7 @@ public class StandardTokens {
     /**
      * The prefix of the arbitrary attribute tokens.
      */
-    public static final String ATTR_TOKEN_PREFIX = "GUAC_ATTR_";
+    public static final String ATTR_TOKEN_PREFIX = "GUAC_ATTR:";
 
     /**
      * This utility class should not be instantiated.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -21,6 +21,8 @@ package org.apache.guacamole.token;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
+import java.util.Map.Entry;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 
@@ -73,6 +75,11 @@ public class StandardTokens {
      * be compatible with Java's SimpleDateFormat.
      */
     private static final String TIME_FORMAT = "HHmmss";
+    
+    /**
+     * The prefix of the arbitrary attribute tokens.
+     */
+    public static final String ATTR_TOKEN_PREFIX = "GUAC_ATTR_";
 
     /**
      * This utility class should not be instantiated.
@@ -94,6 +101,29 @@ public class StandardTokens {
         filter.setToken(DATE_TOKEN, new SimpleDateFormat(DATE_FORMAT).format(currentTime));
         filter.setToken(TIME_TOKEN, new SimpleDateFormat(TIME_FORMAT).format(currentTime));
 
+    }
+    
+    /**
+     * Add attribute tokens to the TokenFilter object.  These are arbitrary
+     * key/value pairs that may be configured by the various authentication
+     * extensions.
+     * 
+     * @param filter
+     *     The TokenFilter to add attributes tokens to.
+     * 
+     * @param attributes
+     *     The map of key/value pairs to add tokens for.
+     */
+    public static void addAttributeTokens(TokenFilter filter,
+            Map<String, String> attributes) {
+        
+        for (Entry entry : attributes.entrySet()) {
+            String key = entry.getKey().toString();
+            String tokenName = ATTR_TOKEN_PREFIX + key.toUpperCase();
+            String tokenValue = entry.getValue().toString();
+            filter.setToken(tokenName, tokenValue);
+        }
+        
     }
 
     /**
@@ -134,6 +164,9 @@ public class StandardTokens {
         if (address != null)
             filter.setToken(CLIENT_ADDRESS_TOKEN, address);
 
+        // Add tokens derived from the attribute map
+        addAttributeTokens(filter, credentials.getAttributes());
+        
         // Add any tokens which do not require credentials
         addStandardTokens(filter);
 


### PR DESCRIPTION
This is the first in a set of at least a couple of pull requests that allows user attributes retrieved in various authentication extensions to be used in the `TokenFilter` class so that they can be used by connections provided by other extensions.  This change adds the attributes `Map` to the `Credentials` object, along with methods for interacting with it, and also adds the changes into the `TokenFilter` and `StandardToken` classes to map those attributes to token values.

With these changes, if an attribute is added to a `Credentials` object with a key of "email" and a value of "nick@guacamole.local", the token `${GUAC_ATTR:EMAIL} would then substitute in the value "nick@guacamole.local".

Assuming this is acceptable, the next pull request or two would add support to various authentication modules for configuring and retrieving attributes and adding them to the `Credentials` object so that they can be used.