### PR TITLE
GUACAMOLE-716: Add all LDAP properties to Docker start script

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -303,27 +303,31 @@ END
     set_property          "ldap-hostname"           "$LDAP_HOSTNAME"
     set_optional_property "ldap-port"               "$LDAP_PORT"
     set_optional_property "ldap-encryption-method"  "$LDAP_ENCRYPTION_METHOD"
-    set_property          "ldap-user-base-dn"       "$LDAP_USER_BASE_DN"
-    set_optional_property "ldap-username-attribute" "$LDAP_USERNAME_ATTRIBUTE"
-    set_optional_property "ldap-member-attribute"   "$LDAP_MEMBER_ATTRIBUTE"
-    set_optional_property "ldap-group-base-dn"      "$LDAP_GROUP_BASE_DN"
-    set_optional_property "ldap-config-base-dn"     "$LDAP_CONFIG_BASE_DN"
-
-    set_optional_property     \
-        "ldap-search-bind-dn" \
-        "$LDAP_SEARCH_BIND_DN"
+    set_optional_property "ldap-max-search-results" "$LDAP_MAX_SEARCH_RESULTS"
+    set_optional_property "ldap-search-bind-dn"     "$LDAP_SEARCH_BIND_DN"
 
     set_optional_property           \
         "ldap-search-bind-password" \
         "$LDAP_SEARCH_BIND_PASSWORD"
 
-    set_optional_property         \
-        "ldap-user-search-filter" \
-        "$LDAP_USER_SEARCH_FILTER"
+    set_property          "ldap-user-base-dn"       "$LDAP_USER_BASE_DN"
+    set_optional_property "ldap-username-attribute" "$LDAP_USERNAME_ATTRIBUTE"
+    set_optional_property "ldap-member-attribute"   "$LDAP_MEMBER_ATTRIBUTE"
+    set_optional_property "ldap-user-search-filter" "$LDAP_USER_SEARCH_FILTER"
+    set_optional_property "ldap-config-base-dn"     "$LDAP_CONFIG_BASE_DN"
+    set_optional_property "ldap-group-base-dn"      "$LDAP_GROUP_BASE_DN"
 
-    set_optional_property       \
-        "ldap-follow-referrals" \
-        "$LDAP_FOLLOW_REFERRALS"
+    set_optional_property           \
+        "ldap-group-name-attribute" \
+        "$LDAP_GROUP_NAME_ATTRIBUTE"
+
+    set_optional_property           \
+        "ldap-dereference-aliases"  \
+        "$LDAP_DEREFERENCE_ALIASES"
+
+    set_optional_property "ldap-follow-referrals"   "$LDAP_FOLLOW_REFERRALS"
+    set_optional_property "ldap-max-referral-hops"  "$LDAP_MAX_REFERRAL_HOPS"
+    set_optional_property "ldap-operation-timeout"  "$LDAP_OPERATION_TIMEOUT"
 
     # Add required .jar files to GUACAMOLE_EXT
     ln -s /opt/guacamole/ldap/guacamole-auth-*.jar "$GUACAMOLE_EXT"


### PR DESCRIPTION
This will add all possible LDAP guacamole.properties settings to the start.sh script for the Docker container. The five that were missing are:

1. ldap-group-name-attribute
2. ldap-dereference-aliases
3. ldap-max-referral-hops
4. ldap-operation-timeout
5. ldap-max-search-results

I also re-formatted some set_optional_property lines that were < 80 characters to be a single line and re-ordered them single-line entries so they match the order in the documentation.


