### PR TITLE
GUACAMOLE-571: Fix rootConnectionGroup typo in homeController.

### DIFF
--- a/guacamole/src/main/webapp/app/home/controllers/homeController.js
+++ b/guacamole/src/main/webapp/app/home/controllers/homeController.js
@@ -70,7 +70,7 @@ angular.module('home').controller('homeController', ['$scope', '$injector',
      */
     $scope.isLoaded = function isLoaded() {
 
-        return $scope.rootConnectionGroup !== null;
+        return $scope.rootConnectionGroups !== null;
 
     };
 


### PR DESCRIPTION
Quick fix to typo reported on dev mailing list [1].

[1] - http://mail-archives.apache.org/mod_mbox/guacamole-dev/201805.mbox/%3CCAENMeX%3DwCfwNKJy_F%2BVK8E0jpzZkg6OCnbzpqUwSA9jPpUL77Q%40mail.gmail.com%3E