### PR TITLE
GUACAMOLE-146: Allow webapp context to be specified in Docker

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -329,7 +329,7 @@ END
 start_guacamole() {
 
     # Install webapp
-    ln -sf /opt/guacamole/guacamole.war /usr/local/tomcat/webapps/
+    ln -sf /opt/guacamole/guacamole.war /usr/local/tomcat/webapps/${WEBAPP_CONTEXT:-guacamole}.war
 
     # Start tomcat
     cd /usr/local/tomcat


### PR DESCRIPTION
Simple change that allows the application context to be specified for Guacamole within the Docker image, or defaults to guacamole if not overridden.

Pretty simple, but I believe it works and is reasonably safe??