### PR TITLE
GUACAMOLE-593: Allow group membership attribute to be configured.

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -359,6 +359,17 @@ public class ConfigurationService {
         );
     }
     
+    /**
+     * Returns the name of the LDAP attribute used to enumerate
+     * members in a group, or "member" by default.
+     * 
+     * @return
+     *     The name of the LDAP attribute to use to enumerate
+     *     members in a group.
+     * 
+     * @throws GuacamoleException
+     *     If guacamole.properties connect be parsed.
+     */
     public String getMemberAttribute() throws GuacamoleException {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_MEMBER_ATTRIBUTE,

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -358,5 +358,12 @@ public class ConfigurationService {
             LDAPGuacamoleProperties.LDAP_USER_ATTRIBUTES
         );
     }
+    
+    public String getMemberAttribute() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_MEMBER_ATTRIBUTE,
+            "member"
+        );
+    }
 
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -216,6 +216,9 @@ public class LDAPGuacamoleProperties {
 
     };
     
+    /**
+     * LDAP attribute used to enumerate members of a group in the LDAP directory.
+     */
     public static final StringGuacamoleProperty LDAP_MEMBER_ATTRIBUTE = new StringGuacamoleProperty() {
       
         @Override

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -215,4 +215,11 @@ public class LDAPGuacamoleProperties {
         public String getName() { return "ldap-user-attributes"; }
 
     };
+    
+    public static final StringGuacamoleProperty LDAP_MEMBER_ATTRIBUTE = new StringGuacamoleProperty() {
+      
+        @Override
+        public String getName() { return "ldap-member-attribute"; }
+        
+    };
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -247,7 +247,8 @@ public class ConnectionService {
         // Add the prefix to the search filter, prefix filter searches for guacConfigGroups with the userDN as the member attribute value
         connectionSearchFilter.append("(&(objectClass=guacConfigGroup)");
         connectionSearchFilter.append("(|(");
-        connectionSearchFilter.append(confService.getMemberAttribute());
+        connectionSearchFilter.append(escapingService.escapeLDAPSearchFilter(
+                confService.getMemberAttribute()));
         connectionSearchFilter.append("=");
         connectionSearchFilter.append(escapingService.escapeLDAPSearchFilter(userDN));
         connectionSearchFilter.append(")");
@@ -261,7 +262,8 @@ public class ConnectionService {
                 groupBaseDN,
                 LDAPConnection.SCOPE_SUB,
                 "(&(!(objectClass=guacConfigGroup))(" 
-                        + confService.getMemberAttribute() 
+                        + escapingService.escapeLDAPSearchFilter(
+                                confService.getMemberAttribute()) 
                         + "=" + escapingService.escapeLDAPSearchFilter(userDN) 
                         + "))",
                 null,

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -245,7 +245,10 @@ public class ConnectionService {
         StringBuilder connectionSearchFilter = new StringBuilder();
 
         // Add the prefix to the search filter, prefix filter searches for guacConfigGroups with the userDN as the member attribute value
-        connectionSearchFilter.append("(&(objectClass=guacConfigGroup)(|(member=");
+        connectionSearchFilter.append("(&(objectClass=guacConfigGroup)");
+        connectionSearchFilter.append("(|(");
+        connectionSearchFilter.append(confService.getMemberAttribute());
+        connectionSearchFilter.append("=");
         connectionSearchFilter.append(escapingService.escapeLDAPSearchFilter(userDN));
         connectionSearchFilter.append(")");
 
@@ -257,7 +260,10 @@ public class ConnectionService {
             LDAPSearchResults userRoleGroupResults = ldapConnection.search(
                 groupBaseDN,
                 LDAPConnection.SCOPE_SUB,
-                "(&(!(objectClass=guacConfigGroup))(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
+                "(&(!(objectClass=guacConfigGroup))(" 
+                        + confService.getMemberAttribute() 
+                        + "=" + escapingService.escapeLDAPSearchFilter(userDN) 
+                        + "))",
                 null,
                 false,
                 confService.getLDAPSearchConstraints()


### PR DESCRIPTION
This allows the group membership attribute to be modified for the LDAP authentication module for directories that use a different one than the default of "member".