### PR TITLE
GUACAMOLE-220: Add user group support to LDAP.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/sharing/user/SharedUser.java
@@ -35,9 +35,6 @@ import org.apache.guacamole.net.auth.RelatedObjectSet;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
-import org.apache.guacamole.net.auth.simple.SimpleObjectPermissionSet;
-import org.apache.guacamole.net.auth.simple.SimpleRelatedObjectSet;
-import org.apache.guacamole.net.auth.simple.SimpleSystemPermissionSet;
 
 /**
  * An immutable implementation of User which defines READ permission for each of
@@ -122,7 +119,7 @@ public class SharedUser implements User {
 
     @Override
     public SystemPermissionSet getSystemPermissions() throws GuacamoleException {
-        return new SimpleSystemPermissionSet();
+        return SystemPermissionSet.EMPTY_SET;
     }
 
     @Override
@@ -145,22 +142,22 @@ public class SharedUser implements User {
 
     @Override
     public ObjectPermissionSet getUserGroupPermissions() throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getSharingProfilePermissions() throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getActiveConnectionPermissions() throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public RelatedObjectSet getUserGroups() throws GuacamoleException {
-        return new SimpleRelatedObjectSet();
+        return RelatedObjectSet.EMPTY_SET;
     }
 
     @Override

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -23,9 +23,11 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.novell.ldap.LDAPConnection;
 import java.util.List;
+import java.util.Set;
 import org.apache.guacamole.auth.ldap.user.AuthenticatedUser;
 import org.apache.guacamole.auth.ldap.user.UserContext;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.ldap.group.UserGroupService;
 import org.apache.guacamole.auth.ldap.user.UserService;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
@@ -61,6 +63,12 @@ public class AuthenticationProviderService {
      */
     @Inject
     private UserService userService;
