### PR TITLE
GUACAMOLE-684: Insufficient credentials should take precedence over other failures

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -36,6 +36,7 @@ import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
 import org.apache.guacamole.net.auth.credentials.GuacamoleCredentialsException;
+import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredentialsException;
 import org.apache.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
 import org.apache.guacamole.net.event.AuthenticationFailureEvent;
 import org.apache.guacamole.net.event.AuthenticationSuccessEvent;
@@ -170,7 +171,13 @@ public class AuthenticationService {
                     return authenticatedUser;
             }
 
-            // First failure takes priority for now
+            // Insufficient credentials should take precedence
+            catch (GuacamoleInsufficientCredentialsException e) {
+                if (authFailure == null || authFailure instanceof GuacamoleInvalidCredentialsException)
+                    authFailure = e;
+            }
+            
+            // Catch other credentials exceptions and assign the first one
             catch (GuacamoleCredentialsException e) {
                 if (authFailure == null)
                     authFailure = e;


### PR DESCRIPTION
This resolves an issue where, depending on the order of stacked authentication modules, `GuacamoleInsufficientCredentialsException`s are overriden by `GuacamoleInvalidCredentialsException`s that occur prior to the insufficient exceptions.  This particular issue has come up with the RADIUS module when it gets a challenge/response and is stacked on top of the JDBC module, where the JDBC authentication occurs (and fails) prior to the RADIUS authentication attempt, and the additional credentials are never requested.