### PR TITLE
GUACAMOLE-220: Ignore missing user or group when retrieving permissions/memberships.

### DIFF
--- a/guacamole/src/main/webapp/app/rest/services/requestService.js
+++ b/guacamole/src/main/webapp/app/rest/services/requestService.js
@@ -92,6 +92,33 @@ angular.module('rest').factory('requestService', ['$injector',
     };
 
     /**
+     * Creates a promise error callback which resolves the promise with the
+     * given default value only if the @link{Error} in the original rejection
+     * is a NOT_FOUND error. All other errors are passed through and must be
+     * handled as yet more rejections.
+     *
+     * @param {*} value
+     *     The default value to use to resolve the promise if the promise is
+     *     rejected with a NOT_FOUND error.
+     *
+     * @returns {Function}
+     *     A function which can be provided as the error callback for a
+     *     promise.
+     */
+    service.defaultValue = function defaultValue(value) {
+        return service.createErrorCallback(function resolveIfNotFound(error) {
+
+            // Return default value only if not found
+            if (error.type === Error.Type.NOT_FOUND)
+                return value;
+
+            // Reject promise with original error otherwise
+            throw error;
+
+        });
+    };
+
+    /**
      * Promise error callback which ignores all rejections due to REST errors,
      * but logs all other rejections, such as those due to JavaScript errors.
      * This callback should be used in favor of angular.noop in cases where


### PR DESCRIPTION
This change addresses a regression in user management due to changes made for user group support.

When attempting to manage a user or group that doesn't exist in the selected datasource, the interface is supposed to reconfigure itself to allow that user or group to be created. This is particularly necessary when combining LDAP and a database, to allow existing LDAP users to be easily copied within the database and associated with database groups or permissions.

Unfortunately, a combination of several changes to error handling and the management interface broke the above functionality, instead showing an internal error if the user/group does not yet exist.