### PR TITLE
GUACAMOLE-96: Add protected convenience method for retrieving delegate object.

### DIFF
--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUser.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUser.java
@@ -42,11 +42,6 @@ public class TOTPUser extends DelegatingUser {
     public static final String TOTP_KEY_CONFIRMED_ATTRIBUTE_NAME = "guac-totp-key-confirmed";
 
     /**
-     * The User object wrapped by this TOTPUser.
-     */
-    private final User undecorated;
-
-    /**
      * Wraps the given User object, hiding and blocking access to the core
      * attributes used by TOTP.
      *
@@ -55,7 +50,6 @@ public class TOTPUser extends DelegatingUser {
      */
     public TOTPUser(User user) {
         super(user);
-        this.undecorated = user;
     }
 
     /**
@@ -65,7 +59,7 @@ public class TOTPUser extends DelegatingUser {
      *     The wrapped User object.
      */
     public User getUndecorated() {
-        return undecorated;
+        return getDelegateUser();
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingConnection.java
@@ -50,6 +50,16 @@ public class DelegatingConnection implements Connection {
         this.connection = connection;
     }
 
+    /**
+     * Returns the underlying Connection wrapped by this DelegatingConnection.
+     *
+     * @return
+     *     The Connection wrapped by this DelegatingConnection.
+     */
+    protected Connection getDelegateConnection() {
+        return connection;
+    }
+
     @Override
     public String getIdentifier() {
         return connection.getIdentifier();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingConnectionGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingConnectionGroup.java
@@ -47,6 +47,17 @@ public class DelegatingConnectionGroup implements ConnectionGroup {
         this.connectionGroup = connectionGroup;
     }
 
+    /**
+     * Returns the underlying ConnectionGroup wrapped by this
+     * DelegatingConnectionGroup.
+     *
+     * @return
+     *     The ConnectionGroup wrapped by this DelegatingConnectionGroup.
+     */
+    protected ConnectionGroup getDelegateConnectionGroup() {
+        return connectionGroup;
+    }
+
     @Override
     public String getIdentifier() {
         return connectionGroup.getIdentifier();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingDirectory.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingDirectory.java
@@ -49,6 +49,16 @@ public class DelegatingDirectory<ObjectType extends Identifiable>
         this.directory = directory;
     }
 
+    /**
+     * Returns the underlying Directory wrapped by this DelegatingDirectory.
+     *
+     * @return
+     *     The Directory wrapped by this DelegatingDirectory.
+     */
+    protected Directory<ObjectType> getDelegateDirectory() {
+        return directory;
+    }
+
     @Override
     public ObjectType get(String identifier) throws GuacamoleException {
         return directory.get(identifier);

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingSharingProfile.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingSharingProfile.java
@@ -43,6 +43,17 @@ public class DelegatingSharingProfile implements SharingProfile {
         this.sharingProfile = sharingProfile;
     }
 
+    /**
+     * Returns the underlying SharingProfile wrapped by this
+     * DelegatingSharingProfile.
+     *
+     * @return
+     *     The SharingProfile wrapped by this DelegatingSharingProfile.
+     */
+    protected SharingProfile getDelegateSharingProfile() {
+        return sharingProfile;
+    }
+
     @Override
     public String getIdentifier() {
         return sharingProfile.getIdentifier();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUser.java
@@ -48,6 +48,16 @@ public class DelegatingUser implements User {
         this.user = user;
     }
 
+    /**
+     * Returns the underlying User wrapped by this DelegatingUser.
+     *
+     * @return
+     *     The User wrapped by this DelegatingUser.
+     */
+    protected User getDelegateUser() {
+        return user;
+    }
+
     @Override
     public String getIdentifier() {
         return user.getIdentifier();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
@@ -45,6 +45,17 @@ public class DelegatingUserContext implements UserContext {
         this.userContext = userContext;
     }
 
+    /**
+     * Returns the underlying UserContext wrapped by this
+     * DelegatingUserContext.
+     *
+     * @return
+     *     The UserContext wrapped by this DelegatingUserContext.
+     */
+    protected UserContext getDelegateUserContext() {
+        return userContext;
+    }
+
     @Override
     public User self() {
         return userContext.self();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserGroup.java
@@ -46,6 +46,16 @@ public class DelegatingUserGroup implements UserGroup {
         this.userGroup = userGroup;
     }
 
+    /**
+     * Returns the underlying UserGroup wrapped by this DelegatingUserGroup.
+     *
+     * @return
+     *     The UserGroup wrapped by this DelegatingUserGroup.
+     */
+    protected UserGroup getDelegateUserGroupGroup() {
+        return userGroup;
+    }
+
     @Override
     public String getIdentifier() {
         return userGroup.getIdentifier();


### PR DESCRIPTION
When decorating the objects of other extensions, it is frequently necessary to unwrap the decorated object, such as required by `DecoratingDirectory`. These changes add a `protected` method to each of the delegating classes to make this easier and remove the need to repeatedly re-implement storage of the delegate.