### PR TITLE
GUACAMOLE-704: LDAP Follow Referrals setting for Docker containers

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -321,6 +321,10 @@ END
         "ldap-user-search-filter" \
         "$LDAP_USER_SEARCH_FILTER"
 
+    set_optional_property         \
+        "ldap-follow-referrals" \
+        "$LDAP_FOLLOW_REFERRALS"
+
     # Add required .jar files to GUACAMOLE_EXT
     ln -s /opt/guacamole/ldap/guacamole-auth-*.jar "$GUACAMOLE_EXT"
 


### PR DESCRIPTION
This will add the ldap-follow-referrals config setting to the start.sh file for Docker. I've found that setting this to 'false' is necessary for Guacamole to behave correctly in my Active Directory environment.