### PR TITLE
GUACAMOLE-680: Rearrange logout handling

### DIFF
--- a/guacamole/src/main/webapp/app/auth/service/authenticationService.js
+++ b/guacamole/src/main/webapp/app/auth/service/authenticationService.js
@@ -301,6 +301,7 @@ angular.module('auth').factory('authenticationService', ['$injector',
         
         .then(function logoutCompleted(data) {
             
+            // Notify listeners that logout has been completed
             $rootScope.$broadcast('guacLogout', data);
             
         });

--- a/guacamole/src/main/webapp/app/auth/service/authenticationService.js
+++ b/guacamole/src/main/webapp/app/auth/service/authenticationService.js
@@ -297,6 +297,12 @@ angular.module('auth').factory('authenticationService', ['$injector',
         return requestService({
             method: 'DELETE',
             url: 'api/tokens/' + token
+        })
+        
+        .then(function logoutCompleted(data) {
+            
+            $rootScope.$broadcast('guacLogout', data);
+            
         });
 
     };

--- a/guacamole/src/main/webapp/app/auth/service/authenticationService.js
+++ b/guacamole/src/main/webapp/app/auth/service/authenticationService.js
@@ -290,8 +290,8 @@ angular.module('auth').factory('authenticationService', ['$injector',
         var token = service.getCurrentToken();
         clearAuthenticationResult();
 
-        // Notify listeners that a token is being destroyed
-        $rootScope.$broadcast('guacLogout', token);
+        // Notify listeners that a token is about to be destroyed
+        $rootScope.$broadcast('beforeGuacLogout', token);
 
         // Delete old token
         return requestService({

--- a/guacamole/src/main/webapp/app/rest/services/cacheService.js
+++ b/guacamole/src/main/webapp/app/rest/services/cacheService.js
@@ -78,7 +78,7 @@ angular.module('rest').factory('cacheService', ['$injector',
     };
 
     // Clear caches on logout
-    $rootScope.$on('guacLogout', function handleLogout() {
+    $rootScope.$on('beforeGuacLogout', function handleLogout() {
         service.clearCaches();
     });
 

--- a/guacamole/src/main/webapp/app/settings/services/preferenceService.js
+++ b/guacamole/src/main/webapp/app/settings/services/preferenceService.js
@@ -178,7 +178,7 @@ angular.module('settings').provider('preferenceService', ['$injector',
         });
 
         // Persist settings upon logout
-        $rootScope.$on('guacLogout', function handleLogout() {
+        $rootScope.$on('beforeGuacLogout', function handleLogout() {
             service.save();
         });
 

--- a/guacamole/src/main/webapp/app/storage/services/sessionStorageFactory.js
+++ b/guacamole/src/main/webapp/app/storage/services/sessionStorageFactory.js
@@ -88,7 +88,7 @@ angular.module('storage').factory('sessionStorageFactory', ['$injector', functio
         });
 
         // Reset value and disallow storage when the user is logged out
-        $rootScope.$on('guacLogout', function userLoggedOut() {
+        $rootScope.$on('beforeGuacLogout', function userLoggedOut() {
 
             // Call destructor before storage is teared down
             if (angular.isDefined(value) && destructor)


### PR DESCRIPTION
Per discussion on the mailing list, I've taken a stab at renaming the pre-logout broadcast and implenting a post-logout broadcast in order to set up the possibility that events could be fired by the web application after the Guacamole logout has completed.  No idea if this is what was intended, but took a shot...

[1] - http://mail-archives.apache.org/mod_mbox/guacamole-dev/201812.mbox/%3CCALKeL-O1XQBAGFE17_jgB_OC5%2Bf-uCCEgfOiHbn39XyGRm7s6Q%40mail.gmail.com%3E