### PR TITLE
GUACAMOLE-470: Provide predefined values for "color-scheme" parameter.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/form/TextField.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/form/TextField.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.form;
 
+import java.util.Collection;
+
 /**
  * Represents a basic text field. The field may generally contain any data, but
  * may not contain multiple lines.
@@ -33,6 +35,21 @@ public class TextField extends Field {
      */
     public TextField(String name) {
         super(name, Field.Type.TEXT);
+    }
+
+    /**
+     * Creates a new TextField with the given name and possible values. As a
+     * text field may contain any data by definition, any provided options are
+     * simply known-good values.
+     *
+     * @param name
+     *     The unique name to associate with this field.
+     *
+     * @param options
+     *     A set of known legal options for this field.
+     */
+    public TextField(String name, Collection<String> options) {
+        super(name, Field.Type.TEXT, options);
     }
 
     /**

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
@@ -43,7 +43,8 @@
             "fields" : [
                 {
                     "name"  : "color-scheme",
-                    "type"  : "TEXT"
+                    "type"  : "ENUM",
+                    "options" : [ "", "black-white", "gray-black", "green-black", "white-black" ]
                 },
                 {
                     "name"  : "font-name",

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
@@ -43,7 +43,7 @@
             "fields" : [
                 {
                     "name"  : "color-scheme",
-                    "type"  : "ENUM",
+                    "type"  : "TEXT",
                     "options" : [ "", "black-white", "gray-black", "green-black", "white-black" ]
                 },
                 {

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
@@ -39,7 +39,7 @@
             "fields" : [
                 {
                     "name"  : "color-scheme",
-                    "type"  : "ENUM",
+                    "type"  : "TEXT",
                     "options" : [ "", "black-white", "gray-black", "green-black", "white-black" ]
                 },
                 {

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
@@ -39,7 +39,8 @@
             "fields" : [
                 {
                     "name"  : "color-scheme",
-                    "type"  : "TEXT"
+                    "type"  : "ENUM",
+                    "options" : [ "", "black-white", "gray-black", "green-black", "white-black" ]
                 },
                 {
                     "name"  : "font-name",

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -386,6 +386,14 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Polyfill for <datalist> element support -->
+        <dependency>
+            <groupId>org.webjars.bowergithub.mfranzke</groupId>
+            <artifactId>datalist-polyfill</artifactId>
+            <version>1.14.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Jetty 8 servlet API (websocket)  -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -388,7 +388,7 @@
 
         <!-- Polyfill for <datalist> element support -->
         <dependency>
-            <groupId>org.webjars.bowergithub.mfranzke</groupId>
+            <groupId>org.webjars.npm</groupId>
             <artifactId>datalist-polyfill</artifactId>
             <version>1.14.0</version>
             <scope>runtime</scope>

--- a/guacamole/src/licenses/LICENSE
+++ b/guacamole/src/licenses/LICENSE
@@ -390,6 +390,15 @@ Carlito (http://code.google.com/p/chromium/issues/detail?id=280557)
         SIL Open Font (bundled/carlito/LICENSE)
 
 
+datalist-polyfill (https://github.com/mfranzke/datalist-polyfill)
+-----------------------------------------------------------------
+
+    Version: 1.14.0
+    From: 'Maximilian Franzke' (https://github.com/mfranzke)
+    License(s):
+        MIT (bundled/datalist-polyfill-1.14.0/LICENSE)
+
+
 FileSaver.js (https://github.com/eligrey/FileSaver.js)
 ------------------------------------------------------
 

--- a/guacamole/src/licenses/bundled/datalist-polyfill-1.14.0/LICENSE
+++ b/guacamole/src/licenses/bundled/datalist-polyfill-1.14.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/guacamole/src/main/webapp/app/form/controllers/selectFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/selectFieldController.js
@@ -24,44 +24,10 @@
 angular.module('form').controller('selectFieldController', ['$scope', '$injector',
     function selectFieldController($scope, $injector) {
 
-    // Required services
-    var translationStringService = $injector.get('translationStringService');
-
     // Interpret undefined/null as empty string
     $scope.$watch('model', function setModel(model) {
         if (!model && model !== '')
             $scope.model = '';
     });
-
-    /**
-     * Produces the translation string for the given field option
-     * value. The translation string will be of the form:
-     *
-     * <code>NAMESPACE.FIELD_OPTION_NAME_VALUE<code>
-     *
-     * where <code>NAMESPACE</code> is the namespace provided to the
-     * directive, <code>NAME</code> is the field name transformed
-     * via translationStringService.canonicalize(), and
-     * <code>VALUE</code> is the option value transformed via
-     * translationStringService.canonicalize()
-     *
-     * @param {String} value
-     *     The name of the option value.
-     *
-     * @returns {String}
-     *     The translation string which produces the translated name of the
-     *     value specified.
-     */
-    $scope.getFieldOption = function getFieldOption(value) {
-
-        // If no field, or no value, then no corresponding translation string
-        if (!$scope.field || !$scope.field.name || !value)
-            return '';
-
-        return translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE')
-                + '.FIELD_OPTION_' + translationStringService.canonicalize($scope.field.name)
-                + '_'              + translationStringService.canonicalize(value || 'EMPTY');
-
-    };
 
 }]);

