### PR TITLE
GUACAMOLE-805: Handle OpenID "id_token" parameter regardless of location in URL fragment.

### DIFF
--- a/extensions/guacamole-auth-openid/src/main/resources/transformToken.js
+++ b/extensions/guacamole-auth-openid/src/main/resources/transformToken.js
@@ -18,19 +18,17 @@
  */
 
 /**
- * Before AngularJS routing takes effect, test whether the URL fragment
- * contains an OpenID Connect "id_token" parameter, and reformat the fragment
- * such that the client side of Guacamole's authentication system will
- * automatically forward the "id_token" value for server-side validation.
+ * Before AngularJS routing takes effect, reformat the URL fragment
+ * from the format used by OpenID Connect ("#param1=value1&param2=value2&...")
+ * to the format used by AngularJS ("#/?param1=value1&param2=value2&...") such
+ * that the client side of Guacamole's authentication system will automatically
+ * forward the "id_token" value for server-side validation.
  * 
  * Note that not all OpenID identity providers will include the "id_token"
  * parameter in the first position; it may occur after several other parameters
- * within the hash.
+ * within the fragment.
  */
 (function guacOpenIDTransformToken() {
-
-    // Transform "/#id_token=..." to "/#/?id_token=..."
-    if (/(^#|&)id_token=/.test(location.hash))
+    if (/^#(?![?\/])(.*&)?id_token=/.test(location.hash))
         location.hash = '/?' + location.hash.substring(1);
-
 })();

--- a/extensions/guacamole-auth-openid/src/main/resources/transformToken.js
+++ b/extensions/guacamole-auth-openid/src/main/resources/transformToken.js
@@ -18,16 +18,19 @@
  */
 
 /**
- * Config block which registers openid-specific field types.
+ * Before AngularJS routing takes effect, test whether the URL fragment
+ * contains an OpenID Connect "id_token" parameter, and reformat the fragment
+ * such that the client side of Guacamole's authentication system will
+ * automatically forward the "id_token" value for server-side validation.
+ * 
+ * Note that not all OpenID identity providers will include the "id_token"
+ * parameter in the first position; it may occur after several other parameters
+ * within the hash.
  */
-angular.module('guacOpenID').config(['formServiceProvider',
-        function guacOpenIDConfig(formServiceProvider) {
+(function guacOpenIDTransformToken() {
 
-    // Define field for token from OpenID service
-    formServiceProvider.registerFieldType("GUAC_OPENID_TOKEN", {
-        templateUrl : 'app/ext/guac-openid/templates/openidTokenField.html',
-        controller  : 'guacOpenIDController',
-        module      : 'guacOpenID'
-    });
+    // Transform "/#id_token=..." to "/#/?id_token=..."
+    if (/(^#|&)id_token=/.test(location.hash))
+        location.hash = '/?' + location.hash.substring(1);
 
-}]);
+})();


### PR DESCRIPTION
These changes add more robust handling of the `id_token` parameter. The URL fragment is automatically reformatted from the format used by OpenID to the format used by AngularJS, regardless of the location of `id_token` within that fragment.

The fragment is reformatted from `#...` to `#/?...` if all of the following are true:

1. The fragment did not already start with `#/` (an AngularJS path).
2. The fragment did not already start with `#?` (which AngularJS will already handle as a list of parameters).
3. The fragment contains an `id_token` parameter, either at the beginning or elsewhere within the parameter list.

All other fragments are left untouched.