### PR TITLE
[WIP] GUACAMOLE-706: added variable to define link name of RADIUS extension

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -405,7 +405,14 @@ END
        "$RADIUS_EAP_TTLS_INNER_PROTOCOL"
 
     # Add required .jar files to GUACAMOLE_EXT
-    ln -s /opt/guacamole/radius/guacamole-auth-*.jar "$GUACAMOLE_EXT"
+    # Since extensions are loaded in alphabetical order you can explicitly name
+    # the link to influence the order in which guacamole extensions are loaded.
+    # E.g. RADIUS_EXT_LINKNAME=1-guacamole-auth-radius.jar
+    if [ -n "$RADIUS_EXT_LINKNAME" ]; then
+        ln -s /opt/guacamole/radius/guacamole-auth-*.jar "$GUACAMOLE_EXT/${RADIUS_EXT_LINKNAME}.jar"
+    else
+        ln -s /opt/guacamole/radius/guacamole-auth-*.jar "$GUACAMOLE_EXT"
+    fi
 }
 
 ## Adds properties to guacamole.properties which select the OPENID


### PR DESCRIPTION
To combine authentication extension for RADIUS with database authentication extensions it is required to change the order of extensions being loaded. Since by default extensions are being loaded alphabetically and extensions are called in the order loaded, the name of the RADIUS authentication extension needs to be changed when the docker container is created.