### PR TITLE
GUACAMOLE-220: Display readable connections only by default within permission editor.

### DIFF
--- a/guacamole/src/main/webapp/app/index/styles/headers.css
+++ b/guacamole/src/main/webapp/app/index/styles/headers.css
@@ -74,6 +74,10 @@ h2 {
 
 }
 
+.header.tabbed {
+    margin-bottom: 0;
+}
+
 .header ~ * .header,
 .header ~ .header {
     margin-top: 1em;

--- a/guacamole/src/main/webapp/app/manage/directives/connectionPermissionEditor.js
+++ b/guacamole/src/main/webapp/app/manage/directives/connectionPermissionEditor.js
@@ -289,9 +289,12 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
                     // their parents
                     child = copyReadable(child, flags);
 
-                    // Include child only if they are explicitly readable or
-                    // they have explicitly readable descendants
-                    if ((child.children && child.children.length) || isReadable(child, flags))
+                    // Include child only if they are explicitly readable, they
+                    // have explicitly readable descendants, or their parent is
+                    // readable (and thus all children are relevant)
+                    if ((child.children && child.children.length)
+                            || isReadable(item, flags)
+                            || isReadable(child, flags))
                         children.push(child);
 
                 });

--- a/guacamole/src/main/webapp/app/manage/directives/connectionPermissionEditor.js
+++ b/guacamole/src/main/webapp/app/manage/directives/connectionPermissionEditor.js
@@ -110,11 +110,40 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
         var readableRootGroups = null;
 
         /**
-         * Whether the items displayed within the connection permission editor
-         * should be limited to those which had explicit READ permission at the
-         * time the editor was loaded.
+         * The name of the tab within the connection permission editor which
+         * displays readable connections only.
+         *
+         * @constant
+         * @type String
          */
-        $scope.displayReadableOnly = false;
+        var SELECTED_CONNECTIONS = 'SELECTED_CONNECTIONS';
+
+        /**
+         * The name of the tab within the connection permission editor which
+         * displays all connections, regardless of whether they are readable.
+         *
+         * @constant
+         * @type String
+         */
+        var ALL_CONNECTIONS = 'ALL_CONNECTIONS';
+
+        /**
+         * The names of all tabs which should be available within the
+         * connection permission editor, in display order.
+         *
+         * @type String[]
+         */
+        $scope.tabs = [
+            SELECTED_CONNECTIONS,
+            ALL_CONNECTIONS
+        ];
+
+        /**
+         * The name of the currently selected tab.
+         *
+         * @type String
+         */
+        $scope.currentTab = ALL_CONNECTIONS;
 
         /**
          * Array of all connection properties that are filterable.
@@ -145,7 +174,7 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
          *     root connection groups within those data sources.
          */
         $scope.getRootGroups = function getRootGroups() {
-            return $scope.displayReadableOnly ? readableRootGroups : allRootGroups;
+            return $scope.currentTab === SELECTED_CONNECTIONS ? readableRootGroups : allRootGroups;
         };
 
         /**
@@ -312,7 +341,7 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
 
                 // Display only readable connections by default if at least one
                 // readable connection exists
-                $scope.displayReadableOnly = !!readableRootGroups[$scope.dataSource].children.length;
+                $scope.currentTab = !!readableRootGroups[$scope.dataSource].children.length ? SELECTED_CONNECTIONS : ALL_CONNECTIONS;
 
             });
 

--- a/guacamole/src/main/webapp/app/manage/directives/connectionPermissionEditor.js
+++ b/guacamole/src/main/webapp/app/manage/directives/connectionPermissionEditor.js
@@ -111,12 +111,12 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
 
         /**
          * The name of the tab within the connection permission editor which
-         * displays readable connections only.
+         * displays currently selected (readable) connections only.
          *
          * @constant
          * @type String
          */
-        var SELECTED_CONNECTIONS = 'SELECTED_CONNECTIONS';
+        var CURRENT_CONNECTIONS = 'CURRENT_CONNECTIONS';
 
         /**
          * The name of the tab within the connection permission editor which
@@ -134,7 +134,7 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
          * @type String[]
          */
         $scope.tabs = [
-            SELECTED_CONNECTIONS,
+            CURRENT_CONNECTIONS,
             ALL_CONNECTIONS
         ];
 
