### PR TITLE
GUACAMOLE-146: Pre-clean the webapp context before deploying it.

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -575,6 +575,7 @@ END
 start_guacamole() {
 
     # Install webapp
+    rm -Rf /usr/local/tomcat/webapps/${WEBAPP_CONTEXT:-guacamole}
     ln -sf /opt/guacamole/guacamole.war /usr/local/tomcat/webapps/${WEBAPP_CONTEXT:-guacamole}.war
 
     # Start tomcat


### PR DESCRIPTION
This fixes an issue where, when the directory specified for the Tomcat WebApp context is already present (for example, ROOT), Tomcat does not actually deploy the application.  This cleans any existing context directory before linking in the WAR and starting Tomcat.