### PR TITLE
GUACAMOLE-524: Allow custom LDAP attributes to be used as tokens

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -26,6 +26,11 @@ import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Map;
+
+
 /**
  * Associates a user with the credentials they used to authenticate, their
  * corresponding ModeledUser, and the AuthenticationProvider which produced
@@ -79,6 +84,7 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
         super(authenticatedUser.getAuthenticationProvider(), authenticatedUser.getCredentials());
         this.modelAuthenticationProvider = modelAuthenticationProvider;
         this.user = user;
+        this.setAttributes(authenticatedUser.getAttributes());
     }
 
     /**
@@ -93,7 +99,7 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
      *     A ModeledUser object which is backed by the data associated with
      *     this user in the database.
      *
-     * @param credentials 
+     * @param credentials
      *     The credentials given by the user when they authenticated.
      */
     public ModeledAuthenticatedUser(AuthenticationProvider authenticationProvider,
@@ -107,7 +113,7 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
      * Returns a ModeledUser object which is backed by the data associated with
      * this user within the database.
      *
-     * @return 
+     * @return
      *     A ModeledUser object which is backed by the data associated with
      *     this user in the database.
      */

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -26,11 +26,6 @@ import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.util.Map;
-
-
 /**
  * Associates a user with the credentials they used to authenticate, their
  * corresponding ModeledUser, and the AuthenticationProvider which produced
@@ -84,7 +79,7 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
         super(authenticatedUser.getAuthenticationProvider(), authenticatedUser.getCredentials());
         this.modelAuthenticationProvider = modelAuthenticationProvider;
         this.user = user;
-        this.setAttributes(authenticatedUser.getAttributes());
+        super.setAttributes(authenticatedUser.getAttributes());
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.auth.jdbc.user;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
@@ -68,6 +70,21 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
     private static final Pattern X_FORWARDED_FOR = Pattern.compile("^" + IP_ADDRESS_REGEX + "(, " + IP_ADDRESS_REGEX + ")*$");
 
     /**
+     * Arbitrary attributes associated with this RemoteAuthenticatedUser object.
+     */
+    private Map<String, String> attributes = new HashMap<String, String>();
+
+    @Override
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    /**
      * Derives the remote host of the authenticating user from the given
      * credentials object. The remote host is derived from X-Forwarded-For
      * in addition to the actual source IP of the request, and thus is not
@@ -98,7 +115,7 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
         return request.getRemoteAddr();
 
     }
-    
+
     /**
      * Creates a new RemoteAuthenticatedUser, deriving the associated remote
      * host from the given credentials.
@@ -106,7 +123,7 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
      * @param authenticationProvider
      *     The AuthenticationProvider that has authenticated the given user.
      *
-     * @param credentials 
+     * @param credentials
      *     The credentials given by the user when they authenticated.
      */
     public RemoteAuthenticatedUser(AuthenticationProvider authenticationProvider,

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -26,9 +26,7 @@ import com.novell.ldap.LDAPAttributeSet;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
-import com.novell.ldap.LDAPReferralException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.guacamole.auth.ldap.user.AuthenticatedUser;
@@ -236,9 +234,7 @@ public class AuthenticationProviderService {
             authenticatedUser.init(credentials);
 
             // Set attributes
-            String username = credentials.getUsername();
-            Map<String, String> attrs = getLDAPAttributes(ldapConnection, username);
-            authenticatedUser.setAttributes(attrs);
+            authenticatedUser.setAttributes(getLDAPAttributes(ldapConnection, credentials.getUsername()));
 
             return authenticatedUser;
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -269,7 +269,7 @@ public class AuthenticationProviderService {
      *     If an error occurs while searching for the user attributes.
      *
      * @throws GuacamoleException
-     *     If an error occurs retrieving the user DN.
+     *     If an error occurs retrieving the user DN or the attributes.
      */
     private Map<String, String> getLDAPAttributes(LDAPConnection ldapConnection,
             String username) throws GuacamoleException {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -197,7 +197,8 @@ public class AuthenticationProviderService {
 
     /**
      * Returns an AuthenticatedUser representing the user authenticated by the
-     * given credentials. Also adds custom LDAP attributes to credentials object.
+     * given credentials. Also adds custom LDAP attributes to the
+     * AuthenticatedUser.
      *
      * @param credentials
      *     The credentials to use for authentication.
@@ -233,7 +234,7 @@ public class AuthenticationProviderService {
             AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
             authenticatedUser.init(credentials);
 
-            //set attributes
+            // Set attributes
             String username = credentials.getUsername();
             Map<String, String> attrs = getLDAPAttributes(ldapConnection, username);
             authenticatedUser.setAttributes(attrs);
@@ -293,9 +294,7 @@ public class AuthenticationProviderService {
             // Add each attribute into Map
             for (Object attrObj : attrSet) {
                 LDAPAttribute attr = (LDAPAttribute)attrObj;
-                String attrName = attr.getName();
-                String attrValue = attr.getStringValue();
-                attrMap.put(attrName, attrValue);
+                attrMap.put(attr.getName(), attr.getStringValue());
             }
         }
         catch (LDAPException e) {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -21,11 +21,12 @@ package org.apache.guacamole.auth.ldap;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.novell.ldap.LDAPConnection;
-import com.novell.ldap.LDAPAttributeSet;
-import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPAttribute;
+import com.novell.ldap.LDAPAttributeSet;
+import com.novell.ldap.LDAPConnection;
+import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
+import com.novell.ldap.LDAPReferralException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -265,9 +265,6 @@ public class AuthenticationProviderService {
      *     given LDAP connection, as a map of attribute name to
      *     corresponding attribute value.
      *
-     * @throws LDAPException
-     *     If an error occurs while searching for the user attributes.
-     *
      * @throws GuacamoleException
      *     If an error occurs retrieving the user DN or the attributes.
      */

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -227,7 +227,7 @@ public class ConfigurationService {
     private int getMaxResults() throws GuacamoleException {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_MAX_SEARCH_RESULTS,
-            1000 
+            1000
         );
     }
 
@@ -341,6 +341,22 @@ public class ConfigurationService {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_OPERATION_TIMEOUT,
             30
+        );
+    }
+
+    /**
+     * Returns names for custom LDAP user attributes.
+     *
+     * @return
+     *     LDAP user attributes as defined in the guacamole.properties file
+     *     as ldap-user-attributes: ''
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public List<String> getAttributes() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_USER_ATTRIBUTES
         );
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -348,8 +348,7 @@ public class ConfigurationService {
      * Returns names for custom LDAP user attributes.
      *
      * @return
-     *     LDAP user attributes as defined in the guacamole.properties file
-     *     as ldap-user-attributes: ''
+     *     Custom LDAP user attributes as configured in guacamole.properties.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -206,8 +206,8 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * Custom attribute or attributes in Guacamole user's record in the
-     * LDAP directory.
+     * Custom attribute or attributes to query from Guacamole user's record in
+     * the LDAP directory.
      */
     public static final StringListProperty LDAP_USER_ATTRIBUTES = new StringListProperty() {
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -205,4 +205,14 @@ public class LDAPGuacamoleProperties {
 
     };
 
+    /**
+     * Custom attribute or attributes in Guacamole user's record in the
+     * LDAP directory.
+     */
+    public static final StringListProperty LDAP_USER_ATTRIBUTES = new StringListProperty() {
+
+        @Override
+        public String getName() { return "ldap-user-attributes"; }
+
+    };
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -36,7 +36,6 @@ import org.apache.guacamole.auth.ldap.EscapingService;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-//import org.apache.guacamole.auth.ldap.user.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.simple.SimpleConnection;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
@@ -128,7 +127,7 @@ public class ConnectionService {
             StandardTokens.addStandardTokens(tokenFilter, user);
 
             // Add custom attribute tokens
-            Map<String, String> attrs = ( (org.apache.guacamole.auth.ldap.user.AuthenticatedUser) user).getAttributes();
+            Map<String, String> attrs = user.getAttributes();
             StandardTokens.addAttributeTokens(tokenFilter, attrs);
 
             // Produce connections for each readable configuration

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -126,10 +126,6 @@ public class ConnectionService {
             TokenFilter tokenFilter = new TokenFilter();
             StandardTokens.addStandardTokens(tokenFilter, user);
 
-            // Add custom attribute tokens
-            Map<String, String> attrs = user.getAttributes();
-            StandardTokens.addAttributeTokens(tokenFilter, attrs);
-
             // Produce connections for each readable configuration
             Map<String, Connection> connections = new HashMap<String, Connection>();
             while (results.hasMore()) {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -36,6 +36,7 @@ import org.apache.guacamole.auth.ldap.EscapingService;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
+//import org.apache.guacamole.auth.ldap.user.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.simple.SimpleConnection;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
@@ -125,6 +126,10 @@ public class ConnectionService {
             // Build token filter containing credential tokens
             TokenFilter tokenFilter = new TokenFilter();
             StandardTokens.addStandardTokens(tokenFilter, user);
+
+            // Add custom attribute tokens
+            Map<String, String> attrs = ( (org.apache.guacamole.auth.ldap.user.AuthenticatedUser) user).getAttributes();
+            StandardTokens.addAttributeTokens(tokenFilter, attrs);
 
             // Produce connections for each readable configuration
             Map<String, Connection> connections = new HashMap<String, Connection>();
@@ -295,4 +300,3 @@ public class ConnectionService {
     }
 
 }
-

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
@@ -71,49 +71,6 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
         this.attributes = attributes;
     }
 
-    /**
-     * Add the Map of attributes to the current set, without completely
-     * replacing the existing set.  However, if duplicate keys exist the new
-     * values will replace any existing ones.
-     *
-     * @param attributes
-     *     A Map of attributes to add to the existing attributes, without
-     *     completely overwriting them.
-     */
-    public void addAttributes(Map<String, String> attributes) {
-        this.attributes.putAll(attributes);
-    }
-
-    /**
-     * Retrieve a single attribute value from the map of arbitrary attributes
-     * stored in this AuthenticatedUser object.
-     *
-     * @param key
-     *     The key of the attribute to retrieve.
-     *
-     * @return
-     *     The value of the attribute with the specified key.
-     */
-    public String getAttribute(String key) {
-        return attributes.get(key);
-    }
-
-    /**
-     * Set the attribute of the given key to the given value, either adding
-     * a new value if the specified key does not exist, or replacing an existing
-     * value.
-     *
-     * @param key
-     *     The key name of the attribute to set (or overwrite, if it
-     *     already exists).
-     *
-     * @param value
-     *     The value of the attribute to set or overwrite.
-     */
-    public void setAttribute(String key, String value) {
-        attributes.put(key, value);
-    }
-
     @Override
     public AuthenticationProvider getAuthenticationProvider() {
         return authProvider;

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
@@ -20,8 +20,8 @@
 package org.apache.guacamole.auth.ldap.user;
 
 import com.google.inject.Inject;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
 import org.apache.guacamole.net.auth.Attributes;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
@@ -31,8 +31,7 @@ import org.apache.guacamole.net.auth.Credentials;
  * An LDAP-specific implementation of AuthenticatedUser, associating a
  * particular set of credentials with the LDAP authentication provider.
  */
-public class AuthenticatedUser extends AbstractAuthenticatedUser
-            implements Attributes {
+public class AuthenticatedUser extends AbstractAuthenticatedUser {
 
     /**
      * Reference to the authentication provider associated with this
@@ -69,6 +68,7 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser
      *     The Map of arbitrary attributes associated with this
      *     AuthenticatedUser object.
      */
+    @Override
     public Map<String, String> getAttributes() {
         return attributes;
     }
@@ -79,6 +79,7 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser
      * @param attributes
      *      A map of attribute key/value pairs to add to this AuthenticatedUser.
      */
+    @Override
     public void setAttributes(Map<String, String> attributes) {
         this.attributes = attributes;
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
@@ -61,24 +61,11 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
         setIdentifier(credentials.getUsername());
     }
 
-    /**
-     * Get a map of attributes associated with this AuthenticatedUser.
-     *
-     * @return
-     *     The Map of arbitrary attributes associated with this
-     *     AuthenticatedUser object.
-     */
     @Override
     public Map<String, String> getAttributes() {
         return attributes;
     }
 
-    /**
-     * Sets a map of attributes associated with this AuthenticatedUser.
-     *
-     * @param attributes
-     *      A map of attribute key/value pairs to add to this AuthenticatedUser.
-     */
     @Override
     public void setAttributes(Map<String, String> attributes) {
         this.attributes = attributes;

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
@@ -20,7 +20,10 @@
 package org.apache.guacamole.auth.ldap.user;
 
 import com.google.inject.Inject;
+import java.util.Map;
+import java.util.HashMap;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
+import org.apache.guacamole.net.auth.Attributes;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 
@@ -28,7 +31,8 @@ import org.apache.guacamole.net.auth.Credentials;
  * An LDAP-specific implementation of AuthenticatedUser, associating a
  * particular set of credentials with the LDAP authentication provider.
  */
-public class AuthenticatedUser extends AbstractAuthenticatedUser {
+public class AuthenticatedUser extends AbstractAuthenticatedUser
+            implements Attributes {
 
     /**
      * Reference to the authentication provider associated with this
@@ -43,6 +47,11 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
     private Credentials credentials;
 
     /**
+     * Arbitrary attributes associated with this AuthenticatedUser object.
+     */
+    private Map<String, String> attributes = new HashMap<String, String>();
+
+    /**
      * Initializes this AuthenticatedUser using the given credentials.
      *
      * @param credentials
@@ -51,6 +60,70 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
     public void init(Credentials credentials) {
         this.credentials = credentials;
         setIdentifier(credentials.getUsername());
+    }
+
+    /**
+     * Get a map of attributes associated with this AuthenticatedUser.
+     *
+     * @return
+     *     The Map of arbitrary attributes associated with this
+     *     AuthenticatedUser object.
+     */
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    /**
+     * Sets a map of attributes associated with this AuthenticatedUser.
+     *
+     * @param attributes
+     *      A map of attribute key/value pairs to add to this AuthenticatedUser.
+     */
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+
+    /**
+     * Add the Map of attributes to the current set, without completely
+     * replacing the existing set.  However, if duplicate keys exist the new
+     * values will replace any existing ones.
+     *
+     * @param attributes
+     *     A Map of attributes to add to the existing attributes, without
+     *     completely overwriting them.
+     */
+    public void addAttributes(Map<String, String> attributes) {
+        this.attributes.putAll(attributes);
+    }
+
+    /**
+     * Retrieve a single attribute value from the map of arbitrary attributes
+     * stored in this AuthenticatedUser object.
+     *
+     * @param key
+     *     The key of the attribute to retrieve.
+     *
+     * @return
+     *     The value of the attribute with the specified key.
+     */
+    public String getAttribute(String key) {
+        return attributes.get(key);
+    }
+
+    /**
+     * Set the attribute of the given key to the given value, either adding
+     * a new value if the specified key does not exist, or replacing an existing
+     * value.
+     *
+     * @param key
+     *     The key name of the attribute to set (or overwrite, if it
+     *     already exists).
+     *
+     * @param value
+     *     The value of the attribute to set or overwrite.
+     */
+    public void setAttribute(String key, String value) {
+        attributes.put(key, value);
     }
 
     @Override

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
@@ -23,7 +23,6 @@ import com.google.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
-import org.apache.guacamole.net.auth.Attributes;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.net.auth;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -39,6 +40,14 @@ public abstract class AbstractAuthenticatedUser extends AbstractIdentifiable
     @Override
     public void invalidate() {
         // Nothing to invalidate
+    }
+
+    public Map<String, String> getAttributes() {
+        return Collections.<String, String>emptyMap();
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        //do nothing
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractAuthenticatedUser.java
@@ -42,10 +42,12 @@ public abstract class AbstractAuthenticatedUser extends AbstractIdentifiable
         // Nothing to invalidate
     }
 
+    @Override
     public Map<String, String> getAttributes() {
         return Collections.<String, String>emptyMap();
     }
 
+    @Override
     public void setAttributes(Map<String, String> attributes) {
         //do nothing
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AuthenticatedUser.java
@@ -25,7 +25,7 @@ import java.util.Set;
  * A user of the Guacamole web application who has been authenticated by an
  * AuthenticationProvider.
  */
-public interface AuthenticatedUser extends Identifiable {
+public interface AuthenticatedUser extends Identifiable, Attributes {
 
     /**
      * The identifier reserved for representing a user that has authenticated

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -22,7 +22,7 @@ package org.apache.guacamole.net.auth;
 import java.io.Serializable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.util.Map;
+
 
 /**
  * Simple arbitrary set of credentials, including a username/password pair,
@@ -71,29 +71,6 @@ public class Credentials implements Serializable {
      * The HttpSession carrying additional credentials, if any.
      */
     private transient HttpSession session;
-
-    /**
-     * Arbitrary LDAP attributes specified in guacamole.properties
-     */
-     private Map<String, String> ldapAttrs;
-
-     /**
-      * Returns the lDAP attributes associated with this set of credentials.
-      * @return The LDAP attributes Map associated with this set of credentials,
-      *         or  null if no LDAP Attributes have been set.
-      */
-     public Map<String, String> getLDAPAttributes() {
-         return ldapAttrs;
-     }
-
-     /**
-      * Sets the LDAP attributes associated with this set of credentials.
-      * @param attributes The LDAP attributes to associate with this set of
-      *                   credentials.
-      */
-     public void setLDAPAttributes(Map<String, String> attributes) {
-         this.ldapAttrs = attributes;
-     }
 
     /**
      * Returns the password associated with this set of credentials.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -22,7 +22,7 @@ package org.apache.guacamole.net.auth;
 import java.io.Serializable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-
+import java.util.Map;
 
 /**
  * Simple arbitrary set of credentials, including a username/password pair,
@@ -71,6 +71,29 @@ public class Credentials implements Serializable {
      * The HttpSession carrying additional credentials, if any.
      */
     private transient HttpSession session;
+
+    /**
+     * Arbitrary LDAP attributes specified in guacamole.properties
+     */
+     private Map<String, String> ldapAttrs;
+
+     /**
+      * Returns the lDAP attributes associated with this set of credentials.
+      * @return The LDAP attributes Map associated with this set of credentials,
+      *         or  null if no LDAP Attributes have been set.
+      */
+     public Map<String, String> getLDAPAttributes() {
+         return ldapAttrs;
+     }
+
+     /**
+      * Sets the LDAP attributes associated with this set of credentials.
+      * @param attributes The LDAP attributes to associate with this set of
+      *                   credentials.
+      */
+     public void setLDAPAttributes(Map<String, String> attributes) {
+         this.ldapAttrs = attributes;
+     }
 
     /**
      * Returns the password associated with this set of credentials.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
+
 /**
  * Utility class which provides access to standardized token names, as well as
  * facilities for generating those tokens from common objects.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -150,10 +150,11 @@ public class StandardTokens {
      * Adds tokens which are standardized by guacamole-ext to the given
      * TokenFilter using the values from the given AuthenticatedUser object,
      * including any associated credentials. These standardized tokens include
-     * the current username (GUAC_USERNAME), password (GUAC_PASSWORD), and the
-     * server date and time (GUAC_DATE and GUAC_TIME respectively). If either
-     * the username or password are not set within the given user or their
-     * provided credentials, the corresponding token(s) will remain unset.
+     * the current username (GUAC_USERNAME), password (GUAC_PASSWORD), the
+     * server date and time (GUAC_DATE and GUAC_TIME respectively), and custom
+     * user attributes. If either the username or password are not set within
+     * the given user or their provided credentials, the corresponding token(s)
+     * will remain unset.
      *
      * @param filter
      *     The TokenFilter to add standard tokens to.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -171,6 +171,8 @@ public class StandardTokens {
         // Add tokens specific to credentials
         addStandardTokens(filter, user.getCredentials());
 
+        // Add custom attribute tokens
+        addAttributeTokens(filter, user.getAttributes());
     }
 
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -25,8 +25,6 @@ import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utility class which provides access to standardized token names, as well as
@@ -79,11 +77,10 @@ public class StandardTokens {
     private static final String TIME_FORMAT = "HHmmss";
 
     /**
-     * Standard prefix to append to beginning of the name of each custom
-    *  LDAP attribute before adding attributes as tokens.
+     * The prefix of the arbitrary attribute tokens.
      */
-    private static final String LDAP_ATTR_PREFIX = "USER_ATTR:";
-
+    public static final String ATTR_TOKEN_PREFIX = "GUAC_ATTR:";
+    
     /**
      * This utility class should not be instantiated.
      */
@@ -144,15 +141,6 @@ public class StandardTokens {
         if (address != null)
             filter.setToken(CLIENT_ADDRESS_TOKEN, address);
 
-        // Add each custom client LDAP attribute token
-        Map<String, String> ldapAttrs = credentials.getLDAPAttributes();
-        if (ldapAttrs != null) {
-            for (Map.Entry<String, String> attr : ldapAttrs.entrySet()) {
-                String tokenName = LDAP_ATTR_PREFIX + attr.getKey().toUpperCase();
-                filter.setToken(tokenName, attr.getValue());
-            }
-        }
-
         // Add any tokens which do not require credentials
         addStandardTokens(filter);
 
@@ -182,6 +170,31 @@ public class StandardTokens {
 
         // Add tokens specific to credentials
         addStandardTokens(filter, user.getCredentials());
+
+    }
+
+    /**
+     * Add attribute tokens to StandardTokens.  These are arbitrary
+     * key/value pairs that may be configured by the various authentication
+     * extensions.
+     *
+     * @param filter
+     *     The TokenFilter to add attributes tokens to.
+     *
+     * @param attributes
+     *     The map of key/value pairs to add tokens for.
+     */
+    public static void addAttributeTokens(TokenFilter filter,
+            Map<String, String> attributes) {
+
+        if (attributes != null) {
+            for (Map.Entry entry : attributes.entrySet()) {
+                String key = entry.getKey().toString();
+                String tokenName = ATTR_TOKEN_PREFIX + key.toUpperCase();
+                String tokenValue = entry.getValue().toString();
+                filter.setToken(tokenName, tokenValue);
+            }
+        }
 
     }
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -23,6 +23,10 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Credentials;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class which provides access to standardized token names, as well as
@@ -73,6 +77,12 @@ public class StandardTokens {
      * be compatible with Java's SimpleDateFormat.
      */
     private static final String TIME_FORMAT = "HHmmss";
+
+    /**
+     * Standard prefix to append to beginning of the name of each custom
+    *  LDAP attribute before adding attributes as tokens.
+     */
+    private static final String LDAP_ATTR_PREFIX = "USER_ATTR:";
 
     /**
      * This utility class should not be instantiated.
@@ -133,6 +143,15 @@ public class StandardTokens {
         String address = credentials.getRemoteAddress();
         if (address != null)
             filter.setToken(CLIENT_ADDRESS_TOKEN, address);
+
+        // Add each custom client LDAP attribute token
+        Map<String, String> ldapAttrs = credentials.getLDAPAttributes();
+        if (ldapAttrs != null) {
+            for (Map.Entry<String, String> attr : ldapAttrs.entrySet()) {
+                String tokenName = LDAP_ATTR_PREFIX + attr.getKey().toUpperCase();
+                filter.setToken(tokenName, attr.getValue());
+            }
+        }
 
         // Add any tokens which do not require credentials
         addStandardTokens(filter);

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -182,7 +182,7 @@ public class StandardTokens {
      * extensions.
      *
      * @param filter
-     *     The TokenFilter to add attributes tokens to.
+     *     The TokenFilter to add attribute tokens to.
      *
      * @param attributes
      *     The map of key/value pairs to add tokens for.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -21,11 +21,10 @@ package org.apache.guacamole.token;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.auth.Credentials;
 import java.util.Map;
 import java.util.Set;
-
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+import org.apache.guacamole.net.auth.Credentials;
 /**
  * Utility class which provides access to standardized token names, as well as
  * facilities for generating those tokens from common objects.
@@ -80,7 +79,7 @@ public class StandardTokens {
      * The prefix of the arbitrary attribute tokens.
      */
     public static final String ATTR_TOKEN_PREFIX = "GUAC_ATTR:";
-    
+
     /**
      * This utility class should not be instantiated.
      */

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/StandardTokens.java
@@ -79,7 +79,7 @@ public class StandardTokens {
     /**
      * The prefix of the arbitrary attribute tokens.
      */
-    public static final String ATTR_TOKEN_PREFIX = "GUAC_ATTR:";
+    public static final String ATTR_TOKEN_PREFIX = "GUAC_ATTR_";
 
     /**
      * This utility class should not be instantiated.


### PR DESCRIPTION
1. Add property for reading list of LDAP attributes in guacamole.properties.
2. Add LDAP attribute name and attribute value into credentials object.
3. Add attribute name and attribute value into Tokens from credentials object.