@@ -174,7 +174,7 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
          *     root connection groups within those data sources.
          */
         $scope.getRootGroups = function getRootGroups() {
-            return $scope.currentTab === SELECTED_CONNECTIONS ? readableRootGroups : allRootGroups;
+            return $scope.currentTab === CURRENT_CONNECTIONS ? readableRootGroups : allRootGroups;
         };
 
         /**
@@ -344,7 +344,7 @@ angular.module('manage').directive('connectionPermissionEditor', ['$injector',
 
                 // Display only readable connections by default if at least one
                 // readable connection exists
-                $scope.currentTab = !!readableRootGroups[$scope.dataSource].children.length ? SELECTED_CONNECTIONS : ALL_CONNECTIONS;
+                $scope.currentTab = !!readableRootGroups[$scope.dataSource].children.length ? CURRENT_CONNECTIONS : ALL_CONNECTIONS;
 
             });
 

--- a/guacamole/src/main/webapp/app/manage/styles/manage-user.css
+++ b/guacamole/src/main/webapp/app/manage/styles/manage-user.css
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-.manage-user .username.header {
-    margin-bottom: 0;
-}
-
 .manage-user .page-tabs .page-list li.read-only a[href],
 .manage-user .page-tabs .page-list li.unlinked  a[href],
 .manage-user .page-tabs .page-list li.linked    a[href] {

--- a/guacamole/src/main/webapp/app/manage/templates/connectionPermissionEditor.html
+++ b/guacamole/src/main/webapp/app/manage/templates/connectionPermissionEditor.html
@@ -1,7 +1,10 @@
 <div class="connection-permissions">
     <div class="header">
         <h2>{{'MANAGE_USER.SECTION_HEADER_CONNECTIONS' | translate}}</h2>
-        <guac-group-list-filter connection-groups="rootGroups"
+        <div class="filter">
+            <label><input type="checkbox" ng-model="displayReadableOnly"> {{'MANAGE_USER.' | translate}}</label>
+        </div>
+        <guac-group-list-filter connection-groups="getRootGroups()"
             filtered-connection-groups="filteredRootGroups"
             placeholder="'MANAGE_USER.FIELD_PLACEHOLDER_FILTER' | translate"
             connection-properties="filteredConnectionProperties"

--- a/guacamole/src/main/webapp/app/manage/templates/connectionPermissionEditor.html
+++ b/guacamole/src/main/webapp/app/manage/templates/connectionPermissionEditor.html
@@ -1,15 +1,13 @@
 <div class="connection-permissions">
-    <div class="header">
+    <div class="header tabbed">
         <h2>{{'MANAGE_USER.SECTION_HEADER_CONNECTIONS' | translate}}</h2>
-        <div class="filter">
-            <label><input type="checkbox" ng-model="displayReadableOnly"> {{'MANAGE_USER.' | translate}}</label>
-        </div>
         <guac-group-list-filter connection-groups="getRootGroups()"
             filtered-connection-groups="filteredRootGroups"
             placeholder="'MANAGE_USER.FIELD_PLACEHOLDER_FILTER' | translate"
             connection-properties="filteredConnectionProperties"
             connection-group-properties="filteredConnectionGroupProperties"></guac-group-list-filter>
     </div>
+    <guac-section-tabs namespace="MANAGE_USER" current="currentTab" tabs="tabs"></guac-section-tabs>
     <div class="section">
         <guac-group-list
             context="groupListContext"

--- a/guacamole/src/main/webapp/app/manage/templates/manageUser.html
+++ b/guacamole/src/main/webapp/app/manage/templates/manageUser.html
@@ -2,7 +2,7 @@
 <div class="manage-user view" ng-class="{loading: !isLoaded()}">
 
     <!-- User header and data source tabs -->
-    <div class="username header">
+    <div class="header tabbed">
         <h2>{{'MANAGE_USER.SECTION_HEADER_EDIT_USER' | translate}}</h2>
         <guac-user-menu></guac-user-menu>
     </div>

--- a/guacamole/src/main/webapp/app/navigation/directives/guacSectionTabs.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacSectionTabs.js
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Directive which displays a set of tabs dividing a section of a page into
+ * logical subsections or views. The currently selected tab is communicated
+ * through assignment to the variable bound to the <code>current</code>
+ * attribute. No navigation occurs as a result of selecting a tab.
+ */
+angular.module('navigation').directive('guacSectionTabs', ['$injector',
+    function guacSectionTabs($injector) {
+
+    // Required services
+    var translationStringService = $injector.get('translationStringService');
+
+    var directive = {
+
+        restrict    : 'E',
+        replace     : true,
+        templateUrl : 'app/navigation/templates/guacSectionTabs.html',
+
+        scope : {
+
+            /**
+             * The translation namespace to use when producing translation
+             * strings for each tab. Tab translation strings will be of the
+             * form:
+             *
+             * <code>NAMESPACE.SECTION_HEADER_NAME<code>
+             *
+             * where <code>NAMESPACE</code> is the namespace provided to this
+             * attribute and <code>NAME</code> is one of the names within the
+             * array provided to the <code>tabs</code> attribute and
+             * transformed via translationStringService.canonicalize().
+             */
+            namespace : '@',
+
+            /**
+             * The name of the currently selected tab. This name MUST be one of
+             * the names present in the array given via the <code>tabs</code>
+             * attribute. This directive will not automatically choose an
+             * initially selected tab, and a default value should be manually
+             * assigned to <code>current</code> to ensure a tab is initially
+             * selected.
+             *
+             * @type String
+             */
+            current : '=',
+
+            /**
+             * The unique names of all tabs which should be made available, in
+             * display order. These names will be assigned to the variable
+             * bound to the <code>current</code> attribute when the current
+             * tab changes.
+             *
+             * @type String[]
+             */
+            tabs : '='
+
+        }
+
+    };
+
+    directive.controller = ['$scope', function dataSourceTabsController($scope) {
+
+        /**
+         * Produces the translation string for the section header representing
+         * the tab having the given name. The translation string will be of the
+         * form:
+         *
+         * <code>NAMESPACE.SECTION_HEADER_NAME<code>
+         *
+         * where <code>NAMESPACE</code> is the namespace provided to the
+         * directive and <code>NAME</code> is the given name transformed
+         * via translationStringService.canonicalize().
+         *
+         * @param {String} name
+         *     The name of the tab.
+         *
+         * @returns {String}
+         *     The translation string which produces the translated header
+         *     of the tab having the given name.
+         */
+        $scope.getSectionHeader = function getSectionHeader(name) {
+
+            // If no name, then no header
+            if (!name)
+                return '';
+
+            return translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE')
+                    + '.SECTION_HEADER_' + translationStringService.canonicalize(name);
+
+        };
+
+        /**
+         * Selects the tab having the given name. The name of the currently
+         * selected tab will be communicated outside the directive through
+         * $scope.current.
+         *
+         * @param {String} name
+         *     The name of the tab to select.
+         */
+        $scope.selectTab = function selectTab(name) {
+            $scope.current = name;
+        };
+
+        /**
+         * Returns whether the tab having the given name is currently
+         * selected. A tab is currently selected if its name is stored within
+         * $scope.current, as assigned externally or by selectTab().
+         *
+         * @param {String} name
+         *     The name of the tab to test.
+         *
+         * @returns {Boolean}
+         *     true if the tab having the given name is currently selected,
+         *     false otherwise.
+         */
+        $scope.isSelected = function isSelected(name) {
+            return $scope.current === name;
+        };
+
+    }];
+
+    return directive;
+
+}]);

