### PR TITLE
GUACAMOLE-470: Remove translations for "color-scheme" enum values.

### DIFF
--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -378,12 +378,6 @@
         "FIELD_HEADER_PRIVATE_KEY" : "Privater Schlüssel:",
         "FIELD_HEADER_READ_ONLY"   : "Nur-Lesen:",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Schwarz auf Weiß",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grau auf Schwarz",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grün auf Schwarz",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Weiß auf Schwarz",
-
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -421,12 +415,6 @@
         "FIELD_HEADER_PASSWORD_REGEX" : "Reguläre Passwortersetzungen:",
         "FIELD_HEADER_PORT"           : "Port:",
         "FIELD_HEADER_READ_ONLY"      : "Nur-Lesen:",
-
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Schwarz auf Weiß",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grau auf Schwarz",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grün auf Schwarz",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Weiß auf Schwarz",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -453,12 +453,6 @@
         "FIELD_OPTION_BACKSPACE_8"     : "Backspace (Ctrl-H)",
         "FIELD_OPTION_BACKSPACE_127"   : "Delete (Ctrl-?)",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Black on white",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gray on black",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Green on black",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "White on black",
-
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -513,12 +507,6 @@
         "FIELD_OPTION_BACKSPACE_EMPTY" : "",
         "FIELD_OPTION_BACKSPACE_8"     : "Backspace (Ctrl-H)",
         "FIELD_OPTION_BACKSPACE_127"   : "Delete (Ctrl-?)",
-
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Black on white",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gray on black",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Green on black",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "White on black",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/es.json
+++ b/guacamole/src/main/webapp/translations/es.json
@@ -435,12 +435,6 @@
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Nombre script escritura:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Ruta script escritura:",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Negro sobre blanco",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sobre negro",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Verde sobre negro",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanco sobre negro",
-
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -486,12 +480,6 @@
         "FIELD_HEADER_RECORDING_PATH" : "Ruta grabación:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Nombre script escritura:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Ruta script escritura:",
-
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Negro sobre blanco",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sobre negro",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Verde sobre negro",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanco sobre negro",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/fr.json
+++ b/guacamole/src/main/webapp/translations/fr.json
@@ -381,12 +381,6 @@
         "FIELD_HEADER_PRIVATE_KEY" : "Clé privée:",
         "FIELD_HEADER_READ_ONLY"   : "Lecture seule:",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Noir sur blanc",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Vert sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanc sur noir",
-
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -424,12 +418,6 @@
         "FIELD_HEADER_PASSWORD_REGEX" : "Expression régulière Mot de passe:",
         "FIELD_HEADER_PORT"           : "Port:",
         "FIELD_HEADER_READ_ONLY"      : "Lecture seule:",
-
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Noir sur blanc",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Vert sur noir",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanc sur noir",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/nl.json
+++ b/guacamole/src/main/webapp/translations/nl.json
@@ -397,12 +397,6 @@
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript naam:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript map:",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Zwart op wit",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grijs op zwart",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Groen op zwart",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Wit op zwart",
-
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -448,12 +442,6 @@
         "FIELD_HEADER_RECORDING_PATH" : "Opname map:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript naam:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript map:",
-
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Zwart op wit",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grijs op zwart",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Groen op zwart",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Wit op zwart",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/no.json
+++ b/guacamole/src/main/webapp/translations/no.json
@@ -379,12 +379,6 @@
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript navn:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript sti:",
 
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Svart på hvit",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grå på svart",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grønn på svart",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Hvit på svart",
-
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -429,12 +423,6 @@
         "FIELD_HEADER_RECORDING_PATH" : "Sti til opptak:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript navn:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript sti:",
-
-        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Svart på hvit",
-        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
-        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grå på svart",
-        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grønn på svart",
-        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Hvit på svart",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",


### PR DESCRIPTION
Follow-up to #289. Remove translations for the "color-scheme" enum values, because the field type is now "TEXT" and not "ENUM" anymore.

Changing the field type to "TEXT" does have the disadvantage of losing localized enum choices. Maybe it would be better to keep "color-scheme" an ENUM, and add a "custom-color-scheme" TEXT field for customized color schemes?