### PR TITLE
GUACAMOLE-708: Enable auto-creation of users in JDBC modules

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -132,7 +132,7 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
             user = userService.retrieveSkeletonUser(authenticationProvider, authenticatedUser);
             
             // If auto account creation is enabled, add user to DB.
-            if(environment.autoCreateAbsentAccounts()) {
+            if (environment.autoCreateAbsentAccounts()) {
                 userService.createObject(new PrivilegedModeledAuthenticatedUser(user.getCurrentUser()), user);
             }
             

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCEnvironment.java
@@ -151,5 +151,21 @@ public abstract class JDBCEnvironment extends LocalEnvironment {
      *     true if the database supports recursive queries, false otherwise.
      */
     public abstract boolean isRecursiveQuerySupported(SqlSession session);
+    
+    /**
+     * Returns a boolean value representing whether or not the JDBC module
+     * should automatically create accounts within the database for users that
+     * are successfully authenticated via other extensions.  Returns true if
+     * accounts should be auto-created, otherwise returns false.
+     * 
+     * @return
+     *     true if user accounts should be automatically created within the
+     *     database when authentication succeeds from another extension;
+     *     otherwise false.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed.
+     */
+    public abstract boolean autoCreateAbsentAccounts() throws GuacamoleException;
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
@@ -427,11 +427,13 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     protected Collection<ObjectPermissionModel> getImplicitPermissions(ModeledAuthenticatedUser user,
             ModelType model) {
         
+        // Check to see if the user granting permissions is a skeleton user,
+        // thus lacking database backing.
+        if (user.getUser().isSkeleton())
+            return Collections.emptyList();
+
         // Get the user model and check for an entity ID.
         UserModel userModel = user.getUser().getModel();
-        Integer entityId = userModel.getEntityID();
-        if (entityId == null)
-            return Collections.emptyList();
         
         // Build list of implicit permissions
         Collection<ObjectPermissionModel> implicitPermissions =
@@ -442,7 +444,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
 
             // Create model which grants this permission to the current user
             ObjectPermissionModel permissionModel = new ObjectPermissionModel();
-            permissionModel.setEntityID(entityId);
+            permissionModel.setEntityID(userModel.getEntityID());
             permissionModel.setType(permission);
             permissionModel.setObjectIdentifier(model.getIdentifier());
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
@@ -471,7 +471,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
 
         // Add implicit permissions
         Collection<ObjectPermissionModel> implicitPermissions = getImplicitPermissions(user, model);
-        if (implicitPermissions != null && !implicitPermissions.isEmpty())
+        if (!implicitPermissions.isEmpty())
             getPermissionMapper().insert(implicitPermissions);
 
         // Add any arbitrary attributes

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUser.java
@@ -763,5 +763,16 @@ public class ModeledUser extends ModeledPermissions<UserModel> implements User {
     public Permissions getEffectivePermissions() throws GuacamoleException {
         return super.getEffective();
     }
+    
+    /**
+     * Returns true if this user is a skeleton user, lacking a database entity
+     * entry.
+     * 
+     * @return 
+     *     True if this user is a skeleton user, otherwise false.
+     */
+    public boolean isSkeleton() {
+        return (getModel().getEntityID() == null);
+    }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -52,6 +52,7 @@ import org.apache.guacamole.net.auth.ActivityRecord;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.User;
+import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -407,11 +408,8 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         if (authenticatedUser instanceof ModeledAuthenticatedUser)
             return ((ModeledAuthenticatedUser) authenticatedUser).getUser();
 
-        // Get username
-        String username = authenticatedUser.getIdentifier();
-
         // Retrieve corresponding user model, if such a user exists
-        UserModel userModel = userMapper.selectOne(username);
+        UserModel userModel = userMapper.selectOne(authenticatedUser.getIdentifier());
         if (userModel == null)
             return null;
 
@@ -448,6 +446,8 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      */
     public ModeledUser retrieveSkeletonUser(AuthenticationProvider authenticationProvider,
             AuthenticatedUser authenticatedUser) throws GuacamoleException {
+        
+        logger.info(">>>JDBC<<< Creating skeleton user {}", authenticatedUser.getIdentifier());
         
         // Set up an empty user model
         ModeledUser user = getObjectInstance(null,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -52,7 +52,6 @@ import org.apache.guacamole.net.auth.ActivityRecord;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.User;
-import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
@@ -297,8 +296,9 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
     protected Collection<ObjectPermissionModel>
         getImplicitPermissions(ModeledAuthenticatedUser user, UserModel model) {
             
-        // Get original set of implicit permissions
-        Collection<ObjectPermissionModel> implicitPermissions = super.getImplicitPermissions(user, model);
+        // Get original set of implicit permissions and make a copy
+        Collection<ObjectPermissionModel> implicitPermissions =
+                new ArrayList<>(super.getImplicitPermissions(user, model));
         
         // Grant implicit permissions to the new user
         for (ObjectPermission.Type permissionType : IMPLICIT_USER_PERMISSIONS) {
@@ -313,7 +313,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
             
         }
         
-        return implicitPermissions;
+        return Collections.unmodifiableCollection(implicitPermissions);
     }
         
     @Override
@@ -446,8 +446,6 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      */
     public ModeledUser retrieveSkeletonUser(AuthenticationProvider authenticationProvider,
             AuthenticatedUser authenticatedUser) throws GuacamoleException {
-        
-        logger.info(">>>JDBC<<< Creating skeleton user {}", authenticatedUser.getIdentifier());
         
         // Set up an empty user model
         ModeledUser user = getObjectInstance(null,

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLEnvironment.java
@@ -386,5 +386,11 @@ public class MySQLEnvironment extends JDBCEnvironment {
     public String getMYSQLSSLClientPassword() throws GuacamoleException {
         return getProperty(MySQLGuacamoleProperties.MYSQL_SSL_TRUST_PASSWORD);
     }
+    
+    @Override
+    public boolean autoCreateAbsentAccounts() throws GuacamoleException {
+        return getProperty(MySQLGuacamoleProperties.MYSQL_AUTO_CREATE_ACCOUNTS,
+                false);
+    }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
@@ -242,9 +242,9 @@ public class MySQLGuacamoleProperties {
     };
     
     /**
-     * Wether or not to automatically create accounts in the MySQL database for
-     * users who successfully authenticate through another extension.  By
-     * default users will not be automatically created.
+     * Whether or not to automatically create accounts in the MySQL database for
+     * users who successfully authenticate through another extension. By default
+     * users will not be automatically created.
      */
     public static final BooleanGuacamoleProperty MYSQL_AUTO_CREATE_ACCOUNTS =
             new BooleanGuacamoleProperty() {

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
@@ -240,5 +240,13 @@ public class MySQLGuacamoleProperties {
         public String getName() { return "mysql-ssl-client-password"; }
         
     };
+    
+    public static final BooleanGuacamoleProperty MYSQL_AUTO_CREATE_ACCOUNTS =
+            new BooleanGuacamoleProperty() {
+    
+        @Override
+        public String getName() { return "mysql-auto-create-accounts"; }
+                
+    };
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
@@ -241,6 +241,11 @@ public class MySQLGuacamoleProperties {
         
     };
     
+    /**
+     * Wether or not to automatically create accounts in the MySQL database for
+     * users who successfully authenticate through another extension.  By
+     * default users will not be automatically created.
+     */
     public static final BooleanGuacamoleProperty MYSQL_AUTO_CREATE_ACCOUNTS =
             new BooleanGuacamoleProperty() {
     

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
@@ -328,4 +328,10 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
         return getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_SSL_KEY_PASSWORD);
     }
     
+    @Override
+    public boolean autoCreateAbsentAccounts() throws GuacamoleException {
+        return getProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_AUTO_CREATE_ACCOUNTS,
+                false);
+    }
+    
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -234,9 +234,9 @@ public class PostgreSQLGuacamoleProperties {
     };
     
     /**
-     * Wether or not to automatically create accounts in the PostgreSQL database
-     * for users who successfully authenticate through another extension.  By
-     * default users will not be automatically created.
+     * Whether or not to automatically create accounts in the PostgreSQL
+     * database for users who successfully authenticate through another
+     * extension. By default users will not be automatically created.
      */
     public static final BooleanGuacamoleProperty POSTGRESQL_AUTO_CREATE_ACCOUNTS =
             new BooleanGuacamoleProperty() {

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -234,8 +234,9 @@ public class PostgreSQLGuacamoleProperties {
     };
     
     /**
-     * Whether or not the PostgreSQL extension should automatically add database
-     * entries for users who are granted access through other extensions.
+     * Wether or not to automatically create accounts in the PostgreSQL database
+     * for users who successfully authenticate through another extension.  By
+     * default users will not be automatically created.
      */
     public static final BooleanGuacamoleProperty POSTGRESQL_AUTO_CREATE_ACCOUNTS =
             new BooleanGuacamoleProperty() {

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -233,4 +233,16 @@ public class PostgreSQLGuacamoleProperties {
         
     };
     
+    /**
+     * Whether or not the PostgreSQL extension should automatically add database
+     * entries for users who are granted access through other extensions.
+     */
+    public static final BooleanGuacamoleProperty POSTGRESQL_AUTO_CREATE_ACCOUNTS =
+            new BooleanGuacamoleProperty() {
+                
+        @Override
+        public String getName() { return "postgresql-auto-create-accounts"; }
+                
+    };
+    
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerAuthenticationProviderModule.java
@@ -25,6 +25,8 @@ import com.google.inject.name.Names;
 import java.lang.UnsupportedOperationException;
 import java.util.Properties;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.sqlserver.conf.SQLServerDriver;
+import org.apache.guacamole.auth.sqlserver.conf.SQLServerEnvironment;
 import org.mybatis.guice.datasource.helper.JdbcHelper;
 
 /**
@@ -45,7 +47,7 @@ public class SQLServerAuthenticationProviderModule implements Module {
     /**
      * Which SQL Server driver should be used.
      */
-    private SQLServerDriver sqlServerDriver;
+    private final SQLServerDriver sqlServerDriver;
 
     /**
      * Creates a new SQLServer authentication provider module that configures

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerInjectorProvider.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerInjectorProvider.java
@@ -24,6 +24,7 @@ import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCAuthenticationProviderModule;
 import org.apache.guacamole.auth.jdbc.JDBCInjectorProvider;
+import org.apache.guacamole.auth.sqlserver.conf.SQLServerEnvironment;
 
 /**
  * JDBCInjectorProvider implementation which configures Guice injections for

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerDriver.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerDriver.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.guacamole.auth.sqlserver;
+package org.apache.guacamole.auth.sqlserver.conf;
 
 import org.apache.guacamole.properties.EnumGuacamoleProperty.PropertyValue;
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerEnvironment.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.guacamole.auth.sqlserver;
+package org.apache.guacamole.auth.sqlserver.conf;
 
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;
@@ -272,6 +272,12 @@ public class SQLServerEnvironment extends JDBCEnvironment {
     @Override
     public boolean isRecursiveQuerySupported(SqlSession session) {
         return true; // All versions of SQL Server support recursive queries through CTEs
+    }
+    
+    @Override
+    public boolean autoCreateAbsentAccounts() throws GuacamoleException {
+        return getProperty(SQLServerGuacamoleProperties.SQLSERVER_AUTO_CREATE_ACCOUNTS,
+                false);
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerGuacamoleProperties.java
@@ -194,6 +194,11 @@ public class SQLServerGuacamoleProperties {
 
     };
     
+    /**
+     * Wether or not to automatically create accounts in the SQL Server database
+     * for users who successfully authenticate through another extension.  By
+     * default users will not be automatically created.
+     */
     public static final BooleanGuacamoleProperty SQLSERVER_AUTO_CREATE_ACCOUNTS =
             new BooleanGuacamoleProperty() {
         

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerGuacamoleProperties.java
@@ -195,9 +195,9 @@ public class SQLServerGuacamoleProperties {
     };
     
     /**
-     * Wether or not to automatically create accounts in the SQL Server database
-     * for users who successfully authenticate through another extension.  By
-     * default users will not be automatically created.
+     * Whether or not to automatically create accounts in the SQL Server
+     * database for users who successfully authenticate through another
+     * extension. By default users will not be automatically created.
      */
     public static final BooleanGuacamoleProperty SQLSERVER_AUTO_CREATE_ACCOUNTS =
             new BooleanGuacamoleProperty() {

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerGuacamoleProperties.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.guacamole.auth.sqlserver;
+package org.apache.guacamole.auth.sqlserver.conf;
 
 import org.apache.guacamole.properties.BooleanGuacamoleProperty;
 import org.apache.guacamole.properties.EnumGuacamoleProperty;
@@ -192,6 +192,14 @@ public class SQLServerGuacamoleProperties {
         @Override
         public String getName() { return "sqlserver-driver"; }
 
+    };
+    
+    public static final BooleanGuacamoleProperty SQLSERVER_AUTO_CREATE_ACCOUNTS =
+            new BooleanGuacamoleProperty() {
+        
+        @Override
+        public String getName() { return "sqlserver-auto-create-accounts"; }
+        
     };
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerPasswordPolicy.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/conf/SQLServerPasswordPolicy.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.guacamole.auth.sqlserver;
+package org.apache.guacamole.auth.sqlserver.conf;
 
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.JDBCEnvironment;


### PR DESCRIPTION
As noted in the JIRA issue, it seems like it cold be useful to allow the JDBC module to auto-create users that are logged in successfully with other modules.  This PR introduces the option to enable it (and leaves it disabled by default), along with the creation of those users.

A little unsure if this is desirable behavior, and if this is the best way to go about it, but figured I'd give it a shot :smile:.