### PR TITLE
GUACAMOLE-734: Update logback version to latest stable.

### DIFF
--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -257,7 +257,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.3</version>
         </dependency>
         
         <!-- Guacamole Java API -->


### PR DESCRIPTION
Brings the logback version up to the latest stable available in Maven repository.