### PR TITLE
GUACAMOLE-742: Use "data-disabled" instead of "disabled" for directive attributes.

### DIFF
--- a/guacamole/src/main/webapp/app/form/templates/form.html
+++ b/guacamole/src/main/webapp/app/form/templates/form.html
@@ -9,7 +9,7 @@
         <div class="fields">
             <guac-form-field ng-repeat="field in form.fields" namespace="namespace"
                              ng-if="isVisible(field)"
-                             disabled="disabled"
+                             data-disabled="disabled"
                              field="field" model="values[field.name]"></guac-form-field>
         </div>
 

--- a/guacamole/src/main/webapp/app/login/templates/login.html
+++ b/guacamole/src/main/webapp/app/login/templates/login.html
@@ -27,7 +27,7 @@
                         namespace="'LOGIN'"
                         content="remainingFields"
                         model="enteredValues"
-                        disabled="submitted"></guac-form>
+                        data-disabled="submitted"></guac-form>
                 </div>
 
                 <!-- Login/continue button -->


### PR DESCRIPTION
Internet Explorer 11 interprets the `disabled` attribute on all HTML elements, even unknown elements like AngularJS directives, disabling any input fields that end up on the DOM tree within those elements. This breaks the login form.

The alternative `data-disabled` attribute form supported by AngularJS allows things to work without interference.