### PR TITLE
GUACAMOLE-524: Update connect() API changes for backward compatibility with 1.0.0.

### DIFF
--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectDirectory.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectDirectory.java
@@ -107,7 +107,7 @@ public class QuickConnectDirectory extends SimpleDirectory<Connection> {
         String name = QCParser.getName(config);
 
         // Create a new connection and set the parent identifier.
-        Connection connection = new SimpleConnection(name, newConnectionId, config);
+        Connection connection = new SimpleConnection(name, newConnectionId, config, true);
         connection.setParentIdentifier(QuickConnectUserContext.ROOT_IDENTIFIER);
 
         // Place the object in this directory.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connectable.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connectable.java
@@ -19,7 +19,6 @@
 
 package org.apache.guacamole.net.auth;
 
-import java.util.Collections;
 import java.util.Map;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.GuacamoleTunnel;
@@ -30,36 +29,14 @@ import org.apache.guacamole.protocol.GuacamoleClientInformation;
  */
 public interface Connectable {
 
-    /**
-     * Establishes a connection to guacd using the information associated with
-     * this object. The connection will be provided the given client
-     * information.
-     *
-     * @deprecated
-     *     This function has been deprecated in favor of
-     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)},
-     *     which allows for connection parameter tokens to be injected and
-     *     applied by cooperating extensions, replacing the functionality
-     *     previously provided through the {@link org.apache.guacamole.token.StandardTokens}
-     *     class. It continues to be defined on this interface for
-     *     compatibility. <strong>New implementations should instead implement
-     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)}.</strong>
-     *
-     * @param info
-     *     Information associated with the connecting client.
-     *
-     * @return
-     *     A fully-established GuacamoleTunnel.
-     *
-     * @throws GuacamoleException
-     *     If an error occurs while connecting to guacd, or if permission to
-     *     connect is denied.
+    /*
+     * IMPORTANT:
+     * ----------
+     * The web application (guacamole) defines its own version of this
+     * interface containing defaults which allow backwards compatibility with
+     * 1.0.0. Any changes to this interface MUST be properly reflected in that
+     * copy of the interface such that they are binary compatible.
      */
-    @Deprecated
-    default GuacamoleTunnel connect(GuacamoleClientInformation info)
-            throws GuacamoleException {
-        return this.connect(info, Collections.emptyMap());
-    }
 
     /**
      * Establishes a connection to guacd using the information associated with
@@ -67,17 +44,6 @@ public interface Connectable {
      * information. Implementations which support parameter tokens should
      * apply the given tokens when configuring the connection, such as with a
      * {@link org.apache.guacamole.token.TokenFilter}.
-     *
-     * <p>A default implementation which invokes the old, deprecated
-     * {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation)}
-     * is provided solely for compatibility with extensions which implement only
-     * the deprecated function. This default implementation is useful only
-     * for extensions relying on the deprecated function and will be removed
-     * when the deprecated function is removed.
-     *
-     * <p><strong>New implementations should always implement this function
-     * in favor of the deprecated
-     * {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation)}.</strong>
      *
      * @see <a href="http://guacamole.apache.org/doc/gug/configuring-guacamole.html#parameter-tokens">Parameter Tokens</a>
      *
@@ -97,13 +63,8 @@ public interface Connectable {
      *     If an error occurs while connecting to guacd, or if permission to
      *     connect is denied.
      */
-    default GuacamoleTunnel connect(GuacamoleClientInformation info,
-            Map<String, String> tokens) throws GuacamoleException {
-
-        // Allow old implementations of Connectable to continue to work
-        return this.connect(info);
-
-    }
+    public GuacamoleTunnel connect(GuacamoleClientInformation info,
+            Map<String, String> tokens) throws GuacamoleException;
 
     /**
      * Returns the number of active connections associated with this object.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connectable.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connectable.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.net.auth;
 
+import java.util.Collections;
 import java.util.Map;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.GuacamoleTunnel;
@@ -32,9 +33,51 @@ public interface Connectable {
     /**
      * Establishes a connection to guacd using the information associated with
      * this object. The connection will be provided the given client
+     * information.
+     *
+     * @deprecated
+     *     This function has been deprecated in favor of
+     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)},
+     *     which allows for connection parameter tokens to be injected and
+     *     applied by cooperating extensions, replacing the functionality
+     *     previously provided through the {@link org.apache.guacamole.token.StandardTokens}
+     *     class. It continues to be defined on this interface for
+     *     compatibility. <strong>New implementations should instead implement
+     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)}.</strong>
+     *
+     * @param info
+     *     Information associated with the connecting client.
+     *
+     * @return
+     *     A fully-established GuacamoleTunnel.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while connecting to guacd, or if permission to
+     *     connect is denied.
+     */
+    @Deprecated
+    default GuacamoleTunnel connect(GuacamoleClientInformation info)
+            throws GuacamoleException {
+        return this.connect(info, Collections.emptyMap());
+    }
+
+    /**
+     * Establishes a connection to guacd using the information associated with
+     * this object. The connection will be provided the given client
      * information. Implementations which support parameter tokens should
      * apply the given tokens when configuring the connection, such as with a
      * {@link org.apache.guacamole.token.TokenFilter}.
+     *
+     * <p>A default implementation which invokes the old, deprecated
+     * {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation)}
+     * is provided solely for compatibility with extensions which implement only
+     * the deprecated function. This default implementation is useful only
+     * for extensions relying on the deprecated function and will be removed
+     * when the deprecated function is removed.
+     *
+     * <p><strong>New implementations should always implement this function
+     * in favor of the deprecated
+     * {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation)}.</strong>
      *
      * @see <a href="http://guacamole.apache.org/doc/gug/configuring-guacamole.html#parameter-tokens">Parameter Tokens</a>
      *
@@ -54,8 +97,13 @@ public interface Connectable {
      *     If an error occurs while connecting to guacd, or if permission to
      *     connect is denied.
      */
-    public GuacamoleTunnel connect(GuacamoleClientInformation info,
-            Map<String, String> tokens) throws GuacamoleException;
+    default GuacamoleTunnel connect(GuacamoleClientInformation info,
+            Map<String, String> tokens) throws GuacamoleException {
+
+        // Allow old implementations of Connectable to continue to work
+        return this.connect(info);
+
+    }
 
     /**
      * Returns the number of active connections associated with this object.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connectable.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connectable.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.net.auth;
 
+import java.util.Collections;
 import java.util.Map;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.GuacamoleTunnel;
@@ -37,6 +38,37 @@ public interface Connectable {
      * 1.0.0. Any changes to this interface MUST be properly reflected in that
      * copy of the interface such that they are binary compatible.
      */
+
+    /**
+     * Establishes a connection to guacd using the information associated with
+     * this object. The connection will be provided the given client
+     * information.
+     *
+     * @deprecated
+     *     This function has been deprecated in favor of
+     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)},
+     *     which allows for connection parameter tokens to be injected and
+     *     applied by cooperating extensions, replacing the functionality
+     *     previously provided through the {@link org.apache.guacamole.token.StandardTokens}
+     *     class. It continues to be defined on this interface for
+     *     compatibility. <strong>New implementations should instead implement
+     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)}.</strong>
+     *
+     * @param info
+     *     Information associated with the connecting client.
+     *
+     * @return
+     *     A fully-established GuacamoleTunnel.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while connecting to guacd, or if permission to
+     *     connect is denied.
+     */
+    @Deprecated
+    default GuacamoleTunnel connect(GuacamoleClientInformation info)
+            throws GuacamoleException {
+        return this.connect(info, Collections.emptyMap());
+    }
 
     /**
      * Establishes a connection to guacd using the information associated with

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingConnectionGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingConnectionGroup.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.net.auth;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import org.apache.guacamole.GuacamoleException;
@@ -35,6 +36,25 @@ public class DelegatingConnectionGroup implements ConnectionGroup {
      * The wrapped ConnectionGroup.
      */
     private final ConnectionGroup connectionGroup;
+
+    /**
+     * The tokens which should apply strictly to the next call to
+     * {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation)}.
+     * This storage is intended as a temporary bridge allowing the old version
+     * of connect() to be overridden while still resulting in the same behavior
+     * as older versions of DelegatingConnectionGroup. <strong>This storage
+     * should be removed once support for the old, deprecated connect() is
+     * removed.</strong>
+     */
+    private final ThreadLocal<Map<String, String>> currentTokens =
+            new ThreadLocal<Map<String, String>>() {
+
+        @Override
+        protected Map<String, String> initialValue() {
+            return Collections.emptyMap();
+        }
+
+    };
 
     /**
      * Wraps the given ConnectionGroup such that all function calls against this
@@ -119,9 +139,26 @@ public class DelegatingConnectionGroup implements ConnectionGroup {
     }
 
     @Override
+    @Deprecated
+    public GuacamoleTunnel connect(GuacamoleClientInformation info)
+            throws GuacamoleException {
+        return connectionGroup.connect(info, currentTokens.get());
+    }
+
+    @Override
     public GuacamoleTunnel connect(GuacamoleClientInformation info,
             Map<String, String> tokens) throws GuacamoleException {
-        return connectionGroup.connect(info, tokens);
+
+        // Make received tokens available within the legacy connect() strictly
+        // in context of the current connect() call
+        try {
+            currentTokens.set(tokens);
+            return connect(info);
+        }
+        finally {
+            currentTokens.remove();
+        }
+
     }
 
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleAuthenticationProvider.java
@@ -167,7 +167,7 @@ public abstract class SimpleAuthenticationProvider
             return null;
 
         // Return user context restricted to authorized configs
-        return new SimpleUserContext(this, authenticatedUser.getIdentifier(), configs);
+        return new SimpleUserContext(this, authenticatedUser.getIdentifier(), configs, true);
 
     }
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
@@ -41,10 +41,10 @@ import org.apache.guacamole.protocol.GuacamoleConfiguration;
 import org.apache.guacamole.token.TokenFilter;
 
 /**
- * An extremely basic Connection implementation. The underlying connection to
- * guacd is established using the configuration information provided in
- * guacamole.properties. Parameter tokens provided to connect() are
- * automatically applied. Tracking of active connections and connection history
+ * A Connection implementation which establishes the underlying connection to
+ * guacd using the configuration information provided in guacamole.properties.
+ * Parameter tokens provided to connect() are automatically applied if
+ * explicitly requested. Tracking of active connections and connection history
  * is not provided.
  */
 public class SimpleConnection extends AbstractConnection {
@@ -162,10 +162,11 @@ public class SimpleConnection extends AbstractConnection {
 
     /**
      * Returns the GuacamoleConfiguration describing how to connect to this
-     * connection. Unlike the GuacamoleConfiguration returned by
-     * {@link #getConfiguration()}, which may omit or tokenize information,
-     * the GuacamoleConfiguration returned by this function contains the full
-     * configuration to be used to establish the connection.
+     * connection. Unlike {@link #getConfiguration()}, which is allowed to omit
+     * or tokenize information, the GuacamoleConfiguration returned by this
+     * function will always be the full configuration to be used to establish
+     * the connection, as provided when this SimpleConnection was created or via
+     * {@link #setConfiguration(org.apache.guacamole.protocol.GuacamoleConfiguration)}.
      *
      * @return
      *     The full GuacamoleConfiguration describing how to connect to this
@@ -244,6 +245,19 @@ public class SimpleConnection extends AbstractConnection {
 
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation will connect using the GuacamoleConfiguration
+     * returned by {@link #getFullConfiguration()}, honoring the
+     * "guacd-hostname", "guacd-port", and "guacd-ssl" properties set within
+     * guacamole.properties. Parameter tokens will be taken into account if
+     * the SimpleConnection was explicitly requested to do so when created.
+     *
+     * <p>Implementations requiring more complex behavior should consider using
+     * the {@link AbstractConnection} base class or implementing
+     * {@link Connection} directly.
+     */
     @Override
     public GuacamoleTunnel connect(GuacamoleClientInformation info,
             Map<String, String> tokens) throws GuacamoleException {

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
@@ -196,31 +196,7 @@ public class SimpleConnection extends AbstractConnection {
         // Do nothing - there are no attributes
     }
 
-    /**
-     * Establishes a connection to guacd using the information associated with
-     * this object. The connection will be provided the given client
-     * information.
-     *
-     * <p>This definition is the legacy connect() definition from 1.0.0 and
-     * older. It is redefined here for the sake of ABI compatibility with
-     * 1.0.0 but is no longer defined within the
-     * {@link org.apache.guacamole.net.auth.Connectable} interface.
-     *
-     * @deprecated
-     *     This definition exists solely for binary compatibility. It should
-     *     never be used by new code. New implementations should instead use
-     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)}.
-     *
-     * @param info
-     *     Information associated with the connecting client.
-     *
-     * @return
-     *     A fully-established GuacamoleTunnel.
-     *
-     * @throws GuacamoleException
-     *     If an error occurs while connecting to guacd, or if permission to
-     *     connect is denied.
-     */
+    @Override
     @Deprecated
     public GuacamoleTunnel connect(GuacamoleClientInformation info)
             throws GuacamoleException {

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
@@ -97,8 +97,7 @@ public class SimpleConnection extends AbstractConnection {
      * be set before the SimpleConnection may be used. Parameter tokens within
      * the GuacamoleConfiguration eventually supplied with
      * {@link #setConfiguration(org.apache.guacamole.protocol.GuacamoleConfiguration)}
-     * will not be interpreted unless explicitly requested with
-     * {@link #setInterpretTokens(boolean)}.
+     * will not be interpreted unless explicitly requested.
      *
      * @param interpretTokens
      *     Whether parameter tokens in the underlying GuacamoleConfiguration
@@ -113,7 +112,7 @@ public class SimpleConnection extends AbstractConnection {
      * Creates a new SimpleConnection having the given identifier and
      * GuacamoleConfiguration. Parameter tokens within the
      * GuacamoleConfiguration will not be interpreted unless explicitly
-     * requested with {@link #setInterpretTokens(boolean)}.
+     * requested.
      *
      * @param name
      *     The name to associate with this connection.
@@ -256,7 +255,7 @@ public class SimpleConnection extends AbstractConnection {
      *
      * <p>Implementations requiring more complex behavior should consider using
      * the {@link AbstractConnection} base class or implementing
-     * {@link Connection} directly.
+     * {@link org.apache.guacamole.net.auth.Connection} directly.
      */
     @Override
     public GuacamoleTunnel connect(GuacamoleClientInformation info,

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
@@ -196,8 +196,32 @@ public class SimpleConnection extends AbstractConnection {
         // Do nothing - there are no attributes
     }
 
-    @Override
-    @SuppressWarnings("deprecation")
+    /**
+     * Establishes a connection to guacd using the information associated with
+     * this object. The connection will be provided the given client
+     * information.
+     *
+     * <p>This definition is the legacy connect() definition from 1.0.0 and
+     * older. It is redefined here for the sake of ABI compatibility with
+     * 1.0.0 but is no longer defined within the
+     * {@link org.apache.guacamole.net.auth.Connectable} interface.
+     *
+     * @deprecated
+     *     This definition exists solely for binary compatibility. It should
+     *     never be used by new code. New implementations should instead use
+     *     {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation, java.util.Map)}.
+     *
+     * @param info
+     *     Information associated with the connecting client.
+     *
+     * @return
+     *     A fully-established GuacamoleTunnel.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while connecting to guacd, or if permission to
+     *     connect is denied.
+     */
+    @Deprecated
     public GuacamoleTunnel connect(GuacamoleClientInformation info)
             throws GuacamoleException {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnection.java
@@ -52,7 +52,7 @@ public class SimpleConnection extends AbstractConnection {
     /**
      * Backing configuration, containing all sensitive information.
      */
-    private GuacamoleConfiguration config;
+    private GuacamoleConfiguration fullConfig;
 
     /**
      * Creates a completely uninitialized SimpleConnection.
@@ -71,17 +71,34 @@ public class SimpleConnection extends AbstractConnection {
      */
     public SimpleConnection(String name, String identifier,
             GuacamoleConfiguration config) {
-        
-        // Set name
-        setName(name);
 
-        // Set identifier
-        setIdentifier(identifier);
+        super.setName(name);
+        super.setIdentifier(identifier);
+        super.setConfiguration(config);
 
-        // Set config
-        setConfiguration(config);
-        this.config = config;
+        this.fullConfig = config;
 
+    }
+
+    /**
+     * Returns the GuacamoleConfiguration describing how to connect to this
+     * connection. Unlike the GuacamoleConfiguration returned by
+     * {@link #getConfiguration()}, which may omit or tokenize information,
+     * the GuacamoleConfiguration returned by this function contains the full
+     * configuration to be used to establish the connection.
+     *
+     * @return
+     *     The full GuacamoleConfiguration describing how to connect to this
+     *     connection, without any information omitted or tokenized.
+     */
+    protected GuacamoleConfiguration getFullConfiguration() {
+        return fullConfig;
+    }
+
+    @Override
+    public void setConfiguration(GuacamoleConfiguration config) {
+        super.setConfiguration(config);
+        this.fullConfig = config;
     }
 
     @Override
@@ -112,7 +129,7 @@ public class SimpleConnection extends AbstractConnection {
         int port = proxyConfig.getPort();
 
         // Apply tokens to config parameters
-        GuacamoleConfiguration filteredConfig = new GuacamoleConfiguration(config);
+        GuacamoleConfiguration filteredConfig = new GuacamoleConfiguration(getFullConfiguration());
         new TokenFilter(tokens).filterValues(filteredConfig.getParameters());
 
         GuacamoleSocket socket;

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnectionGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleConnectionGroup.java
@@ -47,7 +47,7 @@ public class SimpleConnectionGroup extends AbstractConnectionGroup {
      * The identifiers of all connection groups in this group.
      */
     private final Set<String> connectionGroupIdentifiers;
-    
+
     /**
      * Creates a new SimpleConnectionGroup having the given name and identifier
      * which will expose the given contents.
@@ -109,9 +109,16 @@ public class SimpleConnectionGroup extends AbstractConnectionGroup {
     }
 
     @Override
+    @Deprecated
+    public GuacamoleTunnel connect(GuacamoleClientInformation info)
+            throws GuacamoleException {
+        throw new GuacamoleSecurityException("Permission denied.");
+    }
+
+    @Override
     public GuacamoleTunnel connect(GuacamoleClientInformation info,
             Map<String, String> tokens) throws GuacamoleException {
-        throw new GuacamoleSecurityException("Permission denied.");
+        return connect(info);
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
@@ -129,7 +129,7 @@ public class SimpleUserContext extends AbstractUserContext {
             GuacamoleConfiguration config = configEntry.getValue();
 
             // Add as simple connection
-            Connection connection = new SimpleConnection(identifier, identifier, config, true);
+            Connection connection = new SimpleConnection(identifier, identifier, config, interpretTokens);
             connection.setParentIdentifier(DEFAULT_ROOT_CONNECTION_GROUP);
             connections.put(identifier, connection);
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/simple/SimpleUserContext.java
@@ -59,7 +59,8 @@ public class SimpleUserContext extends AbstractUserContext {
      * Creates a new SimpleUserContext which provides access to only those
      * configurations within the given Map. The username is set to the
      * ANONYMOUS_IDENTIFIER defined by AuthenticatedUser, effectively declaring
-     * the current user as anonymous.
+     * the current user as anonymous. Parameter tokens within the given
+     * GuacamoleConfigurations will not be interpreted.
      *
      * @param authProvider
      *     The AuthenticationProvider creating this UserContext.
@@ -76,6 +77,8 @@ public class SimpleUserContext extends AbstractUserContext {
     /**
      * Creates a new SimpleUserContext for the user with the given username
      * which provides access to only those configurations within the given Map.
+     * Parameter tokens within the given GuacamoleConfigurations will not be
+     * interpreted.
      *
      * @param authProvider
      *     The AuthenticationProvider creating this UserContext.
@@ -89,6 +92,33 @@ public class SimpleUserContext extends AbstractUserContext {
      */
     public SimpleUserContext(AuthenticationProvider authProvider,
             String username, Map<String, GuacamoleConfiguration> configs) {
+        this(authProvider, username, configs, false);
+    }
+
+    /**
+     * Creates a new SimpleUserContext for the user with the given username
+     * which provides access to only those configurations within the given Map.
+     * Parameter tokens within the given GuacamoleConfigurations will be
+     * interpreted if explicitly requested.
+     *
+     * @param authProvider
+     *     The AuthenticationProvider creating this UserContext.
+     *
+     * @param username
+     *     The username of the user associated with this UserContext.
+     *
+     * @param configs
+     *     A Map of all configurations for which the user associated with
+     *     this UserContext has read access.
+     *
+     * @param interpretTokens
+     *     Whether parameter tokens in the underlying GuacamoleConfigurations
+     *     should be automatically applied upon connecting. If false, parameter
+     *     tokens will not be interpreted at all.
+     */
+    public SimpleUserContext(AuthenticationProvider authProvider,
+            String username, Map<String, GuacamoleConfiguration> configs,
+            boolean interpretTokens) {
 
         // Produce map of connections from given configs
         Map<String, Connection> connections = new ConcurrentHashMap<String, Connection>(configs.size());
@@ -99,7 +129,7 @@ public class SimpleUserContext extends AbstractUserContext {
             GuacamoleConfiguration config = configEntry.getValue();
 
             // Add as simple connection
-            Connection connection = new SimpleConnection(identifier, identifier, config);
+            Connection connection = new SimpleConnection(identifier, identifier, config, true);
             connection.setParentIdentifier(DEFAULT_ROOT_CONNECTION_GROUP);
             connections.put(identifier, connection);
 

--- a/guacamole/src/main/java/org/apache/guacamole/net/auth/Connectable.java
+++ b/guacamole/src/main/java/org/apache/guacamole/net/auth/Connectable.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.GuacamoleTunnel;
+import org.apache.guacamole.protocol.GuacamoleClientInformation;
+
+/**
+ * Internal, ABI-compatible version of the Connectable interface from
+ * guacamole-ext which defines fallback defaults for older versions of the API.
+ * As this interface will take precedence in the servlet container's
+ * classloader over the definition from guacamole-ext, this allows backwards
+ * compatibility with the 1.0.0 API while keeping the actual API definition
+ * within guacamole-ext strict.
+ *
+ * <p>For this to work, this interface definition <strong>MUST</strong> be 100%
+ * ABI-compatible with the Connectable interface defined by guacamole-ext in
+ * 1.0.0 and onward.
+ */
+public interface Connectable {
+
+    /**
+     * Establishes a connection to guacd using the information associated with
+     * this object. The connection will be provided the given client
+     * information.
+     *
+     * <p>This definition is the legacy connect() definition from 1.0.0 and
+     * older. It is redefined here for the sake of ABI compatibility with
+     * 1.0.0 but is no longer defined within guacamole-ext.
+     *
+     * @deprecated
+     *     This definition exists solely for binary compatibility. It should
+     *     never be used by new code. New implementations should instead use
+     *     the current version of connect() as defined by guacamole-ext.
+     *
+     * @param info
+     *     Information associated with the connecting client.
+     *
+     * @return
+     *     A fully-established GuacamoleTunnel.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while connecting to guacd, or if permission to
+     *     connect is denied.
+     */
+    @Deprecated
+    default GuacamoleTunnel connect(GuacamoleClientInformation info)
+            throws GuacamoleException {
+
+        // Pass through usages of the old API to the new API
+        return this.connect(info, Collections.emptyMap());
+
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This definition is the current version of connect() as defined by
+     * guacamole-ext.
+     *
+     * <p>A default implementation which invokes the old, deprecated
+     * {@link #connect(org.apache.guacamole.protocol.GuacamoleClientInformation)}
+     * is provided solely for compatibility with extensions which implement only
+     * the old version of this function. This default implementation is useful
+     * only for extensions relying on the older API and will be removed when
+     * support for that version of the API is removed.
+     *
+     * @see
+     *     The definition of getActiveConnections() in the current version of
+     *     the Connectable interface, as defined by guacamole-ext.
+     */
+    default GuacamoleTunnel connect(GuacamoleClientInformation info,
+            Map<String, String> tokens) throws GuacamoleException {
+
+        // Allow old implementations of Connectable to continue to work
+        return this.connect(info);
+
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see
+     *     The definition of getActiveConnections() in the current version of
+     *     the Connectable interface, as defined by guacamole-ext.
+     */
+    int getActiveConnections();
+    
+}

--- a/guacamole/src/main/java/org/apache/guacamole/net/auth/Connectable.java
+++ b/guacamole/src/main/java/org/apache/guacamole/net/auth/Connectable.java
@@ -46,7 +46,7 @@ public interface Connectable {
      *
      * <p>This definition is the legacy connect() definition from 1.0.0 and
      * older. It is redefined here for the sake of ABI compatibility with
-     * 1.0.0 but is no longer defined within guacamole-ext.
+     * 1.0.0 but is deprecated within guacamole-ext.
      *
      * @deprecated
      *     This definition exists solely for binary compatibility. It should


### PR DESCRIPTION
[As discussed on dev@](https://lists.apache.org/thread.html/c74221a629bd2da53996b0f6e4cfebc4647ac1239aa8817a45fd0c12@%3Cdev.guacamole.apache.org%3E), these changes modify the `Connectable` interface such that implementations of the previous version of the `connect()` function will continue to work, even if those implementations extended `SimpleConnection` and overrode the old, now-deprecated function. This is achieved through:

1. Continuing to use the old `connect()` as the basis for the implementation.
2. Using a `ThreadLocal` to make the additional `Map<String, String>` parameter available to the old `connect()` within a strict context.

The `SimpleConnection` class and related classes are also modified to provide the same behavior as past releases, particularly for downstream subclasses.

With these changes, things are ABI-compatible with 1.0.0. Things are also API-compatible with 1.0.0, though continuing to use/override the old `connect()` will result in compiler warnings. Behavior of the relevant classes should now be as follows:

| Class | Behavior in 1.0.0 and older | New behavior |
| ----- | --------------------------- | ------------ |
| `SimpleAuthenticationProvider` | Tokens are applied and "baked-in" when the user authenticates. | Tokens are applied dynamically when connecting. |
| `SimpleUserContext` | Tokens are applied only if explicitly implemented. | Tokens are applied only if explicitly implemented *or* if requested via the constructor. |
| `SimpleConnection` | Tokens are applied only if explicitly implemented. | Tokens are applied only if explicitly implemented *or* if requested via the constructor. |

Overall, behavior should be identical to 1.0.0 with the following exceptions:

* Subclasses of `SimpleAuthenticationProvider` will now handle additional tokens and apply those tokens in context of the connection, not at time of authentication.
* The result of calling `getConfiguration()` on a connection accessed via a subclass of `SimpleAuthenticationProvider` will now contain any tokens in uninterpreted form.
