### PR TITLE
GUACAMOLE-704: Add ldap-follow-referrals setting for Docker containers

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -321,7 +321,7 @@ END
         "ldap-user-search-filter" \
         "$LDAP_USER_SEARCH_FILTER"
 
-    set_optional_property         \
+    set_optional_property       \
         "ldap-follow-referrals" \
         "$LDAP_FOLLOW_REFERRALS"
 

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -321,6 +321,10 @@ END
         "ldap-user-search-filter" \
         "$LDAP_USER_SEARCH_FILTER"
 
+    set_optional_property         \
+        "ldap-follow-referrals" \
+        "$LDAP_FOLLOW_REFERRALS"
+
     # Add required .jar files to GUACAMOLE_EXT
     ln -s /opt/guacamole/ldap/guacamole-auth-*.jar "$GUACAMOLE_EXT"
 


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/browse/GUACAMOLE-704

This will add the ldap-follow-referrals config setting to the start.sh file for Docker if the LDAP_FOLLOW_REFERRALS environment variable is set. I've found that setting this to 'false' is necessary for Guacamole to behave correctly in my Active Directory environment.