### PR TITLE
GUACAMOLE-783: Ensure GET requests to the REST API are not serviced from the cache in Internet Explorer.

### DIFF
--- a/guacamole/src/main/webapp/app/index/config/httpDefaults.js
+++ b/guacamole/src/main/webapp/app/index/config/httpDefaults.js
@@ -18,14 +18,19 @@
  */
 
 /**
- * The config block for setting up the HTTP PATCH method.
+ * Defaults for the AngularJS $http service.
  */
-angular.module('index').config(['$httpProvider', 
-        function indexHttpPatchConfig($httpProvider) {
-    
+angular.module('index').config(['$httpProvider', function httpDefaults($httpProvider) {
+
+    // Do not cache the responses of GET requests
+    $httpProvider.defaults.headers.get = {
+        'Cache-Control' : 'no-cache',
+        'Pragma' : 'no-cache'
+    };
+
+    // Use "application/json" content type by default for PATCH requests
     $httpProvider.defaults.headers.patch = {
-        'Content-Type': 'application/json'
-    }
+        'Content-Type' : 'application/json'
+    };
+
 }]);
-
-


### PR DESCRIPTION
IE 11 appears to ignore the `Cache-Control` header on requests despite RFC 7234 and does not invalidate cache after changes are made to a resource via PUT/DELETE/POST despite RFC 2616. It _does_ behave correctly when the `Pragma` header is included.

This behavior is not observed for Chrome/Firefox which both correctly honor the `Cache-Control` header and correctly invalidate cache after changes.