+
+    /**
+     * Service for retrieving user groups.
+     */
+    @Inject
+    private UserGroupService userGroupService;
 
     /**
      * Provider for AuthenticatedUser objects.
@@ -222,9 +230,14 @@ public class AuthenticationProviderService {
 
         try {
 
+            // Retrieve group membership of the user that just authenticated
+            Set<String> effectiveGroups =
+                    userGroupService.getParentUserGroupIdentifiers(ldapConnection,
+                            ldapConnection.getAuthenticationDN());
+
             // Return AuthenticatedUser if bind succeeds
             AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
-            authenticatedUser.init(credentials);
+            authenticatedUser.init(credentials, effectiveGroups);
             return authenticatedUser;
 
         }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConfigurationService.java
@@ -139,6 +139,24 @@ public class ConfigurationService {
     }
 
     /**
+     * Returns all attributes which should be used to determine the unique
+     * identifier of each user group. By default, this will be "cn".
+     *
+     * @return
+     *     The attributes which should be used to determine the unique
+     *     identifier of each group.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public List<String> getGroupNameAttributes() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_GROUP_NAME_ATTRIBUTE,
+            Collections.singletonList("cn")
+        );
+    }
+
+    /**
      * Returns the base DN under which all Guacamole role based access control
      * (RBAC) groups will be stored within the LDAP directory. If RBAC will not
      * be used, null is returned.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProviderModule.java
@@ -77,6 +77,7 @@ public class LDAPAuthenticationProviderModule extends AbstractModule {
         bind(ConnectionService.class);
         bind(EscapingService.class);
         bind(LDAPConnectionService.class);
+        bind(ObjectQueryService.class);
         bind(UserService.class);
 
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPAuthenticationProviderModule.java
@@ -23,6 +23,7 @@ import com.google.inject.AbstractModule;
 import org.apache.guacamole.auth.ldap.connection.ConnectionService;
 import org.apache.guacamole.auth.ldap.user.UserService;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.ldap.group.UserGroupService;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.environment.LocalEnvironment;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
@@ -78,6 +79,7 @@ public class LDAPAuthenticationProviderModule extends AbstractModule {
         bind(EscapingService.class);
         bind(LDAPConnectionService.class);
         bind(ObjectQueryService.class);
+        bind(UserGroupService.class);
         bind(UserService.class);
 
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPGuacamoleProperties.java
@@ -87,6 +87,18 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
+     * The attribute or attributes which identify user groups. One of these
+     * attributes must be present within each Guacamole user group's record in
+     * the LDAP directory for that group to be visible.
+     */
+    public static final StringListProperty LDAP_GROUP_NAME_ATTRIBUTE = new StringListProperty() {
+
+        @Override
+        public String getName() { return "ldap-group-name-attribute"; }
+
+    };
+
+    /**
      * The port on the LDAP server to connect to when authenticating users.
      */
     public static final IntegerGuacamoleProperty LDAP_PORT = new IntegerGuacamoleProperty() {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.ldap;
+
+import com.google.inject.Inject;
+import com.novell.ldap.LDAPAttribute;
+import com.novell.ldap.LDAPConnection;
+import com.novell.ldap.LDAPEntry;
+import com.novell.ldap.LDAPException;
+import com.novell.ldap.LDAPReferralException;
+import com.novell.ldap.LDAPSearchResults;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.net.auth.Identifiable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service for executing queries against an LDAP directory intended to retrieve
+ * Guacamole-related objects. Referrals are automatically handled. Convenience
+ * functions are provided for generating the LDAP queries typically required
+ * for retrieving Guacamole objects, as well as for converting the results of a
+ * query into a Map of Guacamole objects.
+ */
+public class ObjectQueryService {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ObjectQueryService.class);
+
+    /**
+     * Service for escaping parts of LDAP queries.
+     */
+    @Inject
+    private EscapingService escapingService;
+
+    /**
+     * Service for retrieving LDAP server configuration information.
+     */
+    @Inject
+    private ConfigurationService confService;
+
+    /**
+     * Returns the identifier of the object represented by the given LDAP
+     * entry. Multiple attributes may be declared as containing the identifier
+     * of the object when present on an LDAP entry. If multiple such attributes
+     * are present on the same LDAP entry, the value of the attribute with
+     * highest priority is used. If multiple copies of the same attribute are
+     * present on the same LDAPentry, the first value of that attribute is
+     * used.
+     *
+     * @param entry
+     *     The entry representing the Guacamole object whose unique identifier
+     *     should be determined.
+     *
+     * @param attributes
+     *     A collection of all attributes which may be used to specify the
+     *     unique identifier of the Guacamole object represented by an LDAP
+     *     entry, in order of decreasing priority.
+     *
+     * @return
+     *     The identifier of the object represented by the given LDAP entry, or
+     *     null if no attributes declared as containing the identifier of the
+     *     object are present on the entry.
+     */
+    public String getIdentifier(LDAPEntry entry, Collection<String> attributes) {
+
+        // Retrieve the first value of the highest priority identifier attribute
+        for (String identifierAttribute : attributes) {
+            LDAPAttribute identifier = entry.getAttribute(identifierAttribute);
+            if (identifier != null)
+                return identifier.getStringValue();
+        }
+
+        // No identifier attribute is present on the entry
+        return null;
+
+    }
+
+    /**
+     * Generates a properly-escaped LDAP query which finds all objects which
+     * match the given LDAP filter and which have at least one of the given
+     * attributes set to the specified value.
+     *
+     * @param filter
+     *     The LDAP filter to apply to reduce the results of the query in
+     *     addition to testing the values of the given attributes.
+     *
+     * @param attributes
+     *     A collection of all attributes to test for equivalence to the given
+     *     value, in order of decreasing priority.
+     *
+     * @param attributeValue
+     *     The value that the resulting LDAP query should search for within the
+     *     attributes of objects within the LDAP directory. If null, the
+     *     resulting LDAP query will search for the presence of at least one of
+     *     the given attributes on each object, regardless of the value of
+     *     those attributes.
+     *
+     * @return
+     *     An LDAP query which will search for arbitrary LDAP objects having at
+     *     least one of the given attributes set to the specified value.
+     */
+    public String generateQuery(String filter,
+            Collection<String> attributes, String attributeValue) {
+
+        // Build LDAP query for objects having at least one attribute and with
+        // the given search filter
+        StringBuilder ldapQuery = new StringBuilder();
+        ldapQuery.append("(&");
+        ldapQuery.append(filter);
+
+        // Include all attributes within OR clause if there are more than one
+        if (attributes.size() > 1)
+            ldapQuery.append("(|");
+
+        // Add equality comparison for each possible attribute
+        for (String attribute : attributes) {
+            ldapQuery.append("(");
+            ldapQuery.append(escapingService.escapeLDAPSearchFilter(attribute));
+
+            if (attributeValue != null) {
+                ldapQuery.append("=");
+                ldapQuery.append(escapingService.escapeLDAPSearchFilter(attributeValue));
+                ldapQuery.append(")");
+            }
+            else
+                ldapQuery.append("=*)");
+
+        }
+
+        // Close OR clause, if any
+        if (attributes.size() > 1)
+            ldapQuery.append(")");
+
+        // Close overall query (AND clause)
+        ldapQuery.append(")");
+
+        return ldapQuery.toString();
+
+    }
+
+    /**
+     * Executes an arbitrary LDAP query using the given connection, returning a
+     * list of all results. Only objects beneath the given base DN are
+     * included in the search.
+     *
+     * @param ldapConnection
+     *     The current connection to the LDAP server, associated with the
+     *     current user.
+     *
+     * @param baseDN
+     *     The base DN to search using the given LDAP query.
+     *
+     * @param query
+     *     The LDAP query to execute.
+     *
+     * @return
+     *     A list of all results accessible to the user currently bound under
+     *     the given LDAP connection.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs executing the query, or if configuration
+     *     information required to execute the query cannot be read from
+     *     guacamole.properties.
+     */
+    public List<LDAPEntry> search(LDAPConnection ldapConnection,
+            String baseDN, String query) throws GuacamoleException {
+
+        logger.debug("Searching \"{}\" for objects matching \"{}\".", baseDN, query);
+
+        try {
+
+            // Search within subtree of given base DN
+            LDAPSearchResults results = ldapConnection.search(baseDN,
+                    LDAPConnection.SCOPE_SUB, query, null, false,
+                    confService.getLDAPSearchConstraints());
+
+            // Produce list of all entries in the search result, automatically
+            // following referrals if configured to do so
+            List<LDAPEntry> entries = new ArrayList<>(results.getCount());
+            while (results.hasMore()) {
+
+                try {
+                    entries.add(results.next());
+                }
+
+                // Warn if referrals cannot be followed
+                catch (LDAPReferralException e) {
+                    if (confService.getFollowReferrals()) {
+                        logger.error("Could not follow referral: {}", e.getFailedReferral());
+                        logger.debug("Error encountered trying to follow referral.", e);
+                        throw new GuacamoleServerException("Could not follow LDAP referral.", e);
+                    }
+                    else {
+                        logger.warn("Given a referral, but referrals are disabled. Error was: {}", e.getMessage());
+                        logger.debug("Got a referral, but configured to not follow them.", e);
+                    }
+                }
+
+            }
+
+            return entries;
+
+        }
+        catch (LDAPException | GuacamoleException e) {
+            throw new GuacamoleServerException("Unable to query list of "
+                    + "objects from LDAP directory.", e);
+        }
+
+    }
+
+    /**
+     * Executes the query which would be returned by generateQuery() using the
+     * given connection, returning a list of all results. Only objects beneath
+     * the given base DN are included in the search.
+     *
+     * @param ldapConnection
+     *     The current connection to the LDAP server, associated with the
+     *     current user.
+     *
+     * @param baseDN
+     *     The base DN to search using the given LDAP query.
+     *
+     * @param filter
+     *     The LDAP filter to apply to reduce the results of the query in
+     *     addition to testing the values of the given attributes.
+     *
+     * @param attributes
+     *     A collection of all attributes to test for equivalence to the given
+     *     value, in order of decreasing priority.
+     *
+     * @param attributeValue
+     *     The value that should be searched search for within the attributes
+     *     of objects within the LDAP directory. If null, the search will test
+     *     only for the presence of at least one of the given attributes on
+     *     each object, regardless of the value of those attributes.
+     *
+     * @return
+     *     A list of all results accessible to the user currently bound under
+     *     the given LDAP connection.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs executing the query, or if configuration
+     *     information required to execute the query cannot be read from
+     *     guacamole.properties.
+     */
+    public List<LDAPEntry> search(LDAPConnection ldapConnection, String baseDN,
+            String filter, Collection<String> attributes, String attributeValue)
+            throws GuacamoleException {
+        String query = generateQuery(filter, attributes, attributeValue);
+        return search(ldapConnection, baseDN, query);
+    }
+
+    /**
+     * Converts a given list of LDAP entries to a map of Guacamole objects
+     * stored by their identifiers.
+     *
+     * @param <ObjectType>
+     *     The type of object to store within the map.
+     *
+     * @param entries
+     *     A list of LDAP entries to convert to Guacamole objects.
+     *
+     * @param mapper
+     *     A mapping function which converts a given LDAP entry to its
+     *     corresponding Guacamole object. If the LDAP entry cannot be
+     *     converted, null should be returned.
+     *
+     * @return
+     *     A new map containing Guacamole object versions of each of the given
+     *     LDAP entries, where each object is stored within the map under its
+     *     corresponding identifier.
+     */
+    public <ObjectType extends Identifiable> Map<String, ObjectType>
+        asMap(List<LDAPEntry> entries, Function<LDAPEntry, ObjectType> mapper) {
+
+        // Convert each entry to the corresponding Guacamole API object
+        Map<String, ObjectType> objects = new HashMap<>(entries.size());
+        for (LDAPEntry entry : entries) {
+
+            ObjectType object = mapper.apply(entry);
+            if (object == null) {
+                logger.debug("Ignoring object \"{}\".", entry.getDN());
+                continue;
+            }
+
+            // Attempt to add object to map, warning if the object appears
+            // to be a duplicate
+            String identifier = object.getIdentifier();
+            if (objects.putIfAbsent(identifier, object) != null)
+                logger.warn("Multiple objects ambiguously map to the "
+                        + "same identifier (\"{}\"). Ignoring \"{}\" as "
+                        + "a duplicate.", identifier, entry.getDN());
+
+        }
+
+        return objects;
+
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -24,8 +24,6 @@ import com.novell.ldap.LDAPAttribute;
 import com.novell.ldap.LDAPConnection;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPException;
-import com.novell.ldap.LDAPReferralException;
-import com.novell.ldap.LDAPSearchResults;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
@@ -36,6 +34,7 @@ import org.apache.guacamole.auth.ldap.EscapingService;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.auth.ldap.ObjectQueryService;
+import org.apache.guacamole.auth.ldap.group.UserGroupService;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.simple.SimpleConnection;
@@ -73,6 +72,12 @@ public class ConnectionService {
      */
     @Inject
     private ObjectQueryService queryService;
+
+    /**
+     * Service for retrieving user groups.
+     */
+    @Inject
+    private UserGroupService userGroupService;
 
     /**
      * Returns all Guacamole connections accessible to the user currently bound
@@ -226,43 +231,12 @@ public class ConnectionService {
         connectionSearchFilter.append(escapingService.escapeLDAPSearchFilter(userDN));
         connectionSearchFilter.append(")");
 
-        // If group base DN is specified search for user groups
-        String groupBaseDN = confService.getGroupBaseDN();
-        if (groupBaseDN != null) {
-
-            // Get all groups the user is a member of starting at the groupBaseDN, excluding guacConfigGroups
-            LDAPSearchResults userRoleGroupResults = ldapConnection.search(
-                groupBaseDN,
-                LDAPConnection.SCOPE_SUB,
-                "(&(!(objectClass=guacConfigGroup))(member=" + escapingService.escapeLDAPSearchFilter(userDN) + "))",
-                null,
-                false,
-                confService.getLDAPSearchConstraints()
-            );
-
-            // Append the additional user groups to the LDAP filter
-            // Now the filter will also look for guacConfigGroups that refer
-            // to groups the user is a member of
-            // The guacConfig group uses the seeAlso attribute to refer
-            // to these other groups
-            while (userRoleGroupResults.hasMore()) {
-                try {
-                    LDAPEntry entry = userRoleGroupResults.next();
-                    connectionSearchFilter.append("(seeAlso=").append(escapingService.escapeLDAPSearchFilter(entry.getDN())).append(")");
-                }
-
-                catch (LDAPReferralException e) {
-                    if (confService.getFollowReferrals()) {
-                        logger.error("Could not follow referral: {}", e.getFailedReferral());
-                        logger.debug("Error encountered trying to follow referral.", e);
-                        throw new GuacamoleServerException("Could not follow LDAP referral.", e);
-                    }
-                    else {
-                        logger.warn("Given a referral, but referrals are disabled. Error was: {}", e.getMessage());
-                        logger.debug("Got a referral, but configured to not follow them.", e);
-                    }
-                }
-            }
+        // Additionally filter by group membership if the current user is a
+        // member of any user groups
+        List<LDAPEntry> userGroups = userGroupService.getParentUserGroupEntries(ldapConnection, userDN);
+        if (!userGroups.isEmpty()) {
+            for (LDAPEntry entry : userGroups)
+                connectionSearchFilter.append("(seeAlso=").append(escapingService.escapeLDAPSearchFilter(entry.getDN())).append(")");
         }
 
         // Complete the search filter.

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.ldap.group;
+
+import com.google.inject.Inject;
+import com.novell.ldap.LDAPConnection;
+import com.novell.ldap.LDAPEntry;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.guacamole.auth.ldap.ConfigurationService;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.ldap.ObjectQueryService;
+import org.apache.guacamole.net.auth.UserGroup;
+import org.apache.guacamole.net.auth.simple.SimpleUserGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service for querying user group membership and retrieving user groups
+ * visible to a particular Guacamole user.
+ */
+public class UserGroupService {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(UserGroupService.class);
+
+    /**
+     * Service for retrieving LDAP server configuration information.
+     */
+    @Inject
+    private ConfigurationService confService;
+
+    /**
+     * Service for executing LDAP queries.
+     */
+    @Inject
+    private ObjectQueryService queryService;
+
+    /**
+     * Returns the base search filter which should be used to retrieve user
+     * groups which do not represent Guacamole connections. As excluding the
+     * guacConfigGroup object class may not work as expected (may always return
+     * zero results) if guacConfigGroup object class is not defined, it should
+     * only be explicitly excluded if it is expected to have been defined.
+     *
+     * @return
+     *     The base search filter which should be used to retrieve user groups.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    private String getGroupSearchFilter() throws GuacamoleException {
+
+        // Explicitly exclude guacConfigGroup object class only if it should
+        // be assumed to be defined (query may fail due to no such object
+        // class existing otherwise)
+        if (confService.getConfigurationBaseDN() != null)
+            return "(!(objectClass=guacConfigGroup))";
+
+        // Read any object as a group if LDAP is not being used for connection
+        // storage (guacConfigGroup)
+        return "(objectClass=*)";
+
+    }
+
+    /**
+     * Returns all Guacamole user groups accessible to the user currently bound
+     * under the given LDAP connection.
+     *
+     * @param ldapConnection
+     *     The current connection to the LDAP server, associated with the
+     *     current user.
+     *
+     * @return
+     *     All user groups accessible to the user currently bound under the
+     *     given LDAP connection, as a map of user group identifier to
+     *     corresponding UserGroup object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs preventing retrieval of user groups.
+     */
+    public Map<String, UserGroup> getUserGroups(LDAPConnection ldapConnection)
+            throws GuacamoleException {
+
+        // Do not return any user groups if base DN is not specified
+        String groupBaseDN = confService.getGroupBaseDN();
+        if (groupBaseDN == null)
+            return Collections.<String, UserGroup>emptyMap();
+
+        // Retrieve all visible user groups which are not guacConfigGroups
+        Collection<String> attributes = confService.getGroupNameAttributes();
+        List<LDAPEntry> results = queryService.search(
+            ldapConnection,
+            groupBaseDN,
+            getGroupSearchFilter(),
+            attributes,
+            null
+        );
+
+        // Convert retrieved user groups to map of identifier to Guacamole
+        // user group object
+        return queryService.asMap(results, entry -> {
+
+            // Translate entry into UserGroup object having proper identifier
+            String name = queryService.getIdentifier(entry, attributes);
+            if (name != null)
+                return new SimpleUserGroup(name);
+
+            // Ignore user groups which lack a name attribute
+            logger.debug("User group \"{}\" is missing a name attribute "
+                    + "and will be ignored.", entry.getDN());
+            return null;
+
+        });
+
+    }
+
+    /**
+     * Returns the LDAP entries representing all user groups that the given
+     * user is a member of. Only user groups which are readable by the current
+     * user will be retrieved.
+     *
+     * @param ldapConnection
+     *     The current connection to the LDAP server, associated with the
+     *     current user.
+     *
+     * @param userDN
+     *     The DN of the user whose group membership should be retrieved.
+     *
+     * @return
+     *     The LDAP entries representing all readable parent user groups of the
+     *     user having the given DN.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs preventing retrieval of user groups.
+     */
+    public List<LDAPEntry> getParentUserGroupEntries(LDAPConnection ldapConnection,
+            String userDN) throws GuacamoleException {
+
+        // Do not return any user groups if base DN is not specified
+        String groupBaseDN = confService.getGroupBaseDN();
+        if (groupBaseDN == null)
+            return Collections.<LDAPEntry>emptyList();
+
+        // Get all groups the user is a member of starting at the groupBaseDN,
+        // excluding guacConfigGroups
+        return queryService.search(
+            ldapConnection,
+            groupBaseDN,
+            getGroupSearchFilter(),
+            Collections.singleton("member"),
+            userDN
+        );
+
+    }
+
+    /**
+     * Returns the identifiers of all user groups that the given user is a
+     * member of. Only identifiers of user groups which are readable by the
+     * current user will be retrieved.
+     *
+     * @param ldapConnection
+     *     The current connection to the LDAP server, associated with the
+     *     current user.
+     *
+     * @param userDN
+     *     The DN of the user whose group membership should be retrieved.
+     *
+     * @return
+     *     The identifiers of all readable parent user groups of the user
+     *     having the given DN.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs preventing retrieval of user groups.
+     */
+    public Set<String> getParentUserGroupIdentifiers(LDAPConnection ldapConnection,
+            String userDN) throws GuacamoleException {
+
+        Collection<String> attributes = confService.getGroupNameAttributes();
+        List<LDAPEntry> userGroups = getParentUserGroupEntries(ldapConnection, userDN);
+
+        Set<String> identifiers = new HashSet<>(userGroups.size());
+        userGroups.forEach(entry -> {
+
+            // Determine unique identifier for user group
+            String name = queryService.getIdentifier(entry, attributes);
+            if (name != null)
+                identifiers.add(name);
+
+            // Ignore user groups which lack a name attribute
+            else
+                logger.debug("User group \"{}\" is missing a name attribute "
+                        + "and will be ignored.", entry.getDN());
+
+        });
+
+        return identifiers;
+
+    }
+
+}

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/AuthenticatedUser.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.auth.ldap.user;
 
 import com.google.inject.Inject;
+import java.util.Set;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
@@ -43,13 +44,25 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
     private Credentials credentials;
 
     /**
-     * Initializes this AuthenticatedUser using the given credentials.
+     * The unique identifiers of all user groups which affect the permissions
+     * available to this user.
+     */
+    private Set<String> effectiveGroups;
+
+    /**
+     * Initializes this AuthenticatedUser with the given credentials and set of
+     * effective user groups.
      *
      * @param credentials
      *     The credentials provided when this user was authenticated.
+     *
+     * @param effectiveGroups
+     *     The unique identifiers of all user groups which affect the
+     *     permissions available to this user.
      */
-    public void init(Credentials credentials) {
+    public void init(Credentials credentials, Set<String> effectiveGroups) {
         this.credentials = credentials;
+        this.effectiveGroups = effectiveGroups;
         setIdentifier(credentials.getUsername());
     }
 
@@ -61,6 +74,11 @@ public class AuthenticatedUser extends AbstractAuthenticatedUser {
     @Override
     public Credentials getCredentials() {
         return credentials;
+    }
+
+    @Override
+    public Set<String> getEffectiveUserGroups() {
+        return effectiveGroups;
     }
 
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserContext.java
@@ -34,8 +34,10 @@ import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserGroup;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.simple.SimpleConnectionGroup;
 import org.apache.guacamole.net.auth.simple.SimpleDirectory;
+import org.apache.guacamole.net.auth.simple.SimpleObjectPermissionSet;
 import org.apache.guacamole.net.auth.simple.SimpleUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -149,13 +151,29 @@ public class UserContext extends AbstractUserContext {
         );
 
         // Init self with basic permissions
-        self = new SimpleUser(
-            user.getIdentifier(),
-            userDirectory.getIdentifiers(),
-            userGroupDirectory.getIdentifiers(),
-            connectionDirectory.getIdentifiers(),
-            Collections.singleton(LDAPAuthenticationProvider.ROOT_CONNECTION_GROUP)
-        );
+        self = new SimpleUser(user.getIdentifier()) {
+
+            @Override
+            public ObjectPermissionSet getUserPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(userDirectory.getIdentifiers());
+            }
+
+            @Override
+            public ObjectPermissionSet getUserGroupPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(userGroupDirectory.getIdentifiers());
+            }
+
+            @Override
+            public ObjectPermissionSet getConnectionPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(connectionDirectory.getIdentifiers());
+            }
+
+            @Override
+            public ObjectPermissionSet getConnectionGroupPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(Collections.singleton(LDAPAuthenticationProvider.ROOT_CONNECTION_GROUP));
+            }
+
+        };
 
     }
 