--- a/guacamole/src/main/webapp/app/form/controllers/textFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/textFieldController.js
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * Controller for text fields.
+ */
+angular.module('form').controller('textFieldController', ['$scope', '$injector',
+    function textFieldController($scope, $injector) {
+
+    /**
+     * The ID of the datalist element that should be associated with the text
+     * field, providing a set of known-good values. If no such values are
+     * defined, this will be null.
+     *
+     * @type String
+     */
+    $scope.dataListId = null;
+
+    // Generate unique ID for datalist, if applicable
+    if ($scope.field.options && $scope.field.options.length)
+        $scope.dataListId = $scope.field.name + '-datalist';
+
+}]);

--- a/guacamole/src/main/webapp/app/form/directives/formField.js
+++ b/guacamole/src/main/webapp/app/form/directives/formField.js
@@ -98,6 +98,37 @@ angular.module('form').directive('guacFormField', [function formField() {
             };
 
             /**
+             * Produces the translation string for the given field option
+             * value. The translation string will be of the form:
+             *
+             * <code>NAMESPACE.FIELD_OPTION_NAME_VALUE<code>
+             *
+             * where <code>NAMESPACE</code> is the namespace provided to the
+             * directive, <code>NAME</code> is the field name transformed
+             * via translationStringService.canonicalize(), and
+             * <code>VALUE</code> is the option value transformed via
+             * translationStringService.canonicalize()
+             *
+             * @param {String} value
+             *     The name of the option value.
+             *
+             * @returns {String}
+             *     The translation string which produces the translated name of the
+             *     value specified.
+             */
+            $scope.getFieldOption = function getFieldOption(value) {
+
+                // If no field, or no value, then no corresponding translation string
+                if (!$scope.field || !$scope.field.name || !value)
+                    return '';
+
+                return translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE')
+                        + '.FIELD_OPTION_' + translationStringService.canonicalize($scope.field.name)
+                        + '_'              + translationStringService.canonicalize(value || 'EMPTY');
+
+            };
+
+            /**
              * Returns whether the current field should be displayed.
              *
              * @returns {Boolean}

--- a/guacamole/src/main/webapp/app/form/services/formService.js
+++ b/guacamole/src/main/webapp/app/form/services/formService.js
@@ -44,6 +44,8 @@ angular.module('form').provider('formService', function formServiceProvider() {
          * @type FieldType
          */
         'TEXT' : {
+            module      : 'form',
+            controller  : 'textFieldController',
             templateUrl : 'app/form/templates/textField.html'
         },
 

--- a/guacamole/src/main/webapp/app/form/templates/textField.html
+++ b/guacamole/src/main/webapp/app/form/templates/textField.html
@@ -1,1 +1,7 @@
-<input type="text" ng-model="model" autocorrect="off" autocapitalize="off"/>
+<div class="text-field">
+    <input type="text" ng-model="model" autocorrect="off" autocapitalize="off" ng-attr-list="{{ dataListId }}"/>
+    <datalist ng-if="dataListId" id="{{ dataListId }}">
+        <option ng-repeat="option in field.options | orderBy: option"
+                value="{{ option }}">{{ getFieldOption(option) | translate }}</option>
+    </datalist>
+</div>

--- a/guacamole/src/main/webapp/index.html
+++ b/guacamole/src/main/webapp/index.html
@@ -71,8 +71,9 @@
         <script type="text/javascript" src="webjars/angular-translate-interpolation-messageformat/2.16.0/angular-translate-interpolation-messageformat.min.js"></script>
         <script type="text/javascript" src="webjars/angular-translate-loader-static-files/2.16.0/angular-translate-loader-static-files.min.js"></script>
 
-        <!-- Polyfills for Blob and the FileSaver API -->
+        <!-- Polyfills for the "datalist" element, Blob and the FileSaver API -->
         <script type="text/javascript" src="webjars/blob-polyfill/1.0.20150320/Blob.js"></script>
+        <script type="text/javascript" src="webjars/datalist-polyfill/1.14.0/datalist-polyfill.min.js"></script>
         <script type="text/javascript" src="webjars/filesaver/1.3.3/FileSaver.min.js"></script>
 
         <!-- Allow arbitrary ordering of Angular module creation and retrieval -->

--- a/guacamole/src/main/webapp/translations/de.json
+++ b/guacamole/src/main/webapp/translations/de.json
@@ -378,6 +378,12 @@
         "FIELD_HEADER_PRIVATE_KEY" : "Privater Schlüssel:",
         "FIELD_HEADER_READ_ONLY"   : "Nur-Lesen:",
 
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Schwarz auf Weiß",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grau auf Schwarz",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grün auf Schwarz",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Weiß auf Schwarz",
+
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -415,6 +421,12 @@
         "FIELD_HEADER_PASSWORD_REGEX" : "Reguläre Passwortersetzungen:",
         "FIELD_HEADER_PORT"           : "Port:",
         "FIELD_HEADER_READ_ONLY"      : "Nur-Lesen:",
+
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Schwarz auf Weiß",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grau auf Schwarz",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grün auf Schwarz",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Weiß auf Schwarz",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -455,6 +455,12 @@
         "FIELD_OPTION_BACKSPACE_8"     : "Backspace (Ctrl-H)",
         "FIELD_OPTION_BACKSPACE_127"   : "Delete (Ctrl-?)",
 
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Black on white",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gray on black",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Green on black",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "White on black",
+
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -518,6 +524,12 @@
         "FIELD_OPTION_BACKSPACE_EMPTY" : "",
         "FIELD_OPTION_BACKSPACE_8"     : "Backspace (Ctrl-H)",
         "FIELD_OPTION_BACKSPACE_127"   : "Delete (Ctrl-?)",
+
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Black on white",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gray on black",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Green on black",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "White on black",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/es.json
+++ b/guacamole/src/main/webapp/translations/es.json
@@ -435,6 +435,12 @@
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Nombre script escritura:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Ruta script escritura:",
 
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Negro sobre blanco",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sobre negro",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Verde sobre negro",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanco sobre negro",
+
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -480,6 +486,12 @@
         "FIELD_HEADER_RECORDING_PATH" : "Ruta grabación:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Nombre script escritura:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Ruta script escritura:",
+
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Negro sobre blanco",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sobre negro",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Verde sobre negro",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanco sobre negro",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/fr.json
+++ b/guacamole/src/main/webapp/translations/fr.json
@@ -381,6 +381,12 @@
         "FIELD_HEADER_PRIVATE_KEY" : "Clé privée:",
         "FIELD_HEADER_READ_ONLY"   : "Lecture seule:",
 
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Noir sur blanc",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sur noir",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Vert sur noir",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanc sur noir",
+
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -418,6 +424,12 @@
         "FIELD_HEADER_PASSWORD_REGEX" : "Expression régulière Mot de passe:",
         "FIELD_HEADER_PORT"           : "Port:",
         "FIELD_HEADER_READ_ONLY"      : "Lecture seule:",
+
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Noir sur blanc",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Gris sur noir",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Vert sur noir",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Blanc sur noir",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/nl.json
+++ b/guacamole/src/main/webapp/translations/nl.json
@@ -397,6 +397,12 @@
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript naam:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript map:",
 
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Zwart op wit",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grijs op zwart",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Groen op zwart",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Wit op zwart",
+
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -442,6 +448,12 @@
         "FIELD_HEADER_RECORDING_PATH" : "Opname map:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript naam:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript map:",
+
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Zwart op wit",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grijs op zwart",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Groen op zwart",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Wit op zwart",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",

--- a/guacamole/src/main/webapp/translations/no.json
+++ b/guacamole/src/main/webapp/translations/no.json
@@ -379,6 +379,12 @@
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript navn:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript sti:",
 
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Svart på hvit",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grå på svart",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grønn på svart",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Hvit på svart",
+
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",
         "FIELD_OPTION_FONT_SIZE_10"    : "10",
@@ -423,6 +429,12 @@
         "FIELD_HEADER_RECORDING_PATH" : "Sti til opptak:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript navn:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript sti:",
+
+        "FIELD_OPTION_COLOR_SCHEME_BLACK_WHITE" : "Svart på hvit",
+        "FIELD_OPTION_COLOR_SCHEME_EMPTY"       : "",
+        "FIELD_OPTION_COLOR_SCHEME_GRAY_BLACK"  : "Grå på svart",
+        "FIELD_OPTION_COLOR_SCHEME_GREEN_BLACK" : "Grønn på svart",
+        "FIELD_OPTION_COLOR_SCHEME_WHITE_BLACK" : "Hvit på svart",
 
         "FIELD_OPTION_FONT_SIZE_8"     : "8",
         "FIELD_OPTION_FONT_SIZE_9"     : "9",


### PR DESCRIPTION
This change defines option semantics for `TEXT` fields using the [`<datalist>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist), leveraging this to provide the same predefined option values for the `color-scheme` parameter which were removed via #289 and #296.

Browsers vary in how exactly the field is rendered, but generally provide a text field with autocomplete and a drop-down menu of choices:

![color-scheme-field-en](https://user-images.githubusercontent.com/4632905/41323162-b713cf7e-6e61-11e8-9620-86448cd56352.png) ![color-scheme-field-zh](https://user-images.githubusercontent.com/4632905/41323213-0558bf50-6e62-11e8-80e7-c781fd49a83b.png)


As not all browsers fully support `<datalist>` (with Safari lacking support entirely), this change also adds https://github.com/mfranzke/datalist-polyfill as a dependency, which is the polyfill recommended by the MDN documentation for `<datalist>`.