### PR TITLE
GUACAMOLE-220: Correct handling of permission-filtered directory search.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionDirectoryResource.java
@@ -24,9 +24,12 @@ import com.google.inject.assistedinject.AssistedInject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.ActiveConnection;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
 import org.apache.guacamole.rest.directory.DirectoryResource;
@@ -65,6 +68,12 @@ public class ActiveConnectionDirectoryResource
             DirectoryObjectTranslator<ActiveConnection, APIActiveConnection> translator,
             DirectoryObjectResourceFactory<ActiveConnection, APIActiveConnection> resourceFactory) {
         super(userContext, directory, translator, resourceFactory);
+    }
+
+    @Override
+    protected ObjectPermissionSet getObjectPermissions(Permissions permissions)
+            throws GuacamoleException {
+        return permissions.getActiveConnectionPermissions();
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionDirectoryResource.java
@@ -24,9 +24,12 @@ import com.google.inject.assistedinject.AssistedInject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
 import org.apache.guacamole.rest.directory.DirectoryResource;
@@ -64,6 +67,12 @@ public class ConnectionDirectoryResource
             DirectoryObjectTranslator<Connection, APIConnection> translator,
             DirectoryObjectResourceFactory<Connection, APIConnection> resourceFactory) {
         super(userContext, directory, translator, resourceFactory);
+    }
+
+    @Override
+    protected ObjectPermissionSet getObjectPermissions(Permissions permissions)
+            throws GuacamoleException {
+        return permissions.getConnectionPermissions();
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupDirectoryResource.java
@@ -27,7 +27,9 @@ import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.rest.directory.DirectoryObjectResource;
 import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
@@ -100,6 +102,12 @@ public class ConnectionGroupDirectoryResource
 
         return super.getObjectResource(identifier);
 
+    }
+
+    @Override
+    protected ObjectPermissionSet getObjectPermissions(Permissions permissions)
+            throws GuacamoleException {
+        return permissions.getConnectionGroupPermissions();
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
@@ -120,6 +120,26 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
     }
 
     /**
+     * Returns the ObjectPermissionSet defined within the given Permissions
+     * that represents the permissions affecting objects available within this
+     * DirectoryResource.
+     *
+     * @param permissions
+     *     The Permissions object from which the ObjectPermissionSet should be
+     *     retrieved.
+     *
+     * @return
+     *     The ObjectPermissionSet defined within the given Permissions object
+     *     that represents the permissions affecting objects available within
+     *     this DirectoryResource.
+     *
+     * @throws GuacamoleException
+     *     If an error prevents retrieval of permissions.
+     */
+    protected abstract ObjectPermissionSet getObjectPermissions(
+            Permissions permissions) throws GuacamoleException;
+
+    /**
      * Returns a map of all objects available within this DirectoryResource,
      * filtering the returned map by the given permission, if specified.
      *
@@ -149,7 +169,7 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
         // Filter objects, if requested
         Collection<String> identifiers = directory.getIdentifiers();
         if (!isAdmin && permissions != null && !permissions.isEmpty()) {
-            ObjectPermissionSet objectPermissions = effective.getUserPermissions();
+            ObjectPermissionSet objectPermissions = getObjectPermissions(effective);
             identifiers = objectPermissions.getAccessibleObjects(permissions, identifiers);
         }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileDirectoryResource.java
@@ -24,9 +24,12 @@ import com.google.inject.assistedinject.AssistedInject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.SharingProfile;
 import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
 import org.apache.guacamole.rest.directory.DirectoryResource;
@@ -65,6 +68,12 @@ public class SharingProfileDirectoryResource
             DirectoryObjectTranslator<SharingProfile, APISharingProfile> translator,
             DirectoryObjectResourceFactory<SharingProfile, APISharingProfile> resourceFactory) {
         super(userContext, directory, translator, resourceFactory);
+    }
+
+    @Override
+    protected ObjectPermissionSet getObjectPermissions(Permissions permissions)
+            throws GuacamoleException {
+        return permissions.getSharingProfilePermissions();
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserDirectoryResource.java
@@ -24,9 +24,12 @@ import com.google.inject.assistedinject.AssistedInject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
 import org.apache.guacamole.rest.directory.DirectoryResource;
@@ -63,6 +66,12 @@ public class UserDirectoryResource extends DirectoryResource<User, APIUser> {
             DirectoryObjectTranslator<User, APIUser> translator,
             DirectoryObjectResourceFactory<User, APIUser> resourceFactory) {
         super(userContext, directory, translator, resourceFactory);
+    }
+
+    @Override
+    protected ObjectPermissionSet getObjectPermissions(Permissions permissions)
+            throws GuacamoleException {
+        return permissions.getUserPermissions();
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupDirectoryResource.java
@@ -24,9 +24,12 @@ import com.google.inject.assistedinject.AssistedInject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.UserGroup;
 import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.rest.directory.DirectoryObjectResourceFactory;
 import org.apache.guacamole.rest.directory.DirectoryObjectTranslator;
 import org.apache.guacamole.rest.directory.DirectoryResource;
@@ -63,6 +66,12 @@ public class UserGroupDirectoryResource extends DirectoryResource<UserGroup, API
             DirectoryObjectTranslator<UserGroup, APIUserGroup> translator,
             DirectoryObjectResourceFactory<UserGroup, APIUserGroup> resourceFactory) {
         super(userContext, directory, translator, resourceFactory);
+    }
+
+    @Override
+    protected ObjectPermissionSet getObjectPermissions(Permissions permissions)
+            throws GuacamoleException {
+        return permissions.getUserGroupPermissions();
     }
 
 }


### PR DESCRIPTION
This change uses the correct `ObjectPermissionSet` to filter the identifiers of objects listed via REST when permission filtering is requested.

Previous code was always using the `ObjectPermissionSet` returned by `getUserPermissions()`, but this is only correct for user objects and thus was incorrect for all other object types (connections, connection groups, etc.). This bug likely went unnoticed due to minimal use of permission filtering, however it affects the behavior of the admin interface with respect to managing group memberships.