### PR TITLE
GUACAMOLE-232: Mark key as implicitly pressed only when pressed due to another, identifiable key event.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -964,20 +964,23 @@ Guacamole.Keyboard = function Keyboard(element) {
         // Press if modifier is implicitly pressed
         else if (!remoteState && localState) {
 
-            // Verify that modifier flag isn't set due to another version of
-            // the same key being held down
+            // Verify that modifier flag isn't already pressed or already set
+            // due to another version of the same key being held down
             for (i = 0; i < keysyms.length; i++) {
                 if (guac_keyboard.pressed[keysyms[i]])
                     return;
             }
 
-            // Press key and mark as implicitly pressed (if not already
-            // explicitly pressed)
+            // Mark as implicitly pressed only if there is other information
+            // within the key event relating to a different key. Some
+            // platforms, such as iOS, will send essentially empty key events
+            // for modifier keys, using only the modifier flags to signal the
+            // identity of the key.
             var keysym = keysyms[0];
-            if (!guac_keyboard.pressed(keysym)) {
+            if (keyEvent.keysym)
                 implicitlyPressed[keysym] = true;
-                guac_keyboard.press(keysym);
-            }
+
+            guac_keyboard.press(keysym);
 
         }
 


### PR DESCRIPTION
On iOS, distinct key events are sent for modifier keys, but these key events take the form of empty events with only modifier flags set. The current `Guacamole.Keyboard` implicit key logic seems correct, but a key event which has absolutely no information except modifier flags shouldn't be considered implicit; it's an explicit event for the specific modifiers involved.