### PR TITLE
GUACAMOLE-524: Correct AuthenticatedUser implementations of Attributes interface.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/RemoteAuthenticatedUser.java
@@ -19,7 +19,6 @@
 
 package org.apache.guacamole.auth.jdbc.user;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Collections;
 import java.util.Set;
@@ -48,11 +47,6 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
     private final String remoteHost;
 
     /**
-     * Arbitrary attributes associated with this RemoteAuthenticatedUser object.
-     */
-    private Map<String, String> attributes = new HashMap<String, String>();
-
-    /**
      * The identifiers of any groups of which this user is a member, including
      * groups inherited through membership in other groups.
      */
@@ -60,12 +54,12 @@ public abstract class RemoteAuthenticatedUser implements AuthenticatedUser {
 
     @Override
     public Map<String, String> getAttributes() {
-        return attributes;
+        return Collections.<String, String>emptyMap();
     }
 
     @Override
     public void setAttributes(Map<String, String> attributes) {
-        this.attributes = attributes;
+        // No attributes supported
     }
 
     /**

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -232,10 +232,7 @@ public class AuthenticationProviderService {
         try {
             // Return AuthenticatedUser if bind succeeds
             AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
-            authenticatedUser.init(credentials);
-
-            // Set attributes
-            authenticatedUser.setAttributes(getLDAPAttributes(ldapConnection, credentials.getUsername()));
+            authenticatedUser.init(credentials, getLDAPAttributes(ldapConnection, credentials.getUsername()));
 
             return authenticatedUser;
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
@@ -20,7 +20,6 @@
 package org.apache.guacamole.auth.ldap.user;
 
 import com.google.inject.Inject;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
@@ -47,16 +46,22 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
     /**
      * Arbitrary attributes associated with this AuthenticatedUser object.
      */
-    private Map<String, String> attributes = new HashMap<String, String>();
+    private Map<String, String> attributes;
 
     /**
-     * Initializes this AuthenticatedUser using the given credentials.
+     * Initializes this AuthenticatedUser using the given credentials and
+     * arbitrary attributes.
      *
      * @param credentials
      *     The credentials provided when this user was authenticated.
+     *
+     * @param attributes
+     *     The map of arbitrary attribute name/value pairs to associate with
+     *     this AuthenticatedUser.
      */
-    public void init(Credentials credentials) {
+    public void init(Credentials credentials, Map<String, String> attributes) {
         this.credentials = credentials;
+        this.attributes = attributes;
         setIdentifier(credentials.getUsername());
     }
 
@@ -67,7 +72,7 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
 
     @Override
     public void setAttributes(Map<String, String> attributes) {
-        this.attributes = attributes;
+        // All attributes are read-only
     }
 
     @Override


### PR DESCRIPTION
These changes correct the JDBC and LDAP implementations of `AuthenticatedUser` such that `getAttributes()` and `setAttributes()` follow the definitions of the `Attributes` interface:

* Only attributes which `setAttributes()` will be persisting should be allowed to be set.
* Name/value pairs given to `setAttributes()`, if accepted, should be layered on top of existing attributes. They shouldn't replace the entire attribute map.