### PR TITLE
GUACAMOLE-598: Ignore if current user has no associated data.

### DIFF
--- a/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacUserMenu.js
@@ -95,12 +95,9 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
              */
             $scope.role = null;
 
-            // Pull user data
+            // Display user profile attributes if available
             userService.getUser(authenticationService.getDataSource(), $scope.username)
                     .then(function userRetrieved(user) {
-
-                // Store retrieved user object
-                $scope.user = user;
 
                 // Pull basic profile information
                 $scope.fullName = user.attributes[User.Attributes.FULL_NAME];
@@ -111,7 +108,7 @@ angular.module('navigation').directive('guacUserMenu', [function guacUserMenu() 
                 var email = user.attributes[User.Attributes.EMAIL_ADDRESS];
                 $scope.userURL = email ? 'mailto:' + email : null;
 
-            }, requestService.DIE);
+            }, requestService.IGNORE);
 
             /**
              * The available main pages for the current user.


### PR DESCRIPTION
Authentication providers are not required to provide data for the users they authenticate. In this case, the data is needed only to display optional human-readable profile attributes instead of the username. If no such attributes are available, the username is used instead.