### PR TITLE
GUACAMOLE-598: Show fatal error message only after a fatal error has occurred.

### DIFF
--- a/guacamole/src/main/webapp/app/index/styles/fatal-page-error.css
+++ b/guacamole/src/main/webapp/app/index/styles/fatal-page-error.css
@@ -59,3 +59,18 @@
     margin: 0 0.25em;
     margin-bottom: -0.2em;
 }
+
+/* Ensure fatal error is initially hidden, fading the error message in when
+ * needed */
+
+.fatal-page-error-outer {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity, visibility;
+    transition-duration: 0.25s;
+}
+
+.shown.fatal-page-error-outer {
+    visibility: visible;
+    opacity: 1;
+}

--- a/guacamole/src/main/webapp/index.html
+++ b/guacamole/src/main/webapp/index.html
@@ -58,7 +58,7 @@
         </div>
 
         <!-- Absolute fatal error -->
-        <div ng-if="fatalError" class="fatal-page-error-outer">
+        <div ng-if="fatalError" ng-class="{shown: fatalError}" class="fatal-page-error-outer">
             <div class="fatal-page-error-middle">
                 <div class="fatal-page-error">
                     <h1 translate="APP.DIALOG_HEADER_ERROR"></h1>


### PR DESCRIPTION
As the fatal error message is selectively hidden using AngularJS, there is a moment before AngularJS has loaded during which the error message may be visible even though no error has occurred.

These changes alter the styling of the error such that it is always hidden by default, even before AngularJS kicks in. This is the same technique used to ensure that a mangled status notification dialog doesn't flash into view while the application is loading.