### PR TITLE
GUACAMOLE-678: Implement new UriGuacamoleProperty

### DIFF
--- a/extensions/guacamole-auth-cas/pom.xml
+++ b/extensions/guacamole-auth-cas/pom.xml
@@ -261,6 +261,14 @@
             <version>2.5</version>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- Jersey - JAX-RS Implementation -->
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
@@ -19,7 +19,7 @@
 
 package org.apache.guacamole.auth.cas.conf;
 
-import org.apache.guacamole.properties.UriGuacamoleProperty;
+import org.apache.guacamole.properties.URIGuacamoleProperty;
 
 /**
  * Provides properties required for use of the CAS authentication provider.
@@ -36,8 +36,8 @@ public class CASGuacamoleProperties {
     /**
      * The authorization endpoint (URI) of the CAS service.
      */
-    public static final UriGuacamoleProperty CAS_AUTHORIZATION_ENDPOINT =
-            new UriGuacamoleProperty() {
+    public static final URIGuacamoleProperty CAS_AUTHORIZATION_ENDPOINT =
+            new URIGuacamoleProperty() {
 
         @Override
         public String getName() { return "cas-authorization-endpoint"; }
@@ -49,8 +49,8 @@ public class CASGuacamoleProperties {
      * authentication process is complete. This must be the full URL that a
      * user would enter into their browser to access Guacamole.
      */
-    public static final UriGuacamoleProperty CAS_REDIRECT_URI =
-            new UriGuacamoleProperty() {
+    public static final URIGuacamoleProperty CAS_REDIRECT_URI =
+            new URIGuacamoleProperty() {
 
         @Override
         public String getName() { return "cas-redirect-uri"; }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
@@ -19,7 +19,7 @@
 
 package org.apache.guacamole.auth.cas.conf;
 
-import org.apache.guacamole.properties.StringGuacamoleProperty;
+import org.apache.guacamole.properties.UriGuacamoleProperty;
 
 /**
  * Provides properties required for use of the CAS authentication provider.
@@ -36,8 +36,8 @@ public class CASGuacamoleProperties {
     /**
      * The authorization endpoint (URI) of the CAS service.
      */
-    public static final StringGuacamoleProperty CAS_AUTHORIZATION_ENDPOINT =
-            new StringGuacamoleProperty() {
+    public static final UriGuacamoleProperty CAS_AUTHORIZATION_ENDPOINT =
+            new UriGuacamoleProperty() {
 
         @Override
         public String getName() { return "cas-authorization-endpoint"; }
@@ -49,8 +49,8 @@ public class CASGuacamoleProperties {
      * authentication process is complete. This must be the full URL that a
      * user would enter into their browser to access Guacamole.
      */
-    public static final StringGuacamoleProperty CAS_REDIRECT_URI =
-            new StringGuacamoleProperty() {
+    public static final UriGuacamoleProperty CAS_REDIRECT_URI =
+            new UriGuacamoleProperty() {
 
         @Override
         public String getName() { return "cas-redirect-uri"; }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.auth.cas.conf;
 
 import com.google.inject.Inject;
+import java.net.URI;
 import java.security.PrivateKey;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
@@ -47,7 +48,7 @@ public class ConfigurationService {
      *     If guacamole.properties cannot be parsed, or if the authorization
      *     endpoint property is missing.
      */
-    public String getAuthorizationEndpoint() throws GuacamoleException {
+    public URI getAuthorizationEndpoint() throws GuacamoleException {
         return environment.getRequiredProperty(CASGuacamoleProperties.CAS_AUTHORIZATION_ENDPOINT);
     }
 
@@ -65,7 +66,7 @@ public class ConfigurationService {
      *     If guacamole.properties cannot be parsed, or if the redirect URI
      *     property is missing.
      */
-    public String getRedirectURI() throws GuacamoleException {
+    public URI getRedirectURI() throws GuacamoleException {
         return environment.getRequiredProperty(CASGuacamoleProperties.CAS_REDIRECT_URI);
     }
 

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/form/CASTicketField.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/form/CASTicketField.java
@@ -19,8 +19,8 @@
 
 package org.apache.guacamole.auth.cas.form;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import java.net.URI;
+import javax.ws.rs.core.UriBuilder;
 import org.apache.guacamole.form.Field;
 
 
@@ -47,7 +47,7 @@ public class CASTicketField extends Field {
     /**
      * The full URI which the field should link to.
      */
-    private final String authorizationURI;
+    private final URI authorizationURI;
 
     /**
      * Creates a new CAS "ticket" field which links to the given CAS
@@ -65,29 +65,15 @@ public class CASTicketField extends Field {
      *     The URI that the CAS service should redirect to upon successful
      *     authentication.
      */
-    public CASTicketField(String authorizationEndpoint, String redirectURI) {
+    public CASTicketField(URI authorizationEndpoint, URI redirectURI) {
 
         // Init base field properties
         super(PARAMETER_NAME, "GUAC_CAS_TICKET");
-
-        // Build authorization URI from given values
-        try {
-            final StringBuilder sb = new StringBuilder();
-            sb.append(authorizationEndpoint);
-            // user might configure the endpoint with a trailing slash
-            if (sb.charAt(sb.length() - 1) != '/') {
-                sb.append('/');
-            }
-            sb.append(CAS_LOGIN_URI);
-            sb.append("?service=");
-            sb.append(URLEncoder.encode(redirectURI, "UTF-8"));
-            this.authorizationURI = sb.toString();
-        }
-
-        // Java is required to provide UTF-8 support
-        catch (UnsupportedEncodingException e) {
-            throw new UnsupportedOperationException("Unexpected lack of UTF-8 support.", e);
-        }
+        
+        this.authorizationURI = UriBuilder.fromUri(authorizationEndpoint)
+                .path(CAS_LOGIN_URI)
+                .queryParam("service", redirectURI)
+                .build();
 
     }
 
@@ -99,7 +85,7 @@ public class CASTicketField extends Field {
      *     The full URI that this field should link to.
      */
     public String getAuthorizationURI() {
-        return authorizationURI;
+        return authorizationURI.toString();
     }
 
 }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
@@ -21,6 +21,7 @@ package org.apache.guacamole.auth.cas.ticket;
 
 import com.google.common.io.BaseEncoding;
 import com.google.inject.Inject;
+import java.net.URI;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -83,13 +84,13 @@ public class TicketValidationService {
         // Retrieve the configured CAS URL, establish a ticket validator,
         // and then attempt to validate the supplied ticket.  If that succeeds,
         // grab the principal returned by the validator.
-        String casServerUrl = confService.getAuthorizationEndpoint();
-        Cas20ProxyTicketValidator validator = new Cas20ProxyTicketValidator(casServerUrl);
+        URI casServerUrl = confService.getAuthorizationEndpoint();
+        Cas20ProxyTicketValidator validator = new Cas20ProxyTicketValidator(casServerUrl.toString());
         validator.setAcceptAnyProxy(true);
         validator.setEncoding("UTF-8");
         try {
-            String confRedirectURI = confService.getRedirectURI();
-            Assertion a = validator.validate(ticket, confRedirectURI);
+            URI confRedirectURI = confService.getRedirectURI();
+            Assertion a = validator.validate(ticket, confRedirectURI.toString());
             AttributePrincipal principal =  a.getPrincipal();
 
             // Retrieve username and set the credentials.

--- a/extensions/guacamole-auth-openid/pom.xml
+++ b/extensions/guacamole-auth-openid/pom.xml
@@ -246,6 +246,14 @@
             <version>2.5</version>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- Jersey - JAX-RS Implementation -->
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
@@ -25,7 +25,7 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
-import org.apache.guacamole.properties.UriGuacamoleProperty;
+import org.apache.guacamole.properties.URIGuacamoleProperty;
 
 /**
  * Service for retrieving configuration information regarding the OpenID
@@ -65,8 +65,8 @@ public class ConfigurationService {
     /**
      * The authorization endpoint (URI) of the OpenID service.
      */
-    private static final UriGuacamoleProperty OPENID_AUTHORIZATION_ENDPOINT =
-            new UriGuacamoleProperty() {
+    private static final URIGuacamoleProperty OPENID_AUTHORIZATION_ENDPOINT =
+            new URIGuacamoleProperty() {
 
         @Override
         public String getName() { return "openid-authorization-endpoint"; }
@@ -77,8 +77,8 @@ public class ConfigurationService {
      * The endpoint (URI) of the JWKS service which defines how received ID
      * tokens (JWTs) shall be validated.
      */
-    private static final UriGuacamoleProperty OPENID_JWKS_ENDPOINT =
-            new UriGuacamoleProperty() {
+    private static final URIGuacamoleProperty OPENID_JWKS_ENDPOINT =
+            new URIGuacamoleProperty() {
 
         @Override
         public String getName() { return "openid-jwks-endpoint"; }
@@ -176,8 +176,8 @@ public class ConfigurationService {
      * authentication process is complete. This must be the full URL that a
      * user would enter into their browser to access Guacamole.
      */
-    private static final UriGuacamoleProperty OPENID_REDIRECT_URI =
-            new UriGuacamoleProperty() {
+    private static final URIGuacamoleProperty OPENID_REDIRECT_URI =
+            new URIGuacamoleProperty() {
 
         @Override
         public String getName() { return "openid-redirect-uri"; }

--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
@@ -20,10 +20,12 @@
 package org.apache.guacamole.auth.openid.conf;
 
 import com.google.inject.Inject;
+import java.net.URI;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
+import org.apache.guacamole.properties.UriGuacamoleProperty;
 
 /**
  * Service for retrieving configuration information regarding the OpenID
@@ -63,8 +65,8 @@ public class ConfigurationService {
     /**
      * The authorization endpoint (URI) of the OpenID service.
      */
-    private static final StringGuacamoleProperty OPENID_AUTHORIZATION_ENDPOINT =
-            new StringGuacamoleProperty() {
+    private static final UriGuacamoleProperty OPENID_AUTHORIZATION_ENDPOINT =
+            new UriGuacamoleProperty() {
 
         @Override
         public String getName() { return "openid-authorization-endpoint"; }
@@ -75,8 +77,8 @@ public class ConfigurationService {
      * The endpoint (URI) of the JWKS service which defines how received ID
      * tokens (JWTs) shall be validated.
      */
-    private static final StringGuacamoleProperty OPENID_JWKS_ENDPOINT =
-            new StringGuacamoleProperty() {
+    private static final UriGuacamoleProperty OPENID_JWKS_ENDPOINT =
+            new UriGuacamoleProperty() {
 
         @Override
         public String getName() { return "openid-jwks-endpoint"; }
@@ -174,8 +176,8 @@ public class ConfigurationService {
      * authentication process is complete. This must be the full URL that a
      * user would enter into their browser to access Guacamole.
      */
-    private static final StringGuacamoleProperty OPENID_REDIRECT_URI =
-            new StringGuacamoleProperty() {
+    private static final UriGuacamoleProperty OPENID_REDIRECT_URI =
+            new UriGuacamoleProperty() {
 
         @Override
         public String getName() { return "openid-redirect-uri"; }
@@ -200,7 +202,7 @@ public class ConfigurationService {
      *     If guacamole.properties cannot be parsed, or if the authorization
      *     endpoint property is missing.
      */
-    public String getAuthorizationEndpoint() throws GuacamoleException {
+    public URI getAuthorizationEndpoint() throws GuacamoleException {
         return environment.getRequiredProperty(OPENID_AUTHORIZATION_ENDPOINT);
     }
 
@@ -236,7 +238,7 @@ public class ConfigurationService {
      *     If guacamole.properties cannot be parsed, or if the redirect URI
      *     property is missing.
      */
-    public String getRedirectURI() throws GuacamoleException {
+    public URI getRedirectURI() throws GuacamoleException {
         return environment.getRequiredProperty(OPENID_REDIRECT_URI);
     }
 
@@ -270,7 +272,7 @@ public class ConfigurationService {
      *     If guacamole.properties cannot be parsed, or if the JWKS endpoint
      *     property is missing.
      */
-    public String getJWKSEndpoint() throws GuacamoleException {
+    public URI getJWKSEndpoint() throws GuacamoleException {
         return environment.getRequiredProperty(OPENID_JWKS_ENDPOINT);
     }
 

--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/form/TokenField.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/form/TokenField.java
@@ -19,8 +19,8 @@
 
 package org.apache.guacamole.auth.openid.form;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import java.net.URI;
+import javax.ws.rs.core.UriBuilder;
 import org.apache.guacamole.form.Field;
 
 /**
@@ -38,7 +38,7 @@ public class TokenField extends Field {
     /**
      * The full URI which the field should link to.
      */
-    private final String authorizationURI;
+    private final URI authorizationURI;
 
     /**
      * Creates a new field which requests authentication via OpenID connect.
@@ -69,26 +69,19 @@ public class TokenField extends Field {
      *     A random string unique to this request. To defend against replay
      *     attacks, this value must cease being valid after its first use.
      */
-    public TokenField(String authorizationEndpoint, String scope,
-            String clientID, String redirectURI, String nonce) {
+    public TokenField(URI authorizationEndpoint, String scope,
+            String clientID, URI redirectURI, String nonce) {
 
         // Init base field properties
         super(PARAMETER_NAME, "GUAC_OPENID_TOKEN");
 
-        // Build authorization URI from given values
-        try {
-            this.authorizationURI = authorizationEndpoint
-                    + "?scope=" + URLEncoder.encode(scope, "UTF-8")
-                    + "&response_type=id_token"
-                    + "&client_id=" + URLEncoder.encode(clientID, "UTF-8")
-                    + "&redirect_uri=" + URLEncoder.encode(redirectURI, "UTF-8")
-                    + "&nonce=" + nonce;
-        }
-
-        // Java is required to provide UTF-8 support
-        catch (UnsupportedEncodingException e) {
-            throw new UnsupportedOperationException("Unexpected lack of UTF-8 support.", e);
-        }
+        this.authorizationURI = UriBuilder.fromUri(authorizationEndpoint)
+                .queryParam("scope", scope)
+                .queryParam("response_type", "id_token")
+                .queryParam("client_id","clientID")
+                .queryParam("redirect_uri", redirectURI)
+                .queryParam("nonce", nonce)
+                .build();
 
     }
 
@@ -100,7 +93,7 @@ public class TokenField extends Field {
      *     The full URI that this field should link to.
      */
     public String getAuthorizationURI() {
-        return authorizationURI;
+        return authorizationURI.toString();
     }
 
 }

--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/token/TokenValidationService.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/token/TokenValidationService.java
@@ -74,7 +74,7 @@ public class TokenValidationService {
     public String processUsername(String token) throws GuacamoleException {
 
         // Validating the token requires a JWKS key resolver
-        HttpsJwks jwks = new HttpsJwks(confService.getJWKSEndpoint());
+        HttpsJwks jwks = new HttpsJwks(confService.getJWKSEndpoint().toString());
         HttpsJwksVerificationKeyResolver resolver = new HttpsJwksVerificationKeyResolver(jwks);
 
         // Create JWT consumer for validating received token

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/URIGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/URIGuacamoleProperty.java
@@ -27,7 +27,7 @@ import org.apache.guacamole.GuacamoleServerException;
 /**
  * A GuacamoleProperty whose value is a URI.
  */
-public abstract class UriGuacamoleProperty implements GuacamoleProperty<URI> {
+public abstract class URIGuacamoleProperty implements GuacamoleProperty<URI> {
     
     @Override
     public URI parseValue(String value) throws GuacamoleException {

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/UriGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/UriGuacamoleProperty.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.properties;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+
+/**
+ * A GuacamoleProperty whose value is a URI.
+ */
+public abstract class UriGuacamoleProperty implements GuacamoleProperty<URI> {
+    
+    @Override
+    public URI parseValue(String value) throws GuacamoleException {
+        
+        try {
+            return new URI(value);
+        }
+        catch (URISyntaxException e) {
+            throw new GuacamoleServerException("Value \"" + value
+                + "\" is not a valid URI.");
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
This PR implements a new property type, the `UriGuacamoleProperty`, which parses a string into a URI.  Several of the extensions were converted to use the new property, and I also added properties to the JDBC modules that allow for configuring the connection with a single URI property rather than the individual components.  Providing this type of property allows for validation of URI/URLs in the configuration file, catching errors when the configuration is loaded.

The other advantage of using URI is that, from what I have read, it takes care of all of the encoding of the various URL parts internal, which avoids the need to explicitly use `URLEncoder`.

For the JDBC modules, I configured it such that, if the URI is specified, the other module parameters are completely ignored.  This could go the other direction where the URI is the base and the others override it, if desired - it would be a pretty easy change.