### PR TITLE
GUACAMOLE-643: Show connection groups during filter operations

### DIFF
--- a/guacamole/src/main/webapp/app/groupList/directives/guacGroupListFilter.js
+++ b/guacamole/src/main/webapp/app/groupList/directives/guacGroupListFilter.js
@@ -136,19 +136,23 @@ angular.module('groupList').directive('guacGroupListFilter', [function guacGroup
                 // Flatten all children to the top-level group
                 angular.forEach(connectionGroup.childConnectionGroups, function flattenChild(child) {
 
-                    var flattenedChild = flattenConnectionGroup(child);
+                    if (child.attributes.filter != 'false') {
 
-                    // Merge all child connections
-                    Array.prototype.push.apply(
-                        connectionGroup.childConnections,
-                        flattenedChild.childConnections
-                    );
+                        var flattenedChild = flattenConnectionGroup(child);
 
-                    // Merge all child connection groups
-                    Array.prototype.push.apply(
-                        connectionGroup.childConnectionGroups,
-                        flattenedChild.childConnectionGroups
-                    );
+                        // Merge all child connections
+                        Array.prototype.push.apply(
+	                    connectionGroup.childConnections,
+                            flattenedChild.childConnections
+                        );
+	
+                        // Merge all child connection groups
+                        Array.prototype.push.apply(
+                            connectionGroup.childConnectionGroups,
+                            flattenedChild.childConnectionGroups
+                        );
+                    
+                    }
 
                 });
 

--- a/guacamole/src/main/webapp/app/list/types/FilterPattern.js
+++ b/guacamole/src/main/webapp/app/list/types/FilterPattern.js
@@ -221,7 +221,7 @@ angular.module('list').factory('FilterPattern', ['$injector',
          * @param {String} pattern
          *     The pattern to compile.
          */
-        this.compile = function compile(pattern) {
+        this.compileConnectionFilter = function compileConnectionFilter(pattern) {
 
             // If no pattern provided, everything matches
             if (!pattern) {
@@ -235,6 +235,45 @@ angular.module('list').factory('FilterPattern', ['$injector',
             // Return predicate which matches against the value of any getter in the getters array
             filterPattern.predicate = function matchesAllTokens(object) {
 
+                // False if any token does not match
+                for (var i=0; i < tokens.length; i++) {
+                    if (!matchesToken(object, tokens[i]))
+                        return false;
+                }
+
+                // True if all tokens matched
+                return true;
+
+            };
+            
+        };
+
+        /**
+         * Compiles the given pattern string, assigning the resulting filter
+         * predicate. The resulting predicate will accept only objects that
+         * match the given pattern.
+         * 
+         * @param {String} pattern
+         *     The pattern to compile.
+         */
+        this.compileConnectionGroupFilter = function compileConnectionGroupFilter(pattern) {
+
+            // If no pattern provided, everything matches
+            if (!pattern) {
+                filterPattern.predicate = nullPredicate;
+                return;
+            }
+                
+            // Tokenize pattern, converting to lower case for case-insensitive matching
+            var tokens = FilterToken.tokenize(pattern.toLowerCase());
+
+            // Return predicate which matches against the value of any getter in the getters array
+            filterPattern.predicate = function matchesAllTokens(object) {
+
+                if (object.attributes.filter == 'false') {
+                    return true;
+                }
+            	
                 // False if any token does not match
                 for (var i=0; i < tokens.length; i++) {
                     if (!matchesToken(object, tokens[i]))


### PR DESCRIPTION
If a connection group has the 'filter' attribute to 'false', it won't be hidden during a search.

Example of connection group that won't be hidden:

```
ConnectionGroup group = new MyConnectionGroup(groupName, groupName, Collections.<String>emptyList(), Collections.<String>emptyList());
group.setParentIdentifier(ROOT_IDENTIFIER);
group.setAttributes(Collections.singletonMap("filter", "false"));
rootGroup.getConnectionGroupIdentifiers().add(groupName);
connectionGroups.add(group);
```