### PR TITLE
GUACAMOLE-696: In JDBC module, merge effective groups

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.auth.jdbc.user;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
@@ -167,6 +168,13 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
     @Override
     public void setIdentifier(String identifier) {
         user.setIdentifier(identifier);
+    }
+    
+    @Override
+    public Set<String> getEffectiveUserGroups() {
+        Set<String> allGroups = new HashSet<>(user.getEffectiveUserGroups());
+        allGroups.addAll(super.getEffectiveUserGroups());
+        return Collections.unmodifiableSet(allGroups);
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -19,8 +19,8 @@
 
 package org.apache.guacamole.auth.jdbc.user;
 
+import com.google.common.collect.Sets;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
@@ -172,9 +172,8 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
     
     @Override
     public Set<String> getEffectiveUserGroups() {
-        Set<String> allGroups = new HashSet<>(user.getEffectiveUserGroups());
-        allGroups.addAll(super.getEffectiveUserGroups());
-        return Collections.unmodifiableSet(allGroups);
+        return Sets.union(user.getEffectiveUserGroups(),
+                super.getEffectiveUserGroups());
     }
 
 }


### PR DESCRIPTION
This pull request overrides the `getEffectiveUserGroups()` method for the `ModeledAuthenticatedUser` class such that the user groups are merged between ones passed in from the provider that authenticated the user and the ones present for the same user within the JDBC module.

I don't know if this is the best way to do this, if it fully resolves all of the issues associated with this particular JIRA issue, or if it introduces any adverse behavior, but my testing indicates that it at least clarifies/resolves the issue reported in GUACAMOLE-696.