### PR TITLE
GUACAMOLE-774: Add in MD4 support for MSCHAPv1/2

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
@@ -66,12 +66,10 @@ public class RadiusAuthenticationProviderModule extends AbstractModule {
         // Check for MD4 requirement
         RadiusAuthenticationProtocol authProtocol = environment.getProperty(RadiusGuacamoleProperties.RADIUS_AUTH_PROTOCOL);
         RadiusAuthenticationProtocol innerProtocol = environment.getProperty(RadiusGuacamoleProperties.RADIUS_EAP_TTLS_INNER_PROTOCOL);
-        if ((authProtocol != null 
-                    && (authProtocol == RadiusAuthenticationProtocol.MSCHAPv1 
-                    || authProtocol == RadiusAuthenticationProtocol.MSCHAPv2)) 
-                || (innerProtocol != null 
-                    && (innerProtocol == RadiusAuthenticationProtocol.MSCHAPv1 
-                    || innerProtocol == RadiusAuthenticationProtocol.MSCHAPv2))) {
+        if (authProtocol == RadiusAuthenticationProtocol.MSCHAPv1 
+                    || authProtocol == RadiusAuthenticationProtocol.MSCHAPv2
+                    || innerProtocol == RadiusAuthenticationProtocol.MSCHAPv1 
+                    || innerProtocol == RadiusAuthenticationProtocol.MSCHAPv2) {
             
             Security.addProvider(new Provider("MD4", 0.00, "MD4 for MSCHAPv1/2 Support") {
                 {

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
@@ -21,6 +21,7 @@ package org.apache.guacamole.auth.radius;
 
 import com.google.inject.AbstractModule;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.radius.conf.ConfigurationService;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.environment.LocalEnvironment;
 import org.apache.guacamole.net.auth.AuthenticationProvider;

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
-import java.security.Security;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.auth.radius.conf.ConfigurationService;
@@ -66,36 +64,6 @@ public class RadiusConnectionService {
      */
     @Inject
     private ConfigurationService confService;
-
-
-    /**
-     * Set up a new instance of this class, and check the provided
-     * authentication protocol.  If the protocol requires MD4 support,
-     * this loads the required security providers.
-     */
-    public RadiusConnectionService() {
-        
-        try {
-            RadiusAuthenticationProtocol authProtocol = confService.getRadiusAuthProtocol();
-        
-            // Check for MS-CHAP and add MD4 support
-            if (authProtocol == RadiusAuthenticationProtocol.MSCHAPv1
-                    || authProtocol == RadiusAuthenticationProtocol.MSCHAPv2) {
-
-                Security.addProvider(new Provider("MD4", 0.00, "MD4 for MSCHAPv1/2 RADIUS") {
-                    {
-                        this.put("MessageDigest.MD4",
-                                org.bouncycastle.jce.provider.JDKMessageDigest.MD4.class.getName());
-                    }
-                });
-
-            }
-        } catch(GuacamoleException e) {
-            logger.error("Could not retrieve RADIUS authentication protocol: {}", e.getMessage());
-            logger.debug("Failed to determine authentication protocol", e);
-        }
-        
-    }
     
     /**
      * Creates a new instance of RadiusClient, configured with parameters

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
@@ -72,26 +72,27 @@ public class RadiusConnectionService {
      * Set up a new instance of this class, and check the provided
      * authentication protocol.  If the protocol requires MD4 support,
      * this loads the required security providers.
-     * 
-     * @throws GuacamoleException
-     *     If guacamole.properties cannot be parsed or an invalid
-     *     authentication protocol is provided.
      */
-    public RadiusConnectionService() throws GuacamoleException {
+    public RadiusConnectionService() {
         
-        RadiusAuthenticationProtocol authProtocol = confService.getRadiusAuthProtocol();
+        try {
+            RadiusAuthenticationProtocol authProtocol = confService.getRadiusAuthProtocol();
         
-        // Check for MS-CHAP and add MD4 support
-        if (authProtocol == RadiusAuthenticationProtocol.MSCHAPv1
-                || authProtocol == RadiusAuthenticationProtocol.MSCHAPv2) {
-            
-            Security.addProvider(new Provider("MD4", 0.00, "MD4 for MSCHAPv1/2 RADIUS") {
-                {
-                    this.put("MessageDigest.MD4",
-                            org.bouncycastle.jce.provider.JDKMessageDigest.MD4.class.getName());
-                }
-            });
-            
+            // Check for MS-CHAP and add MD4 support
+            if (authProtocol == RadiusAuthenticationProtocol.MSCHAPv1
+                    || authProtocol == RadiusAuthenticationProtocol.MSCHAPv2) {
+
+                Security.addProvider(new Provider("MD4", 0.00, "MD4 for MSCHAPv1/2 RADIUS") {
+                    {
+                        this.put("MessageDigest.MD4",
+                                org.bouncycastle.jce.provider.JDKMessageDigest.MD4.class.getName());
+                    }
+                });
+
+            }
+        } catch(GuacamoleException e) {
+            logger.error("Could not retrieve RADIUS authentication protocol: {}", e.getMessage());
+            logger.debug("Failed to determine authentication protocol", e);
         }
         
     }

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
@@ -22,6 +22,7 @@ package org.apache.guacamole.auth.radius.conf;
 import com.google.inject.Inject;
 import java.io.File;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.environment.Environment;
 
 /**
@@ -322,6 +323,8 @@ public class ConfigurationService {
         
         if (authProtocol == RadiusAuthenticationProtocol.EAP_TTLS)
             throw new GuacamoleServerException("Invalid inner protocol specified for EAP-TTLS.");
+        
+        return authProtocol;
         
     }
 

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.guacamole.auth.radius;
+package org.apache.guacamole.auth.radius.conf;
 
 import com.google.inject.Inject;
 import java.io.File;
@@ -123,8 +123,9 @@ public class ConfigurationService {
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public String getRadiusAuthProtocol() throws GuacamoleException {
-        return environment.getProperty(
+    public RadiusAuthenticationProtocol getRadiusAuthProtocol()
+            throws GuacamoleException {
+        return environment.getRequiredProperty(
             RadiusGuacamoleProperties.RADIUS_AUTH_PROTOCOL
         );
     }
@@ -309,12 +310,19 @@ public class ConfigurationService {
      *     an EAP-TTLS RADIUS connection. 
      *     
      * @throws GuacamoleException
-     *     If guacamole.properties cannot be parsed.
+     *     If guacamole.properties cannot be parsed, or if EAP-TTLS is specified
+     *     as the inner protocol.
      */
-    public String getRadiusEAPTTLSInnerProtocol() throws GuacamoleException {
-        return environment.getProperty(
+    public RadiusAuthenticationProtocol getRadiusEAPTTLSInnerProtocol()
+            throws GuacamoleException {
+        
+        RadiusAuthenticationProtocol authProtocol = environment.getProperty(
             RadiusGuacamoleProperties.RADIUS_EAP_TTLS_INNER_PROTOCOL
         );
+        
+        if (authProtocol == RadiusAuthenticationProtocol.EAP_TTLS)
+            throw new GuacamoleServerException("Invalid inner protocol specified for EAP-TTLS.");
+        
     }
 
 }

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
@@ -1,0 +1,64 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.apache.guacamole.auth.radius.conf;
+
+/**
+ * This enum represents supported RADIUS authentication protocols for
+ * the guacamole-auth-radius extension.
+ */
+public enum RadiusAuthenticationProtocol {
+    
+    // Password authentication protocol
+    PAP("pap"),
+    
+    // Challenge-Handshake AUthentication Protocol
+    CHAP("chap"),
+    
+    // Microsoft CHAP version 1
+    MSCHAPv1("mschapv1"),
+    
+    // Microsoft CHAP version 2
+    MSCHAPv2("mschapv2"),
+    
+    // Extensible authentication protocol with MD5 hashing.
+    EAP_MD5("eap-md5"),
+
+    // Extensible authentication protocol with TLS
+    EAP_TLS("eap-tls"),
+
+    // Extensible authentication protocol with Tunneled TLS
+    EAP_TTLS("eap-ttls");
+
+    // Store the string value used in the configuration file.
+    private final String strValue;
+    
+    /**
+     * Create a new RadiusAuthenticationProtocol object having the
+     * given string value.
+     * 
+     * @param strValue
+     *     The string value of the protocol.
+     */
+    public RadiusAuthenticationProtocol(String strValue) {
+        this.strValue = strValue;
+    }
+    
+    @Override
+    public String toString() {
+        return strValue;
+    }
+    
+    @Override
+    public static RadiusAuthenticationProtocol valueOf(String value) {
+    
+        for (RadiusAuthenticationProtocol v : values())
+            if(v.toString().equals(value))
+                return v;
+        
+        return null;
+    }
+    
+}

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
@@ -25,28 +25,46 @@ package org.apache.guacamole.auth.radius.conf;
  */
 public enum RadiusAuthenticationProtocol {
     
-    // Password authentication protocol
+    /**
+     * Password Authentication Protocol (PAP)
+     */
     PAP("pap"),
     
-    // Challenge-Handshake AUthentication Protocol
+    /**
+     * Challenge-Handshake Authentication Protocol (CHAP)
+     */
     CHAP("chap"),
     
-    // Microsoft CHAP version 1
+    /**
+     * Microsoft implementation of CHAP, Version 1 (MS-CHAPv1)
+     */
     MSCHAPv1("mschapv1"),
     
-    // Microsoft CHAP version 2
+    /**
+     * Microsoft implementation of CHAP, Version 2 (MS-CHAPv2)
+     */
     MSCHAPv2("mschapv2"),
     
-    // Extensible authentication protocol with MD5 hashing.
+    /**
+     * Extensible Authentication Protocol (EAP) with MD5 Hashing (EAP-MD5)
+     */
     EAP_MD5("eap-md5"),
 
-    // Extensible authentication protocol with TLS
+    /**
+     * Extensible Authentication Protocol (EAP) with TLS encryption (EAP-TLS).
+     */
     EAP_TLS("eap-tls"),
 
-    // Extensible authentication protocol with Tunneled TLS
+    /**
+     * Extensible Authentication Protocol (EAP) with Tunneled TLS (EAP-TTLS).
+     */
     EAP_TTLS("eap-ttls");
 
-    // Store the string value used in the configuration file.
+    /**
+     * This variable stores the string value of the protocol, and is also
+     * used within the extension to pass to JRadius for configuring the
+     * library to talk to the RADIUS server.
+     */
     private final String strValue;
     
     /**
@@ -54,17 +72,40 @@ public enum RadiusAuthenticationProtocol {
      * given string value.
      * 
      * @param strValue
-     *     The string value of the protocol.
+     *     The value of the protocol to store as a string, which will be used
+     *     in specifying the protocol within the guacamole.properties file, and
+     *     will also be used by the JRadius library for its configuration.
      */
     RadiusAuthenticationProtocol(String strValue) {
         this.strValue = strValue;
     }
     
+    /**
+    * {@inheritDoc}
+    * <p>
+    * This function returns the stored string values of the selected RADIUS
+    * protocol, which is used both in Guacamole configuration and also to pass
+    * on to the JRadius library for its configuration.
+    * 
+    * @return
+    *     The string value stored for the selected RADIUS protocol.
+    */
     @Override
     public String toString() {
         return strValue;
     }
     
+    /**
+     * For a given String value, return the enum value that matches that string,
+     * or null if no matchi is found.
+     * 
+     * @param value
+     *     The string value to search for in the list of enums.
+     * 
+     * @return
+     *     The RadiusAuthenticationProtocol value that is identified by the
+     *     provided String value.
+     */
     public static RadiusAuthenticationProtocol getEnum(String value) {
     
         for (RadiusAuthenticationProtocol v : values())

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
@@ -1,8 +1,22 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.apache.guacamole.auth.radius.conf;
 
 /**

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocol.java
@@ -56,7 +56,7 @@ public enum RadiusAuthenticationProtocol {
      * @param strValue
      *     The string value of the protocol.
      */
-    public RadiusAuthenticationProtocol(String strValue) {
+    RadiusAuthenticationProtocol(String strValue) {
         this.strValue = strValue;
     }
     
@@ -65,8 +65,7 @@ public enum RadiusAuthenticationProtocol {
         return strValue;
     }
     
-    @Override
-    public static RadiusAuthenticationProtocol valueOf(String value) {
+    public static RadiusAuthenticationProtocol getEnum(String value) {
     
         for (RadiusAuthenticationProtocol v : values())
             if(v.toString().equals(value))

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.auth.radius.conf;
 
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 
 /**
@@ -37,7 +38,7 @@ public abstract class RadiusAuthenticationProtocolProperty
         
         // Attempt to parse the string value
         RadiusAuthenticationProtocol authProtocol = 
-                RadiusAuthenticationProtocol.valueOf(value);
+                RadiusAuthenticationProtocol.getEnum(value);
         
         // Throw an exception if nothing matched.
         if (authProtocol == null)

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
@@ -21,6 +21,7 @@ package org.apache.guacamole.auth.radius.conf;
 
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.properties.GuacamoleProperty;
 
 /**
  * A GuacamoleProperty whose value is a RadiusAuthenticationProtocol.

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
@@ -1,8 +1,22 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.apache.guacamole.auth.radius.conf;
 
 import org.apache.guacamole.GuacamoleServerException;

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusAuthenticationProtocolProperty.java
@@ -1,0 +1,38 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.apache.guacamole.auth.radius.conf;
+
+import org.apache.guacamole.GuacamoleServerException;
+
+/**
+ * A GuacamoleProperty whose value is a RadiusAuthenticationProtocol.
+ */
+public abstract class RadiusAuthenticationProtocolProperty
+        implements GuacamoleProperty<RadiusAuthenticationProtocol> {
+    
+    @Override
+    public RadiusAuthenticationProtocol parseValue(String value)
+            throws GuacamoleException {
+        
+        // Nothing provided, nothing returned
+        if (value == null)
+            return null;
+        
+        // Attempt to parse the string value
+        RadiusAuthenticationProtocol authProtocol = 
+                RadiusAuthenticationProtocol.valueOf(value);
+        
+        // Throw an exception if nothing matched.
+        if (authProtocol == null)
+            throw new GuacamoleServerException(
+                    "Invalid or unsupported RADIUS authentication protocol.");
+        
+        // Return the answer
+        return authProtocol;
+        
+    }
+    
+}

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusGuacamoleProperties.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusGuacamoleProperties.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.guacamole.auth.radius;
+package org.apache.guacamole.auth.radius.conf;
 
 import org.apache.guacamole.properties.BooleanGuacamoleProperty;
 import org.apache.guacamole.properties.FileGuacamoleProperty;
@@ -81,7 +81,8 @@ public class RadiusGuacamoleProperties {
     /**
      * The authentication protocol of the RADIUS server to connect to when authenticating users.
      */
-    public static final StringGuacamoleProperty RADIUS_AUTH_PROTOCOL = new StringGuacamoleProperty() {
+    public static final RadiusAuthenticationProtocolProperty RADIUS_AUTH_PROTOCOL =
+            new RadiusAuthenticationProtocolProperty() {
 
         @Override
         public String getName() { return "radius-auth-protocol"; }
@@ -181,7 +182,8 @@ public class RadiusGuacamoleProperties {
     /**
      * The tunneled protocol to use inside a RADIUS EAP-TTLS connection.
      */
-    public static final StringGuacamoleProperty RADIUS_EAP_TTLS_INNER_PROTOCOL = new StringGuacamoleProperty() {
+    public static final RadiusAuthenticationProtocolProperty RADIUS_EAP_TTLS_INNER_PROTOCOL =
+            new RadiusAuthenticationProtocolProperty() {
 
         @Override
         public String getName() { return "radius-eap-ttls-inner-protocol"; }


### PR DESCRIPTION
Takes a stab at manually pulling in the MD4 provider for Java versions that do not include that support, which is required for MSCHAPv1/2 RADIUS conversations.

Full Disclosure: I do not have a RADIUS server running MSCHAP, so I cannot test these changes.  The code compiles, and this seems to be the method that will work based on other changes, but if someone can test against a Windows RADIUS server running MSCHAP, that would be helpful.