--- a/guacamole/src/main/webapp/app/navigation/styles/tabs.css
+++ b/guacamole/src/main/webapp/app/navigation/styles/tabs.css
@@ -17,23 +17,27 @@
  * under the License.
  */
 
-.page-tabs .page-list ul {
+.page-tabs .page-list ul,
+.section-tabs ul {
     margin: 0;
     padding: 0;
     background: rgba(0, 0, 0, 0.0125);
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 }
 
-.page-tabs .page-list ul + ul {
+.page-tabs .page-list ul + ul,
+.section-tabs ul + ul {
     font-size: 0.75em;
 }
 
-.page-tabs .page-list li {
+.page-tabs .page-list li,
+.section-tabs li {
     display: inline-block;
     list-style: none;
 }
 
-.page-tabs .page-list li a[href] {
+.page-tabs .page-list li a[href],
+.section-tabs li a {
     display: block;
     color: black;
     text-decoration: none;
@@ -44,12 +48,16 @@
     color: black;
 }
 
-.page-tabs .page-list li a[href]:hover {
+.page-tabs .page-list li a[href]:hover,
+.section-tabs li a:hover {
     background-color: #CDA;
+    cursor: pointer;
 }
 
 .page-tabs .page-list li a[href].current,
-.page-tabs .page-list li a[href].current:hover {
+.page-tabs .page-list li a[href].current:hover,
+.section-tabs li a.current,
+.section-tabs li a.current:hover {
     background: rgba(0,0,0,0.3);
     cursor: default;
 }

--- a/guacamole/src/main/webapp/app/navigation/templates/guacSectionTabs.html
+++ b/guacamole/src/main/webapp/app/navigation/templates/guacSectionTabs.html
@@ -1,0 +1,10 @@
+<div class="section-tabs" ng-show="tabs.length">
+    <ul>
+        <li ng-repeat="name in tabs">
+            <a ng-click="selectTab(name)"
+               ng-class="{ current : isSelected(name) }">
+                {{ getSectionHeader(name) | translate }}
+            </a>
+        </li>
+    </ul>
+</div>

--- a/guacamole/src/main/webapp/app/settings/styles/settings.css
+++ b/guacamole/src/main/webapp/app/settings/styles/settings.css
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-.settings .header {
-    margin-bottom: 0;
-}
-
 .settings table.properties th {
     text-align: left;
     font-weight: normal;

--- a/guacamole/src/main/webapp/app/settings/templates/settings.html
+++ b/guacamole/src/main/webapp/app/settings/templates/settings.html
@@ -1,7 +1,7 @@
 
 <div class="view">
 
-    <div class="header">
+    <div class="header tabbed">
         <h2>{{'SETTINGS.SECTION_HEADER_SETTINGS' | translate}}</h2>
         <guac-user-menu></guac-user-menu>
     </div>

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -303,11 +303,11 @@
 
         "INFO_READ_ONLY" : "Sorry, but this user account cannot be edited.",
 
-        "SECTION_HEADER_ALL_CONNECTIONS"      : "All Connections",
-        "SECTION_HEADER_CONNECTIONS"          : "Connections",
-        "SECTION_HEADER_EDIT_USER"            : "Edit User",
-        "SECTION_HEADER_PERMISSIONS"          : "Permissions",
-        "SECTION_HEADER_SELECTED_CONNECTIONS" : "Selected Connections",
+        "SECTION_HEADER_ALL_CONNECTIONS"     : "All Connections",
+        "SECTION_HEADER_CONNECTIONS"         : "Connections",
+        "SECTION_HEADER_CURRENT_CONNECTIONS" : "Current Connections",
+        "SECTION_HEADER_EDIT_USER"           : "Edit User",
+        "SECTION_HEADER_PERMISSIONS"         : "Permissions",
 
         "TEXT_CONFIRM_DELETE" : "Users cannot be restored after they have been deleted. Are you sure you want to delete this user?"
 

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -303,9 +303,11 @@
 
         "INFO_READ_ONLY" : "Sorry, but this user account cannot be edited.",
 
-        "SECTION_HEADER_CONNECTIONS" : "Connections",
-        "SECTION_HEADER_EDIT_USER"   : "Edit User",
-        "SECTION_HEADER_PERMISSIONS" : "Permissions",
+        "SECTION_HEADER_ALL_CONNECTIONS"      : "All Connections",
+        "SECTION_HEADER_CONNECTIONS"          : "Connections",
+        "SECTION_HEADER_EDIT_USER"            : "Edit User",
+        "SECTION_HEADER_PERMISSIONS"          : "Permissions",
+        "SECTION_HEADER_SELECTED_CONNECTIONS" : "Selected Connections",
 
         "TEXT_CONFIRM_DELETE" : "Users cannot be restored after they have been deleted. Are you sure you want to delete this user?"
 


### PR DESCRIPTION
In the interest of reducing clutter within the group editor (which has even more sections than the already-somewhat-cluttered user editor), this change splits the "Connections" section into tabs such that the view can be limited to only the connections currently accessible by that user. This reduced view is selected by default for users which have access to at least one connection.

This has the effect that the default view within the editor (1) functions as a report of what the user may currently access and (2) allows direct management of the most relevant permissions:

![guac-user-current-connections](https://user-images.githubusercontent.com/4632905/43040224-421f1092-8cf3-11e8-8cb8-e1ca4115239a.png)

To grant access to connections, connection groups, etc. which are not already accessible nor nested within already accessible groups, the administrator can switch to the "All Connections" view:

![guac-user-all-connections](https://user-images.githubusercontent.com/4632905/43040228-523275fa-8cf3-11e8-8d24-6d42761903e4.png)

For any user that does not have access to any connections, including new users, the "All Connections" view is selected by default:

![guac-new-user-all-connections](https://user-images.githubusercontent.com/4632905/43040233-64c92542-8cf3-11e8-9078-496c55936d6d.png)

It is intended that these views represent the actual, current state of things, not the state of unsaved changes made within the editor. Each view is thus populated at the time the editor loads. Connections will not appear within nor disappear from the "Current Connections" view as a result of unsaved changes made within the editor.

Part of all this required modifying the `guacGroupListFilter` directive to preserve the type of its input, which varies between `ConnectionGroup` and `GroupListItem` depending on usage. It previously always converted to `ConnectionGroup` by unwrapping any given `GroupListItem`, thus undoing any filtering performed only on the `GroupListItem` hierarchy.