### PR TITLE
GUACAMOLE-624: Include user full name and organization in display and filter.

### DIFF
--- a/guacamole/src/main/webapp/app/settings/directives/guacSettingsUsers.js
+++ b/guacamole/src/main/webapp/app/settings/directives/guacSettingsUsers.js
@@ -88,6 +88,8 @@ angular.module('settings').directive('guacSettingsUsers', [function guacSettings
              * @type String[]
              */
             $scope.filteredUserProperties = [
+                'user.attributes["guac-full-name"]',
+                'user.attributes["guac-organization"]',
                 'user.lastActive',
                 'user.username'
             ];
@@ -107,7 +109,9 @@ angular.module('settings').directive('guacSettingsUsers', [function guacSettings
              */
             $scope.order = new SortOrder([
                 'user.username',
-                '-user.lastActive'
+                '-user.lastActive',
+                'user.attributes["guac-organization"]',
+                'user.attributes["guac-full-name"]'
             ]);
 
             // Get session date format

--- a/guacamole/src/main/webapp/app/settings/styles/user-list.css
+++ b/guacamole/src/main/webapp/app/settings/styles/user-list.css
@@ -24,12 +24,11 @@
 .settings.users table.user-list th.last-active,
 .settings.users table.user-list td.last-active {
     white-space: nowrap;
-    width: 0;
 }
 
-.settings.users table.user-list th.username,
-.settings.users table.user-list td.username {
-    width: 100%;
+.settings.users table.user-list th,
+.settings.users table.user-list td {
+    width: 25%;
 }
 
 .settings.users table.user-list tr.user td.username a[href] {

--- a/guacamole/src/main/webapp/app/settings/templates/settingsUsers.html
+++ b/guacamole/src/main/webapp/app/settings/templates/settingsUsers.html
@@ -27,6 +27,12 @@
                 <th guac-sort-order="order" guac-sort-property="'user.username'" class="username">
                     {{'SETTINGS_USERS.TABLE_HEADER_USERNAME' | translate}}
                 </th>
+                <th guac-sort-order="order" guac-sort-property="'user.attributes[\'guac-organization\']'" class="organization">
+                    {{'SETTINGS_USERS.TABLE_HEADER_ORGANIZATION' | translate}}
+                </th>
+                <th guac-sort-order="order" guac-sort-property="'user.attributes[\'guac-full-name\']'" class="full-name">
+                    {{'SETTINGS_USERS.TABLE_HEADER_FULL_NAME' | translate}}
+                </th>
                 <th guac-sort-order="order" guac-sort-property="'user.lastActive'" class="last-active">
                     {{'SETTINGS_USERS.TABLE_HEADER_LAST_ACTIVE' | translate}}
                 </th>
@@ -40,6 +46,8 @@
                         <span class="name">{{manageableUser.user.username}}</span>
                     </a>
                 </td>
+                <td class="organization">{{manageableUser.user.attributes['guac-organization']}}</td>
+                <td class="full-name">{{manageableUser.user.attributes['guac-full-name']}}</td>
                 <td class="last-active">{{manageableUser.user.lastActive | date : dateFormat}}</td>
             </tr>
         </tbody>

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -789,7 +789,9 @@
 
         "SECTION_HEADER_USERS"       : "Users",
 
+        "TABLE_HEADER_FULL_NAME"   : "Full name",
         "TABLE_HEADER_LAST_ACTIVE" : "Last active",
+        "TABLE_HEADER_ORGANIZATION" : "Organization",
         "TABLE_HEADER_USERNAME"    : "Username"
 
     },

--- a/guacamole/src/main/webapp/translations/es.json
+++ b/guacamole/src/main/webapp/translations/es.json
@@ -678,7 +678,11 @@
 
         "HELP_USERS" : "Haga Clic o toque un usuario abajo para gestionar dicho usuario. Dependiendo de su nivel de acceso, podrá añadir/borrar usuarios y cambiar sus contraseñas.",
 
-        "SECTION_HEADER_USERS"       : "Usuarios"
+        "SECTION_HEADER_USERS"       : "Usuarios",
+
+        "TABLE_HEADER_FULL_NAME"   : "Nombre completo",
+        "TABLE_HEADER_ORGANIZATION" : "Organización",
+        "TABLE_HEADER_USERNAME"    : "Usuario"
 
     },
     

--- a/guacamole/src/main/webapp/translations/zh.json
+++ b/guacamole/src/main/webapp/translations/zh.json
@@ -714,7 +714,9 @@
 
         "SECTION_HEADER_USERS"       : "用户",
 
+        "TABLE_HEADER_FULL_NAME"   : "全名",
         "TABLE_HEADER_LAST_ACTIVE" : "最近活动",
+        "TABLE_HEADER_ORGANIZATION" : "组织",
         "TABLE_HEADER_USERNAME"    : "用户名"
 
     },


### PR DESCRIPTION
This change adds two new columns to the user admin interface, "Full name" and "Organization", which display the contents of the standard attributes `guac-full-name` and `guac-organization` respectively. These attributes are also added to the set of filtered attributes, allowing the list of users to be filtered by any of the values displayed.