### PR TITLE
GUACAMOLE-683: Add OpenID support in Docker Build Scripts

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -126,3 +126,11 @@ if [ -f extensions/guacamole-auth-radius/target/guacamole-auth-radius*.jar ]; th
     mkdir -p "$DESTINATION/radius"
     cp extensions/guacamole-auth-radius/target/guacamole-auth-radius*.jar "$DESTINATION/radius"
 fi
+
+# Copy OPENID auth extension and schema modifications
+#
+
+if [ -f extensions/guacamole-auth-openid/target/guacamole-auth-openid*.jar ]; then
+    mkdir -p "$DESTINATION/openid"
+    cp extensions/guacamole-auth-openid/target/guacamole-auth-openid*.jar "$DESTINATION/openid"
+fi


### PR DESCRIPTION
This change introduces openid authentication support for the docker build.
Openid is sorted as a first module to make it work together with database. 

The patch was tested together with this commit https://github.com/mike-jumper/guacamole-client/commit/a62a3dcb1125f4bc2dc562016e41df82a3d415db
to make it work against keycloak as openid provider.