### PR TITLE
GUACAMOLE-220: Add missing definitions for CREATE_USER_GROUP system permission.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/SystemPermission.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/SystemPermission.java
@@ -38,6 +38,11 @@ public class SystemPermission implements Permission<SystemPermission.Type> {
         CREATE_USER,
 
         /**
+         * Create user groups.
+         */
+        CREATE_USER_GROUP,
+
+        /**
          * Create connections.
          */
         CREATE_CONNECTION,

--- a/guacamole/src/main/webapp/app/rest/types/PermissionSet.js
+++ b/guacamole/src/main/webapp/app/rest/types/PermissionSet.js
@@ -143,6 +143,11 @@ angular.module('rest').factory('PermissionSet', [function definePermissionSet() 
         CREATE_USER : "CREATE_USER",
 
         /**
+         * Permission to create new user groups.
+         */
+        CREATE_USER_GROUP : "CREATE_USER_GROUP",
+
+        /**
          * Permission to create new connections.
          */
         CREATE_CONNECTION : "CREATE_CONNECTION",


### PR DESCRIPTION
The `CREATE_USER_GROUP` system permission was missing from both the `SystemPermission` class (guacamole-ext) and the `PermissionSet` type (JavaScript half of Guacamole webapp). Lacking this definition, management of the `CREATE_USER_GROUP` permission for users or groups fails.