### PR TITLE
GUACAMOLE-585: getFieldOption should return EMPTY when value is not present

### DIFF
--- a/guacamole/src/main/webapp/app/form/directives/formField.js
+++ b/guacamole/src/main/webapp/app/form/directives/formField.js
@@ -119,7 +119,7 @@ angular.module('form').directive('guacFormField', [function formField() {
             $scope.getFieldOption = function getFieldOption(value) {
 
                 // If no field, or no value, then no corresponding translation string
-                if (!$scope.field || !$scope.field.name || !value)
+                if (!$scope.field || !$scope.field.name)
                     return '';
 
                 return translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE')


### PR DESCRIPTION
This resolves a dead code issues found by Coverity and also restores the proper functionality for retrieving field options - if the value is not present or empty, the `getFieldOption()` method should have the translation service return the _EMPTY option value rather than bailing out with a null return value.