### PR TITLE
GUACAMOLE-422: Switch to TIMEZONE field type for RDP/SSH "timezone" parameter.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/form/TimeZoneField.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/form/TimeZoneField.java
@@ -20,8 +20,9 @@
 package org.apache.guacamole.form;
 
 /**
- * Represents a time zone field. The field may contain only valid time zone IDs,
- * as dictated by TimeZone.getAvailableIDs().
+ * Represents a time zone field. The field may contain only valid time zone
+ * identifiers, as defined by the IANA time zone database. Such identifiers are
+ * also valid Java time zone IDs as dictated by TimeZone.getAvailableIDs().
  */
 public class TimeZoneField extends Field {
 

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -108,7 +108,7 @@
                 },
                 {
                     "name"  : "timezone",
-                    "type"  : "TEXT"
+                    "type"  : "TIMEZONE"
                 },
                 {
                     "name"    : "console",

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
@@ -80,7 +80,7 @@
                 },
                 {
                     "name"  : "timezone",
-                    "type"  : "TEXT"
+                    "type"  : "TIMEZONE"
                 },
                 {
                     "name"  : "server-alive-interval",

--- a/guacamole/src/main/webapp/app/form/controllers/timeZoneFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/timeZoneFieldController.js
@@ -19,8 +19,9 @@
 
 
 /**
- * Controller for time zone fields. Time zone fields use Java IDs as the
- * standard representation for each supported time zone.
+ * Controller for time zone fields. Time zone fields use IANA time zone
+ * database identifiers as the standard representation for each supported time
+ * zone. These identifiers are also legal Java time zone IDs.
  */
 angular.module('form').controller('timeZoneFieldController', ['$scope', '$injector',
     function timeZoneFieldController($scope, $injector) {

--- a/guacamole/src/main/webapp/app/form/controllers/timeZoneFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/timeZoneFieldController.js
@@ -419,7 +419,6 @@ angular.module('form').controller('timeZoneFieldController', ['$scope', '$inject
         "Canada" : {
             "Atlantic"          : "Canada/Atlantic",
             "Central"           : "Canada/Central",
-            "East-Saskatchewan" : "Canada/East-Saskatchewan",
             "Eastern"           : "Canada/Eastern",
             "Mountain"          : "Canada/Mountain",
             "Newfoundland"      : "Canada/Newfoundland",


### PR DESCRIPTION
As discussed on #348, the `TIMEZONE` field can indeed safely be used to represent the `timezone` parameter used by RDP and SSH. This change modifies the field definition added via #403 such that the `TIMEZONE` field type is used instead of `TEXT`, and updates the field type documentation to note the use of IANA identifiers.

This change also removes the `Canada/East-Saskatchewan` time zone, which is no longer available within the IANA database as of release "2017c".