--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectUserContext.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectUserContext.java
@@ -26,6 +26,8 @@ import org.apache.guacamole.net.auth.AbstractUserContext;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.User;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
+import org.apache.guacamole.net.auth.simple.SimpleObjectPermissionSet;
 import org.apache.guacamole.net.auth.simple.SimpleUser;
 
 /**
@@ -93,10 +95,19 @@ public class QuickConnectUserContext extends AbstractUserContext {
 
         // Initialize the user to a SimpleUser with the provided username,
         // no connections, and the single root group.
-        this.self = new SimpleUser(username,
-            connectionDirectory.getIdentifiers(),
-            Collections.singleton(ROOT_IDENTIFIER)
-        );
+        this.self = new SimpleUser(username) {
+
+            @Override
+            public ObjectPermissionSet getConnectionPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(connectionDirectory.getIdentifiers());
+            }
+
+            @Override
+            public ObjectPermissionSet getConnectionGroupPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(Collections.singleton(ROOT_IDENTIFIER));
+            }
+
+        };
 
         // Set the authProvider to the calling authProvider object.
         this.authProvider = authProvider;

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserGroup.java
@@ -20,36 +20,16 @@
 package org.apache.guacamole.net.auth;
 
 import java.util.Collections;
-import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 
 /**
- * Base implementation of User which provides default implementations of
+ * Base implementation of UserGroup which provides default implementations of
  * most functions.
  */
