### PR TITLE
GUACAMOLE-717: Handle LDAPException gracefully when doing a search

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
@@ -221,6 +221,11 @@ public class ObjectQueryService {
                         logger.debug("Got a referral, but configured to not follow them.", e);
                     }
                 }
+                
+                catch (LDAPException e) {
+                  logger.warn("Failed to process an LDAP search result. Error was: {}", e.resultCodeToString());
+                  logger.debug("Error processing LDAPEntry search result.", e);
+                }
 
             }
 


### PR DESCRIPTION
JIRA Issue: https://issues.apache.org/jira/projects/GUACAMOLE/issues/GUACAMOLE-717

In certain cases, the LDAPSearchResults.next() function returns an LDAPException "Sizelimit Exceeded". In ObjectQueryService.search(), this is not handled within the immediate try/catch block so the other valid results are not returned to the calling function. This fix handles LDAPException the same graceful way that LDAPReferralException is handled.