### PR TITLE
GUACAMOLE-611: Selectively fall through to other extensions when authentication fails

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
@@ -179,7 +179,9 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
 
         // Ignore auth attempts if no auth provider could be loaded
         if (authProvider == null) {
-            logger.warn("Authentication attempt denied because the authentication system could not be loaded. Please check for errors earlier in the logs.");
+            logger.warn("Authentication attempt ignored because the relevant "
+                    + "authentication provider could not be loaded. Please "
+                    + "check for errors earlier in the logs.");
             return null;
         }
 
@@ -244,7 +246,9 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
 
         // Ignore auth attempts if no auth provider could be loaded
         if (authProvider == null) {
-            logger.warn("Reauthentication attempt denied because the authentication system could not be loaded. Please check for errors earlier in the logs.");
+            logger.warn("Reauthentication attempt ignored because the relevant "
+                    + "authentication provider could not be loaded. Please "
+                    + "check for errors earlier in the logs.");
             return null;
         }
 
@@ -259,7 +263,9 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
 
         // Ignore auth attempts if no auth provider could be loaded
         if (authProvider == null) {
-            logger.warn("User data retrieval attempt denied because the authentication system could not be loaded. Please check for errors earlier in the logs.");
+            logger.warn("User data retrieval attempt ignored because the "
+                    + "relevant authentication provider could not be loaded. "
+                    + "Please check for errors earlier in the logs.");
             return null;
         }
 
@@ -325,7 +331,9 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
 
         // Ignore auth attempts if no auth provider could be loaded
         if (authProvider == null) {
-            logger.warn("User data refresh attempt denied because the authentication system could not be loaded. Please check for errors earlier in the logs.");
+            logger.warn("User data refresh attempt ignored because the "
+                    + "relevant authentication provider could not be loaded. "
+                    + "Please check for errors earlier in the logs.");
             return null;
         }
 

--- a/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
@@ -154,6 +154,25 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
 
     }
 
+    /**
+     * Logs a warning that the authentication process will be entirely aborted
+     * due to an internal error, advising the administrator to set the
+     * "skip-if-unavailable" property if error encountered is expected and
+     * should be tolerated.
+     */
+    private void warnAuthAborted() {
+        String identifier = getIdentifier();
+        logger.warn("The \"{}\" authentication provider has encountered an "
+                + "internal error which will halt the authentication "
+                + "process. If this is unexpected or you are the developer of "
+                + "this authentication provider, you may wish to enable "
+                + "debug-level logging. If this is expected and you wish to "
+                + "ignore such failures in the future, please set \"{}: {}\" "
+                + "within your guacamole.properties.",
+                identifier, ExtensionModule.SKIP_IF_UNAVAILABLE.getName(),
+                identifier);
+    }
+
     @Override
     public AuthenticatedUser authenticateUser(Credentials credentials)
             throws GuacamoleException {
@@ -186,6 +205,7 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
                 return null;
             }
 
+            warnAuthAborted();
             throw e;
 
         }
@@ -198,6 +218,7 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
                 return null;
             }
 
+            warnAuthAborted();
             throw e;
 
         }
@@ -251,6 +272,7 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
                 return null;
             }
 
+            warnAuthAborted();
             throw e;
 
         }
@@ -263,6 +285,7 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
                 return null;
             }
 
+            warnAuthAborted();
             throw e;
 
         }

--- a/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
@@ -222,6 +222,19 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
             throw e;
 
         }
+        catch (Error e) {
+
+            // Skip using this authentication provider if configured to ignore
+            // internal failures during auth
+            if (isFailureTolerated()) {
+                warnAuthProviderSkipped(e);
+                return null;
+            }
+
+            warnAuthAborted();
+            throw e;
+
+        }
 
     }
 
