### PR TITLE
GUACAMOLE-678: Assign clientID variable instead of string literal

### DIFF
--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/form/TokenField.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/form/TokenField.java
@@ -78,7 +78,7 @@ public class TokenField extends Field {
         this.authorizationURI = UriBuilder.fromUri(authorizationEndpoint)
                 .queryParam("scope", scope)
                 .queryParam("response_type", "id_token")
-                .queryParam("client_id","clientID")
+                .queryParam("client_id", clientID)
                 .queryParam("redirect_uri", redirectURI)
                 .queryParam("nonce", nonce)
                 .build();


### PR DESCRIPTION
Fix issue introduced with #349.