### PR TITLE
GUACAMOLE-524: Correct handling of parameter tokens within SimpleConnection

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
@@ -113,8 +113,7 @@ public class SimpleConnection extends AbstractConnection {
 
         // Apply tokens to config parameters
         GuacamoleConfiguration filteredConfig = new GuacamoleConfiguration(config);
-        TokenFilter tokenFilter = new TokenFilter();
-        tokenFilter.filterValues(config.getParameters());
+        new TokenFilter(tokens).filterValues(filteredConfig.getParameters());
 
         GuacamoleSocket socket;
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/TokenFilter.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/TokenFilter.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.token;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -68,7 +69,27 @@ public class TokenFilter {
     /**
      * The values of all known tokens.
      */
-    private final Map<String, String> tokenValues = new HashMap<String, String>();
+    private final Map<String, String> tokenValues;
+
+    /**
+     * Creates a new TokenFilter which has no associated tokens. Tokens must
+     * later be given using {@link #setToken(java.lang.String, java.lang.String)}
+     * or {@link #setTokens(java.util.Map)}.
+     */
+    public TokenFilter() {
+         this(Collections.<String, String>emptyMap());
+    }
+
+    /**
+     * Creates a new TokenFilter which is initialized with the given token
+     * name/value pairs.
+     *
+     * @param tokenValues
+     *     A map containing token names and their corresponding values.
+     */
+    public TokenFilter(Map<String, String> tokenValues) {
+        this.tokenValues = new HashMap<>(tokenValues);
+    }
 
     /**
      * Sets the token having the given name to the given value. Any existing


### PR DESCRIPTION
The changes introduced by #333 do not correctly apply parameter tokens within `SimplyConnection`. The created `TokenFilter` is never assigned any tokens and is ultimately applied to the wrong `GuacamoleConfiguration`.

These changes correct all that.