@@ -277,6 +290,19 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
 
         }
         catch (RuntimeException e) {
+
+            // Skip using this authentication provider if configured to ignore
+            // internal failures during auth
+            if (isFailureTolerated()) {
+                warnAuthProviderSkipped(e);
+                return null;
+            }
+
+            warnAuthAborted();
+            throw e;
+
+        }
+        catch (Error e) {
 
             // Skip using this authentication provider if configured to ignore
             // internal failures during auth

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -93,7 +93,7 @@ public class ExtensionModule extends ServletModule {
      * providers that are not within this list will halt the authentication
      * process entirely.
      */
-    private final StringSetProperty SKIP_IF_UNAVAILABLE = new StringSetProperty() {
+    public static final StringSetProperty SKIP_IF_UNAVAILABLE = new StringSetProperty() {
 
         @Override
         public String getName() {

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -93,11 +93,11 @@ public class ExtensionModule extends ServletModule {
      * providers that are not within this list will halt the authentication
      * process entirely.
      */
-    private final StringSetProperty TOLERATE_INTERNAL_FAILURES = new StringSetProperty() {
+    private final StringSetProperty SKIP_IF_UNAVAILABLE = new StringSetProperty() {
 
         @Override
         public String getName() {
-            return "tolerate-internal-failures";
+            return "skip-if-unavailable";
         }
 
     };
@@ -379,13 +379,13 @@ public class ExtensionModule extends ServletModule {
         // Parse list of auth providers whose internal failures should be
         // tolerated
         try {
-            return environment.getProperty(TOLERATE_INTERNAL_FAILURES, Collections.<String>emptySet());
+            return environment.getProperty(SKIP_IF_UNAVAILABLE, Collections.<String>emptySet());
         }
 
         // Use empty set by default if property cannot be parsed
         catch (GuacamoleException e) {
-            logger.warn("The list of authentication providers specified via the \"{}\" property could not be parsed: {}", TOLERATE_INTERNAL_FAILURES.getName(), e.getMessage());
-            logger.debug("Unable to parse \"{}\" property.", TOLERATE_INTERNAL_FAILURES.getName(), e);
+            logger.warn("The list of authentication providers specified via the \"{}\" property could not be parsed: {}", SKIP_IF_UNAVAILABLE.getName(), e.getMessage());
+            logger.debug("Unable to parse \"{}\" property.", SKIP_IF_UNAVAILABLE.getName(), e);
             return Collections.<String>emptySet();
         }
 

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -29,12 +29,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.guacamole.auth.file.FileAuthenticationProvider;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.event.listener.Listener;
+import org.apache.guacamole.properties.StringSetProperty;
 import org.apache.guacamole.resource.Resource;
 import org.apache.guacamole.resource.ResourceServlet;
 import org.apache.guacamole.resource.SequenceResource;
@@ -80,6 +82,25 @@ public class ExtensionModule extends ServletModule {
      * recognized as extensions.
      */
     private static final String EXTENSION_SUFFIX = ".jar";
+
+    /**
+     * A comma-separated list of the identifiers of all authentication
+     * providers whose internal failures should be tolerated during the
+     * authentication process. If an authentication provider within this list
+     * encounters an internal error during the authentication process, it will
+     * simply be skipped, allowing other authentication providers to continue
+     * trying to authenticate the user. Internal errors within authentication
+     * providers that are not within this list will halt the authentication
+     * process entirely.
+     */
+    private final StringSetProperty TOLERATE_INTERNAL_FAILURES = new StringSetProperty() {
+
+        @Override
+        public String getName() {
+            return "tolerate-internal-failures";
+        }
+
+    };
 
     /**
      * The Guacamole server environment.
@@ -156,13 +177,26 @@ public class ExtensionModule extends ServletModule {
      *
      * @param authenticationProvider
      *     The AuthenticationProvider class to bind.
+     *
+     * @param tolerateFailures
+     *     The set of identifiers of all authentication providers whose
+     *     internal failures should be tolerated during the authentication
+     *     process. If the identifier of an authentication provider is within
+     *     this set, errors during authentication will result in the
+     *     authentication provider being ignored for that authentication
+     *     attempt, with the authentication process proceeding as if that
+     *     authentication provider were not present. By default, errors during
+     *     authentication halt the authentication process entirely.
      */
-    private void bindAuthenticationProvider(Class<? extends AuthenticationProvider> authenticationProvider) {
+    private void bindAuthenticationProvider(
+            Class<? extends AuthenticationProvider> authenticationProvider,
+            Set<String> tolerateFailures) {
 
         // Bind authentication provider
         logger.debug("[{}] Binding AuthenticationProvider \"{}\".",
                 boundAuthenticationProviders.size(), authenticationProvider.getName());
-        boundAuthenticationProviders.add(new AuthenticationProviderFacade(authenticationProvider));
+        boundAuthenticationProviders.add(new AuthenticationProviderFacade(
+                authenticationProvider, tolerateFailures));
 
     }
 
@@ -173,12 +207,24 @@ public class ExtensionModule extends ServletModule {
      *
      * @param authProviders
      *     The AuthenticationProvider classes to bind.
+     *
+     * @param tolerateFailures
+     *     The set of identifiers of all authentication providers whose
+     *     internal failures should be tolerated during the authentication
+     *     process. If the identifier of an authentication provider is within
+     *     this set, errors during authentication will result in the
+     *     authentication provider being ignored for that authentication
+     *     attempt, with the authentication process proceeding as if that
+     *     authentication provider were not present. By default, errors during
+     *     authentication halt the authentication process entirely.
      */
-    private void bindAuthenticationProviders(Collection<Class<AuthenticationProvider>> authProviders) {
+    private void bindAuthenticationProviders(
+            Collection<Class<AuthenticationProvider>> authProviders,
+            Set<String> tolerateFailures) {
 
         // Bind each authentication provider within extension
         for (Class<AuthenticationProvider> authenticationProvider : authProviders)
-            bindAuthenticationProvider(authenticationProvider);
+            bindAuthenticationProvider(authenticationProvider, tolerateFailures);
 
     }
 
@@ -314,6 +360,38 @@ public class ExtensionModule extends ServletModule {
     }
 
     /**
+     * Returns the set of identifiers of all authentication providers whose
+     * internal failures should be tolerated during the authentication process.
+     * If the identifier of an authentication provider is within this set,
+     * errors during authentication will result in the authentication provider
+     * being ignored for that authentication attempt, with the authentication
+     * process proceeding as if that authentication provider were not present.
+     * By default, errors during authentication halt the authentication process
+     * entirely.
+     *
+     * @return
+     *     The set of identifiers of all authentication providers whose
+     *     internal failures should be tolerated during the authentication
+     *     process.
+     */
+    private Set<String> getToleratedAuthenticationProviders() {
+
+        // Parse list of auth providers whose internal failures should be
+        // tolerated
+        try {
+            return environment.getProperty(TOLERATE_INTERNAL_FAILURES, Collections.<String>emptySet());
+        }
+
+        // Use empty set by default if property cannot be parsed
+        catch (GuacamoleException e) {
+            logger.warn("The list of authentication providers specified via the \"{}\" property could not be parsed: {}", TOLERATE_INTERNAL_FAILURES.getName(), e.getMessage());
+            logger.debug("Unable to parse \"{}\" property.", TOLERATE_INTERNAL_FAILURES.getName(), e);
+            return Collections.<String>emptySet();
+        }
+
+    }
+
+    /**
      * Loads all extensions within the GUACAMOLE_HOME/extensions directory, if
      * any, adding their static resource to the given resoure collections.
      *
@@ -324,9 +402,20 @@ public class ExtensionModule extends ServletModule {
      * @param cssResources
      *     A modifiable collection of static CSS resources which may receive
      *     new CSS resources from extensions.
+     *
+     * @param toleratedAuthProviders
+     *     The set of identifiers of all authentication providers whose
+     *     internal failures should be tolerated during the authentication
+     *     process. If the identifier of an authentication provider is within
+     *     this set, errors during authentication will result in the
+     *     authentication provider being ignored for that authentication
+     *     attempt, with the authentication process proceeding as if that
+     *     authentication provider were not present. By default, errors during
+     *     authentication halt the authentication process entirely.
      */
     private void loadExtensions(Collection<Resource> javaScriptResources,
-            Collection<Resource> cssResources) {
+            Collection<Resource> cssResources,
+            Set<String> toleratedAuthProviders) {
 
         // Retrieve and validate extensions directory
         File extensionsDir = new File(environment.getGuacamoleHome(), EXTENSIONS_DIRECTORY);
@@ -375,7 +464,7 @@ public class ExtensionModule extends ServletModule {
                 cssResources.addAll(extension.getCSSResources().values());
 
                 // Attempt to load all authentication providers
-                bindAuthenticationProviders(extension.getAuthenticationProviderClasses());
+                bindAuthenticationProviders(extension.getAuthenticationProviderClasses(), toleratedAuthProviders);
 
                 // Attempt to load all listeners
                 bindListeners(extension.getListenerClasses());
@@ -430,10 +519,11 @@ public class ExtensionModule extends ServletModule {
         cssResources.add(new WebApplicationResource(getServletContext(), "/guacamole.min.css"));
 
         // Load all extensions
-        loadExtensions(javaScriptResources, cssResources);
+        final Set<String> toleratedAuthProviders = getToleratedAuthenticationProviders();
+        loadExtensions(javaScriptResources, cssResources, toleratedAuthProviders);
 
         // Always bind default file-driven auth last
-        bindAuthenticationProvider(FileAuthenticationProvider.class);
+        bindAuthenticationProvider(FileAuthenticationProvider.class, toleratedAuthProviders);
 
         // Dynamically generate app.js and app.css from extensions
         serve("/app.js").with(new ResourceServlet(new SequenceResource(javaScriptResources)));


### PR DESCRIPTION
This change adds a new property, `skip-if-unavailable`, which allows specific authentication providers to be skipped in the event of an internal error. In situations where a Guacamole deployment involves multiple authentication providers, administrators can define this property to explicitly allow backend failures  without aborting authentication entirely.

For example, if a deployment is configured to use both LDAP and MySQL, but the network to the MySQL server is known to occasionally go down, the administrator might specify:

```
skip-if-unavailable: mysql
```

to allow LDAP to continue to be used even if connection errors prevent authentication using MySQL. Specifying multiple auth providers is also possible using commas:

```
skip-if-unavailable: mysql, ldap
```

If this property is specified, and an authentication provider is skipped due to an internal error, a warning is logged advising the administrator that this has occurred:

> The "postgresql" authentication provider has been skipped due to an internal error. If this is unexpected or you are the developer of this authentication provider, you may wish to enable debug-level logging: ...

If this property is *not* specified and authentication is halted entirely due to an internal error, a warning is logged advising the administrator that they may wish to set `skip-if-unavailable` if such failures are expected:

> The "postgresql" authentication provider has encountered an internal error which will halt the authentication process. If this is unexpected or you are the developer of this authentication provider, you may wish to enable debug-level logging. If this is expected and you wish to ignore such failures in the future, please set "skip-if-unavailable: postgresql" within your guacamole.properties.