### PR TITLE
GUACAMOLE-670: Add slf4j logging to CAS and RADIUS modules

### DIFF
--- a/extensions/guacamole-auth-cas/pom.xml
+++ b/extensions/guacamole-auth-cas/pom.xml
@@ -227,6 +227,12 @@
             <groupId>org.jasig.cas.client</groupId>
             <artifactId>cas-client-core</artifactId>
             <version>3.4.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Guice -->
@@ -246,14 +252,6 @@
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>2.5</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- slf4j Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.7</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-cas/pom.xml
+++ b/extensions/guacamole-auth-cas/pom.xml
@@ -249,6 +249,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- slf4j Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.7</version>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/guacamole-auth-radius/pom.xml
+++ b/extensions/guacamole-auth-radius/pom.xml
@@ -230,6 +230,14 @@
             <artifactId>jradius-extended</artifactId>
             <version>1.1.5</version>
         </dependency>
+        
+        <!-- slf4j Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.7</version>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/guacamole-auth-radius/pom.xml
+++ b/extensions/guacamole-auth-radius/pom.xml
@@ -215,6 +215,12 @@
             <groupId>net.jradius</groupId>
             <artifactId>jradius-core</artifactId>
             <version>1.1.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- JRadius Dictionary, for accessing packet attributes -->
@@ -229,14 +235,6 @@
             <groupId>net.jradius</groupId>
             <artifactId>jradius-extended</artifactId>
             <version>1.1.5</version>
-        </dependency>
-        
-        <!-- slf4j Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.7</version>
-            <scope>provided</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Looks like there are some differing versions of slf4j getting pulled into some of the extension modules by other dependencies, and causing errors to occur when loading the modules.  This adds the explicit dependency to the pom.xml files for the modules exhibiting these issues.