### PR TITLE
GUACAMOLE-577: Support for configuring the Guacamole Proxy in LDAP Connections

### DIFF
--- a/extensions/guacamole-auth-ldap/schema/guacConfigGroup.ldif
+++ b/extensions/guacamole-auth-ldap/schema/guacConfigGroup.ldif
@@ -20,9 +20,24 @@
 dn: cn=guacConfigGroup,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: guacConfigGroup
-olcAttributeTypes: {0}( 1.3.6.1.4.1.38971.1.1.1 NAME 'guacConfigProtocol' SYNTAX 1.3.6.1.4.1.1466
- .115.121.1.15 )
-olcAttributeTypes: {1}( 1.3.6.1.4.1.38971.1.1.2 NAME 'guacConfigParameter' SYNTAX 1.3.6.1.4.1.146
- 6.115.121.1.15 )
-olcObjectClasses: {0}( 1.3.6.1.4.1.38971.1.2.1 NAME 'guacConfigGroup' DESC 'Guacamole config
- uration group' SUP groupOfNames MUST guacConfigProtocol MAY guacConfigParameter )
+
+olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.1 NAME 'guacConfigProtocol'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.2 NAME 'guacConfigParameter'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.3 NAME 'guacConfigProxyHostname'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.4 NAME 'guacConfigProxyPort'
+  SINGLE-VALUE
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.5 NAME 'guacConfigProxyEncryption'
+  SINGLE-VALUE
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+olcObjectClasses: ( 1.3.6.1.4.1.38971.1.2.1 NAME 'guacConfigGroup'
+  DESC 'Guacamole configuration group'
+  SUP groupOfNames
+  MUST guacConfigProtocol
+  MAY ( guacConfigParameter $
+  guacConfigProxyHostname $
+  guacConfigProxyPort $
+  guacConfigProxyEncryption ) )

--- a/extensions/guacamole-auth-ldap/schema/guacConfigGroup.schema
+++ b/extensions/guacamole-auth-ldap/schema/guacConfigGroup.schema
@@ -18,14 +18,28 @@
 #
 
 attributetype ( 1.3.6.1.4.1.38971.1.1.1 NAME 'guacConfigProtocol'
-	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
 attributetype ( 1.3.6.1.4.1.38971.1.1.2 NAME 'guacConfigParameter'
-	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+attributetype ( 1.3.6.1.4.1.38971.1.1.3 NAME 'guacConfigProxyHostname'
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
+attributetype ( 1.3.6.1.4.1.38971.1.1.4 NAME 'guacConfigProxyPort'
+    SINGLE-VALUE
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+
+attributetype ( 1.3.6.1.4.1.38971.1.1.5 NAME 'guacConfigProxyEncryption'
+    SINGLE-VALUE
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
 objectClass ( 1.3.6.1.4.1.38971.1.2.1 NAME 'guacConfigGroup'
     DESC 'Guacamole configuration group'
     SUP groupOfNames
     MUST guacConfigProtocol
-    MAY guacConfigParameter )
+    MAY ( guacConfigParameter $
+          guacConfigProxyHostname $
+          guacConfigProxyPort $
+          guacConfigProxyEncryption ) )
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
@@ -24,7 +24,6 @@ import java.util.Date;
 import java.util.Map;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
-import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.environment.LocalEnvironment;
 import org.apache.guacamole.net.GuacamoleSocket;
 import org.apache.guacamole.net.GuacamoleTunnel;
@@ -53,6 +52,11 @@ public class SimpleConnection extends AbstractConnection {
      * Backing configuration, containing all sensitive information.
      */
     private GuacamoleConfiguration fullConfig;
+    
+    /**
+     * The proxy configuration describing how to connect to guacd.
+     */
+    private GuacamoleProxyConfiguration proxyConfig;
 
     /**
      * Whether parameter tokens in the underlying GuacamoleConfiguration should
@@ -158,6 +162,39 @@ public class SimpleConnection extends AbstractConnection {
         this.interpretTokens = interpretTokens;
 
     }
+    
+    /**
+     * Creates a new SimpleConnection having the given identifier,
+     * GuacamoleConfiguration, and GuacamoleProxyConfiguration. Parameter tokens
+     * will be interpreted if explicitly requested.
+     *
+     * @param name
+     *     The name to associate with this connection.
+     *
+     * @param identifier
+     *     The identifier to associate with this connection.
+     * 
+     * @param proxyConfig
+     *     The Guacamole proxy configuration describing how the connection to
+     *     guacd should be established, or null if the default settings will be
+     *     used.
+     *
+     * @param config
+     *     The configuration describing how to connect to this connection.
+     *
+     * @param interpretTokens
+     *     Whether parameter tokens in the underlying GuacamoleConfiguration
+     *     should be automatically applied upon connecting. If false, parameter
+     *     tokens will not be interpreted at all.
+     */
+    public SimpleConnection(String name, String identifier,
+            GuacamoleProxyConfiguration proxyConfig,
+            GuacamoleConfiguration config, boolean interpretTokens) {
+
+        this(name, identifier, config, interpretTokens);
+        this.proxyConfig = proxyConfig;
+
+    }
 
     /**
      * Returns the GuacamoleConfiguration describing how to connect to this
@@ -201,9 +238,9 @@ public class SimpleConnection extends AbstractConnection {
     public GuacamoleTunnel connect(GuacamoleClientInformation info)
             throws GuacamoleException {
 
-        // Retrieve proxy configuration from environment
-        Environment environment = LocalEnvironment.getInstance();
-        GuacamoleProxyConfiguration proxyConfig = environment.getDefaultGuacamoleProxyConfiguration();
+        // Retrieve proxy configuration from environment if we don't have one
+        if (proxyConfig == null)
+            proxyConfig = LocalEnvironment.getInstance().getDefaultGuacamoleProxyConfiguration();
 
         // Get guacd connection parameters
         String hostname = proxyConfig.getHostname();


### PR DESCRIPTION
This pull request implements the changes necessary to support the `GuacamoleProxyConfiguration` in LDAP connections (and any future extensions that make use of the `SimpleConnection` class.  Not entirely sure this is the right/best way to go, but took a stab at it.