### PR TITLE
 GUACAMOLE-713: Add support for changing Logback verbosity to Docker start script

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -643,6 +643,12 @@ if [ -n "$DUO_API_HOSTNAME" ]; then
     associate_duo
 fi
 
+# Set logback level if specified
+if [ -n "$LOGBACK_LEVEL" ]; then
+    unzip -o -j /opt/guacamole/guacamole.war WEB-INF/classes/logback.xml -d $GUACAMOLE_HOME
+    sed -i "s/level=\"info\"/level=\"$LOGBACK_LEVEL\"/" $GUACAMOLE_HOME/logback.xml
+fi
+
 #
 # Finally start Guacamole (under Tomcat)
 #


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/GUACAMOLE-713

This change would enable changing the Logback verbosity level using a LOGBACK_LEVEL environment variable passed to Docker using the start.sh script.  Doing this via a guacamole.properties setting would be more elegant, but I'm not familiar enough with the codebase to implement that right now.