-public abstract class AbstractUser extends AbstractIdentifiable
-        implements User {
-
-    /**
-     * This user's password. Note that while this provides a means for the
-     * password to be set, the data stored in this String is not necessarily
-     * the user's actual password. It may be hashed, it may be arbitrary.
-     */
-    private String password;
-
-    @Override
-    public String getPassword() {
-        return password;
-    }
-
-    @Override
-    public void setPassword(String password) {
-        this.password = password;
-    }
+public class AbstractUserGroup extends AbstractIdentifiable implements UserGroup {
 
     /**
      * {@inheritDoc}
@@ -72,29 +52,6 @@ public abstract class AbstractUser extends AbstractIdentifiable
     @Override
     public void setAttributes(Map<String, String> attributes) {
         // Ignore all attributes by default
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>This implementation simply returns {@code null}. Implementations that
-     * wish to expose the date and time that a user was last active should
-     * override this function.
-     */
-    @Override
-    public Date getLastActive() {
-        return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>This implementation simply an immutable, empty list. Implementations
-     * that wish to expose user login history should override this function.
-     */
-    @Override
-    public List<ActivityRecord> getHistory() throws GuacamoleException {
-        return Collections.<ActivityRecord>emptyList();
     }
 
     /**
@@ -202,13 +159,25 @@ public abstract class AbstractUser extends AbstractIdentifiable
     /**
      * {@inheritDoc}
      *
-     * <p>This implementation simply returns {@code this}. Implementations that
-     * wish to expose permissions which apply indirectly (such as through
-     * group inheritance) should override this function.
+     * <p>This implementation simply an immutable, empty related object set.
+     * Implementations that wish to expose group membership should override
+     * this function.
      */
     @Override
-    public Permissions getEffectivePermissions() throws GuacamoleException {
-        return this;
+    public RelatedObjectSet getMemberUsers() throws GuacamoleException {
+        return RelatedObjectSet.EMPTY_SET;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply an immutable, empty related object set.
+     * Implementations that wish to expose group membership should override
+     * this function.
+     */
+    @Override
+    public RelatedObjectSet getMemberUserGroups() throws GuacamoleException {
+        return RelatedObjectSet.EMPTY_SET;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/RelatedObjectSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/RelatedObjectSet.java
@@ -19,8 +19,10 @@
 
 package org.apache.guacamole.net.auth;
 
+import java.util.Collections;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleSecurityException;
 
 /**
  * An arbitrary set of existing objects sharing some common relation. Unlike a
@@ -74,5 +76,29 @@ public interface RelatedObjectSet {
      *     remove objects is denied.
      */
     void removeObjects(Set<String> identifiers) throws GuacamoleException;
+
+    /**
+     * An immutable instance of RelatedObjectSEt which contains no objects.
+     */
+    static final RelatedObjectSet EMPTY_SET = new RelatedObjectSet() {
+
+        @Override
+        public Set<String> getObjects() throws GuacamoleException {
+            return Collections.<String>emptySet();
+        }
+
+        @Override
+        public void addObjects(Set<String> identifiers)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+        @Override
+        public void removeObjects(Set<String> identifiers)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+    };
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/ObjectPermissionSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/ObjectPermissionSet.java
@@ -20,8 +20,10 @@
 package org.apache.guacamole.net.auth.permission;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleSecurityException;
 
 
 /**
@@ -125,5 +127,55 @@ public interface ObjectPermissionSet extends PermissionSet<ObjectPermission> {
     @Override
     void removePermissions(Set<ObjectPermission> permissions)
             throws GuacamoleException;
+
+    /**
+     * An immutable instance of ObjectPermissionSet which contains no
+     * permissions.
+     */
+    static final ObjectPermissionSet EMPTY_SET = new ObjectPermissionSet() {
+
+        @Override
+        public boolean hasPermission(ObjectPermission.Type permission,
+                String identifier) throws GuacamoleException {
+            return false;
+        }
+
+        @Override
+        public void addPermission(ObjectPermission.Type permission,
+                String identifier) throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+        @Override
+        public void removePermission(ObjectPermission.Type permission,
+                String identifier) throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+        @Override
+        public Collection<String> getAccessibleObjects(Collection<ObjectPermission.Type> permissions,
+                Collection<String> identifiers) throws GuacamoleException {
+            return Collections.<String>emptySet();
+        }
+
+        @Override
+        public Set<ObjectPermission> getPermissions()
+                throws GuacamoleException {
+            return Collections.<ObjectPermission>emptySet();
+        }
+
+        @Override
+        public void addPermissions(Set<ObjectPermission> permissions)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+        @Override
+        public void removePermissions(Set<ObjectPermission> permissions)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+    };
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/SystemPermissionSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/SystemPermissionSet.java
@@ -19,8 +19,10 @@
 
 package org.apache.guacamole.net.auth.permission;
 
+import java.util.Collections;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleSecurityException;
 
 
 /**
@@ -80,5 +82,49 @@ public interface SystemPermissionSet extends PermissionSet<SystemPermission> {
     @Override
     void removePermissions(Set<SystemPermission> permissions)
             throws GuacamoleException;
+
+    /**
+     * An immutable instance of SystemPermissionSet which contains no
+     * permissions.
+     */
+    static final SystemPermissionSet EMPTY_SET = new SystemPermissionSet() {
+
+        @Override
+        public boolean hasPermission(SystemPermission.Type permission)
+                throws GuacamoleException {
+            return false;
+        }
+
+        @Override
+        public void addPermission(SystemPermission.Type permission)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+        @Override
+        public void removePermission(SystemPermission.Type permission)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+        @Override
+        public Set<SystemPermission> getPermissions()
+                throws GuacamoleException {
+            return Collections.<SystemPermission>emptySet();
+        }
+
+        @Override
+        public void addPermissions(Set<SystemPermission> permissions)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+        @Override
+        public void removePermissions(Set<SystemPermission> permissions)
+                throws GuacamoleException {
+            throw new GuacamoleSecurityException("Permission denied.");
+        }
+
+    };
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleObjectPermissionSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleObjectPermissionSet.java
@@ -22,6 +22,7 @@ package org.apache.guacamole.net.auth.simple;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
@@ -43,6 +44,66 @@ public class SimpleObjectPermissionSet implements ObjectPermissionSet {
      * Creates a new empty SimpleObjectPermissionSet.
      */
     public SimpleObjectPermissionSet() {
+    }
+
+    /**
+     * Creates a new set of ObjectPermissions for each possible combination of
+     * the given identifiers and permission types.
+     *
+     * @param identifiers
+     *     The identifiers which should have one ObjectPermission for each of
+     *     the given permission types.
+     *
+     * @param types
+     *     The permissions which should be granted for each of the given
+     *     identifiers.
+     *
+     * @return
+     *     A new set of ObjectPermissions containing one ObjectPermission for
+     *     each possible combination of the given identifiers and permission
+     *     types.
+     */
+    private static Set<ObjectPermission> createPermissions(Collection<String> identifiers,
+            Collection<ObjectPermission.Type> types) {
+
+        // Add a permission of each type to the set for each identifier given
+        Set<ObjectPermission> permissions = new HashSet<>(identifiers.size());
+        types.forEach(type -> {
+            identifiers.forEach(identifier -> permissions.add(new ObjectPermission(type, identifier)));
+        });
+
+        return permissions;
+
+    }
+
+    /**
+     * Creates a new SimpleObjectPermissionSet which contains permissions for
+     * all possible unique combinations of the given identifiers and permission
+     * types.
+     *
+     * @param identifiers
+     *     The identifiers which should be associated permissions having each
+     *     of the given permission types.
+     *
+     * @param types
+     *     The types of permissions which should be granted for each of the
+     *     given identifiers.
+     */
+    public SimpleObjectPermissionSet(Collection<String> identifiers,
+            Collection<ObjectPermission.Type> types) {
+        this(createPermissions(identifiers, types));
+    }
+
+    /**
+     * Creates a new SimpleObjectPermissionSet which contains only READ
+     * permissions for each of the given identifiers.
+     *
+     * @param identifiers
+     *     The identifiers which should each be associated with READ
+     *     permission.
+     */
+    public SimpleObjectPermissionSet(Collection<String> identifiers) {
+        this(identifiers, Collections.singletonList(ObjectPermission.Type.READ));
     }
 
     /**

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleObjectPermissionSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleObjectPermissionSet.java
@@ -41,7 +41,10 @@ public class SimpleObjectPermissionSet implements ObjectPermissionSet {
     private Set<ObjectPermission> permissions = Collections.<ObjectPermission>emptySet();
 
     /**
-     * Creates a new empty SimpleObjectPermissionSet.
+     * Creates a new empty SimpleObjectPermissionSet. If you are not extending
+     * SimpleObjectPermissionSet and only need an immutable, empty
+     * ObjectPermissionSet, consider using {@link ObjectPermissionSet#EMPTY_SET}
+     * instead.
      */
     public SimpleObjectPermissionSet() {
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleRelatedObjectSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleRelatedObjectSet.java
@@ -37,7 +37,10 @@ public class SimpleRelatedObjectSet implements RelatedObjectSet {
     private Set<String> identifiers = Collections.<String>emptySet();
 
     /**
-     * Creates a new empty SimpleObjectPermissionSet.
+     * Creates a new empty SimpleRelatedObjectSet. If you are not extending
+     * SimpleRelatedObjectSet and only need an immutable, empty
+     * RelatedObjectSet, consider using {@link RelatedObjectSet#EMPTY_SET}
+     * instead.
      */
     public SimpleRelatedObjectSet() {
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleSystemPermissionSet.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleSystemPermissionSet.java
@@ -38,7 +38,10 @@ public class SimpleSystemPermissionSet implements SystemPermissionSet {
     private Set<SystemPermission> permissions = Collections.<SystemPermission>emptySet();
 
     /**
-     * Creates a new empty SimpleSystemPermissionSet.
+     * Creates a new empty SimpleSystemPermissionSet. If you are not extending
+     * SimpleSystemPermissionSet and only need an immutable, empty
+     * SystemPermissionSet, consider using {@link SystemPermissionSet#EMPTY_SET}
+     * instead.
      */
     public SimpleSystemPermissionSet() {
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
@@ -20,20 +20,12 @@
 package org.apache.guacamole.net.auth.simple;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AbstractUser;
-import org.apache.guacamole.net.auth.ActivityRecord;
-import org.apache.guacamole.net.auth.Permissions;
-import org.apache.guacamole.net.auth.RelatedObjectSet;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
-import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 
 /**
  * A read-only User implementation which has no permissions. Implementations
@@ -70,10 +62,7 @@ public class SimpleUser extends AbstractUser {
      *     The username to assign to this SimpleUser.
      */
     public SimpleUser(String username) {
-
-        // Set username
         super.setIdentifier(username);
-
     }
 
     /**
@@ -173,32 +162,6 @@ public class SimpleUser extends AbstractUser {
     }
 
     @Override
-    public Map<String, String> getAttributes() {
-        return Collections.<String, String>emptyMap();
-    }
-
-    @Override
-    public void setAttributes(Map<String, String> attributes) {
-        // Do nothing - there are no attributes
-    }
-
-    @Override
-    public Date getLastActive() {
-        return null;
-    }
-
-    @Override
-    public List<ActivityRecord> getHistory() throws GuacamoleException {
-        return Collections.<ActivityRecord>emptyList();
-    }
-
-    @Override
-    public SystemPermissionSet getSystemPermissions()
-            throws GuacamoleException {
-        return SystemPermissionSet.EMPTY_SET;
-    }
-
-    @Override
     public ObjectPermissionSet getConnectionPermissions()
             throws GuacamoleException {
         return new SimpleObjectPermissionSet(connectionPermissions);
@@ -214,33 +177,6 @@ public class SimpleUser extends AbstractUser {
     public ObjectPermissionSet getUserPermissions()
             throws GuacamoleException {
         return new SimpleObjectPermissionSet(userPermissions);
-    }
-
-    @Override
-    public ObjectPermissionSet getUserGroupPermissions()
-            throws GuacamoleException {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getActiveConnectionPermissions()
-            throws GuacamoleException {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getSharingProfilePermissions() {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public RelatedObjectSet getUserGroups() throws GuacamoleException {
-        return RelatedObjectSet.EMPTY_SET;
-    }
-
-    @Override
-    public Permissions getEffectivePermissions() throws GuacamoleException {
-        return this;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
@@ -46,11 +46,6 @@ public class SimpleUser extends AbstractUser {
     private final Set<ObjectPermission> userPermissions = new HashSet<>();
 
     /**
-     * All user group permissions granted to this user.
-     */
-    private final Set<ObjectPermission> userGroupPermissions = new HashSet<>();
-
-    /**
      * All connection permissions granted to this user.
      */
     private final Set<ObjectPermission> connectionPermissions = new HashSet<>();
@@ -115,7 +110,15 @@ public class SimpleUser extends AbstractUser {
      * @param connectionGroupIdentifiers
      *     The identifiers of all connection groups this user has READ access
      *     to.
+     *
+     * @deprecated
+     *     Extend and override the applicable permission set getters instead,
+     *     relying on SimpleUser to expose no permissions by default for all
+     *     permission sets that aren't overridden. See {@link SimpleObjectPermissionSet}
+     *     for convenient methods of providing a read-only permission set with
+     *     specific permissions.
      */
+    @Deprecated
     public SimpleUser(String username,
             Collection<String> connectionIdentifiers,
             Collection<String> connectionGroupIdentifiers) {
@@ -123,43 +126,6 @@ public class SimpleUser extends AbstractUser {
         this(username);
 
         // Add permissions
-        addReadPermissions(connectionPermissions,      connectionIdentifiers);
-        addReadPermissions(connectionGroupPermissions, connectionGroupIdentifiers);
-
-    }
-
-    /**
-     * Creates a new SimpleUser having the given username and READ access to
-     * the users, user groups, connections, and connection groups having the
-     * given identifiers.
-     *
-     * @param username
-     *     The username to assign to this SimpleUser.
-     *
-     * @param userIdentifiers
-     *     The identifiers of all users this user has READ access to.
-     *
-     * @param userGroupIdentifiers
-     *     The identifiers of all user groups this user has READ access to.
-     *
-     * @param connectionIdentifiers
-     *     The identifiers of all connections this user has READ access to.
-     *
-     * @param connectionGroupIdentifiers
-     *     The identifiers of all connection groups this user has READ access
-     *     to.
-     */
-    public SimpleUser(String username,
-            Collection<String> userIdentifiers,
-            Collection<String> userGroupIdentifiers,
-            Collection<String> connectionIdentifiers,
-            Collection<String> connectionGroupIdentifiers) {
-
-        this(username);
-
-        // Add permissions
-        addReadPermissions(userPermissions,            userIdentifiers);
-        addReadPermissions(userGroupPermissions,       userGroupIdentifiers);
         addReadPermissions(connectionPermissions,      connectionIdentifiers);
         addReadPermissions(connectionGroupPermissions, connectionGroupIdentifiers);
 
@@ -181,7 +147,15 @@ public class SimpleUser extends AbstractUser {
      * @param connectionGroupIdentifiers
      *     The identifiers of all connection groups this user has READ access
      *     to.
+     *
+     * @deprecated
+     *     Extend and override the applicable permission set getters instead,
+     *     relying on SimpleUser to expose no permissions by default for all
+     *     permission sets that aren't overridden. See {@link SimpleObjectPermissionSet}
+     *     for convenient methods of providing a read-only permission set with
+     *     specific permissions.
      */
+    @Deprecated
     public SimpleUser(String username,
             Collection<String> userIdentifiers,
             Collection<String> connectionIdentifiers,

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
@@ -193,7 +193,7 @@ public class SimpleUser extends AbstractUser {
     @Override
     public SystemPermissionSet getSystemPermissions()
             throws GuacamoleException {
-        return new SimpleSystemPermissionSet();
+        return SystemPermissionSet.EMPTY_SET;
     }
 
     @Override
@@ -217,23 +217,23 @@ public class SimpleUser extends AbstractUser {
     @Override
     public ObjectPermissionSet getUserGroupPermissions()
             throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getActiveConnectionPermissions()
             throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getSharingProfilePermissions() {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public RelatedObjectSet getUserGroups() throws GuacamoleException {
-        return new SimpleRelatedObjectSet();
+        return RelatedObjectSet.EMPTY_SET;
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
@@ -41,22 +41,24 @@ import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 public class SimpleUser extends AbstractUser {
 
     /**
-     * All connection permissions granted to this user.
+     * All user permissions granted to this user.
      */
-    private final Set<ObjectPermission> userPermissions =
-            new HashSet<ObjectPermission>();
+    private final Set<ObjectPermission> userPermissions = new HashSet<>();
+
+    /**
+     * All user group permissions granted to this user.
+     */
+    private final Set<ObjectPermission> userGroupPermissions = new HashSet<>();
 
     /**
      * All connection permissions granted to this user.
      */
-    private final Set<ObjectPermission> connectionPermissions =
-            new HashSet<ObjectPermission>();
+    private final Set<ObjectPermission> connectionPermissions = new HashSet<>();
     
     /**
      * All connection group permissions granted to this user.
      */
-    private final Set<ObjectPermission> connectionGroupPermissions =
-            new HashSet<ObjectPermission>();
+    private final Set<ObjectPermission> connectionGroupPermissions = new HashSet<>();
 
     /**
      * Creates a completely uninitialized SimpleUser.
@@ -73,7 +75,7 @@ public class SimpleUser extends AbstractUser {
     public SimpleUser(String username) {
 
         // Set username
-        setIdentifier(username);
+        super.setIdentifier(username);
 
     }
 
@@ -92,18 +94,17 @@ public class SimpleUser extends AbstractUser {
             Collection<String> identifiers) {
 
         // Add a READ permission to the set for each identifier given
-        for (String identifier : identifiers) {
-            permissions.add(new ObjectPermission (
+        identifiers.forEach(identifier ->
+            permissions.add(new ObjectPermission(
                 ObjectPermission.Type.READ,
-                identifier
+                identifier)
             ));
-        }
 
     }
-    
+
     /**
      * Creates a new SimpleUser having the given username and READ access to
-     * the connections and groups having the given identifiers.
+     * the connections and connection groups having the given identifiers.
      *
      * @param username
      *     The username to assign to this SimpleUser.
@@ -122,6 +123,43 @@ public class SimpleUser extends AbstractUser {
         this(username);
 
         // Add permissions
+        addReadPermissions(connectionPermissions,      connectionIdentifiers);
+        addReadPermissions(connectionGroupPermissions, connectionGroupIdentifiers);
+
+    }
+
+    /**
+     * Creates a new SimpleUser having the given username and READ access to
+     * the users, user groups, connections, and connection groups having the
+     * given identifiers.
+     *
+     * @param username
+     *     The username to assign to this SimpleUser.
+     *
+     * @param userIdentifiers
+     *     The identifiers of all users this user has READ access to.
+     *
+     * @param userGroupIdentifiers
+     *     The identifiers of all user groups this user has READ access to.
+     *
+     * @param connectionIdentifiers
+     *     The identifiers of all connections this user has READ access to.
+     *
+     * @param connectionGroupIdentifiers
+     *     The identifiers of all connection groups this user has READ access
+     *     to.
+     */
+    public SimpleUser(String username,
+            Collection<String> userIdentifiers,
+            Collection<String> userGroupIdentifiers,
+            Collection<String> connectionIdentifiers,
+            Collection<String> connectionGroupIdentifiers) {
+
+        this(username);
+
+        // Add permissions
+        addReadPermissions(userPermissions,            userIdentifiers);
+        addReadPermissions(userGroupPermissions,       userGroupIdentifiers);
         addReadPermissions(connectionPermissions,      connectionIdentifiers);
         addReadPermissions(connectionGroupPermissions, connectionGroupIdentifiers);
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUser.java
@@ -36,7 +36,9 @@ import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 
 /**
- * An extremely basic User implementation.
+ * A read-only User implementation which has no permissions. Implementations
+ * that need to define permissions should extend this class and override the
+ * associated getters.
  */
 public class SimpleUser extends AbstractUser {
 
@@ -62,7 +64,7 @@ public class SimpleUser extends AbstractUser {
     }
 
     /**
-     * Creates a new SimpleUser having the given username and no permissions.
+     * Creates a new SimpleUser having the given username.
      *
      * @param username
      *     The username to assign to this SimpleUser.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
@@ -19,7 +19,6 @@
 
 package org.apache.guacamole.net.auth.simple;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.guacamole.GuacamoleException;
@@ -29,6 +28,7 @@ import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.User;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
 
 /**
@@ -113,20 +113,19 @@ public class SimpleUserContext extends AbstractUserContext {
 
     @Override
     public User self() {
+        return new SimpleUser(username) {
 
-        try {
-            return new SimpleUser(username,
-                    getConnectionDirectory().getIdentifiers(),
-                    getConnectionGroupDirectory().getIdentifiers()
-            );
-        }
+            @Override
+            public ObjectPermissionSet getConnectionGroupPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(getConnectionDirectory().getIdentifiers());
+            }
 
-        catch (GuacamoleException e) {
-            return new SimpleUser(username,
-                    Collections.<String>emptySet(),
-                    Collections.<String>emptySet());
-        }
+            @Override
+            public ObjectPermissionSet getConnectionPermissions() throws GuacamoleException {
+                return new SimpleObjectPermissionSet(getConnectionGroupDirectory().getIdentifiers());
+            }
 
+        };
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth.simple;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractIdentifiable;
+import org.apache.guacamole.net.auth.RelatedObjectSet;
+import org.apache.guacamole.net.auth.UserGroup;
+import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
+import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
+
+/**
+ * A read-only UserGroup implementation which has no members.
+ */
+public class SimpleUserGroup extends AbstractIdentifiable implements UserGroup {
+
+    /**
+     * Creates a completely uninitialized SimpleUserGroup.
+     */
+    public SimpleUserGroup() {
+    }
+
+    /**
+     * Creates a new SimpleUserGroup having the given identifier.
+     *
+     * @param identifier
+     *     The identifier to assign to this SimpleUserGroup.
+     */
+    public SimpleUserGroup(String identifier) {
+        super.setIdentifier(identifier);
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+        return Collections.<String, String>emptyMap();
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+        // Do nothing - there are no attributes
+    }
+
+    @Override
+    public SystemPermissionSet getSystemPermissions()
+            throws GuacamoleException {
+        return new SimpleSystemPermissionSet();
+    }
+
+    @Override
+    public ObjectPermissionSet getConnectionPermissions()
+            throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public ObjectPermissionSet getConnectionGroupPermissions()
+            throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public ObjectPermissionSet getUserPermissions()
+            throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public ObjectPermissionSet getUserGroupPermissions()
+            throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public ObjectPermissionSet getActiveConnectionPermissions()
+            throws GuacamoleException {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public ObjectPermissionSet getSharingProfilePermissions() {
+        return new SimpleObjectPermissionSet();
+    }
+
+    @Override
+    public RelatedObjectSet getUserGroups() throws GuacamoleException {
+        return new SimpleRelatedObjectSet();
+    }
+
+    @Override
+    public RelatedObjectSet getMemberUsers() throws GuacamoleException {
+        return new SimpleRelatedObjectSet();
+    }
+
+    @Override
+    public RelatedObjectSet getMemberUserGroups() throws GuacamoleException {
+        return new SimpleRelatedObjectSet();
+    }
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
@@ -29,7 +29,9 @@ import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
 import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
 
 /**
- * A read-only UserGroup implementation which has no members.
+ * A read-only UserGroup implementation which has no members and no
+ * permissions. Implementations that need to define members or permissions
+ * should extend this class and override the associated getters.
  */
 public class SimpleUserGroup extends AbstractIdentifiable implements UserGroup {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
@@ -62,57 +62,57 @@ public class SimpleUserGroup extends AbstractIdentifiable implements UserGroup {
     @Override
     public SystemPermissionSet getSystemPermissions()
             throws GuacamoleException {
-        return new SimpleSystemPermissionSet();
+        return SystemPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getConnectionPermissions()
             throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getConnectionGroupPermissions()
             throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getUserPermissions()
             throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getUserGroupPermissions()
             throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getActiveConnectionPermissions()
             throws GuacamoleException {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public ObjectPermissionSet getSharingProfilePermissions() {
-        return new SimpleObjectPermissionSet();
+        return ObjectPermissionSet.EMPTY_SET;
     }
 
     @Override
     public RelatedObjectSet getUserGroups() throws GuacamoleException {
-        return new SimpleRelatedObjectSet();
+        return RelatedObjectSet.EMPTY_SET;
     }
 
     @Override
     public RelatedObjectSet getMemberUsers() throws GuacamoleException {
-        return new SimpleRelatedObjectSet();
+        return RelatedObjectSet.EMPTY_SET;
     }
 
     @Override
     public RelatedObjectSet getMemberUserGroups() throws GuacamoleException {
-        return new SimpleRelatedObjectSet();
+        return RelatedObjectSet.EMPTY_SET;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserGroup.java
@@ -19,21 +19,14 @@
 
 package org.apache.guacamole.net.auth.simple;
 
-import java.util.Collections;
-import java.util.Map;
-import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.net.auth.AbstractIdentifiable;
-import org.apache.guacamole.net.auth.RelatedObjectSet;
-import org.apache.guacamole.net.auth.UserGroup;
-import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
-import org.apache.guacamole.net.auth.permission.SystemPermissionSet;
+import org.apache.guacamole.net.auth.AbstractUserGroup;
 
 /**
  * A read-only UserGroup implementation which has no members and no
  * permissions. Implementations that need to define members or permissions
  * should extend this class and override the associated getters.
  */
-public class SimpleUserGroup extends AbstractIdentifiable implements UserGroup {
+public class SimpleUserGroup extends AbstractUserGroup {
 
     /**
      * Creates a completely uninitialized SimpleUserGroup.
@@ -49,72 +42,6 @@ public class SimpleUserGroup extends AbstractIdentifiable implements UserGroup {
      */
     public SimpleUserGroup(String identifier) {
         super.setIdentifier(identifier);
-    }
-
-    @Override
-    public Map<String, String> getAttributes() {
-        return Collections.<String, String>emptyMap();
-    }
-
-    @Override
-    public void setAttributes(Map<String, String> attributes) {
-        // Do nothing - there are no attributes
-    }
-
-    @Override
-    public SystemPermissionSet getSystemPermissions()
-            throws GuacamoleException {
-        return SystemPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getConnectionPermissions()
-            throws GuacamoleException {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getConnectionGroupPermissions()
-            throws GuacamoleException {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getUserPermissions()
-            throws GuacamoleException {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getUserGroupPermissions()
-            throws GuacamoleException {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getActiveConnectionPermissions()
-            throws GuacamoleException {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public ObjectPermissionSet getSharingProfilePermissions() {
-        return ObjectPermissionSet.EMPTY_SET;
-    }
-
-    @Override
-    public RelatedObjectSet getUserGroups() throws GuacamoleException {
-        return RelatedObjectSet.EMPTY_SET;
-    }
-
-    @Override
-    public RelatedObjectSet getMemberUsers() throws GuacamoleException {
-        return RelatedObjectSet.EMPTY_SET;
-    }
-
-    @Override
-    public RelatedObjectSet getMemberUserGroups() throws GuacamoleException {
-        return RelatedObjectSet.EMPTY_SET;
     }
 
 }


### PR DESCRIPTION
These changes add support for querying user groups from an LDAP directory, exposing those groups using Guacamole's new user group API.

The groups which apply to an authenticated user are exposed as effective groups, allowing other authentication providers to dictate permissions based on their own identically-named groups. As with LDAP users, LDAP user groups are additionally exposed in a read-only manner such that they can be easily selected within the admin interface.

To avoid further duplicating LDAP query code, the common aspects of LDAP queries within Guacamole have been abstracted into `ObjectQueryService`, with existing services refactored accordingly.

Additional convenience objects missing from the user group API were also added (`SimpleUserGroup` and `AbstractUserGroup`). The refactor adding these classes involved:

* Adding `EMPTY_SET` convenience constants to remove the need to create new empty permission sets everywhere.
* Deprecating the built-in permission support of `SimpleUser` to keep things in line with the simpler (and arguably more sensible) design of `SimpleUserGroup`.
* Adding convenience constructors to the various sets to make non-deprecated usage of `SimpleUser` and `SimpleUserGroup` easy.