### PR TITLE
GUACAMOLE-807: Correct handling of parameter tokens within LDAP.

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -178,7 +178,7 @@ public class ConnectionService {
 
                 // Store connection using cn for both identifier and name
                 String name = cn.getStringValue();
-                Connection connection = new SimpleConnection(name, name, config);
+                Connection connection = new SimpleConnection(name, name, config, true);
                 connection.setParentIdentifier(LDAPAuthenticationProvider.ROOT_CONNECTION_GROUP);
 
                 // Inject LDAP-specific tokens only if LDAP handled user


### PR DESCRIPTION
This change addresses a regression introduced with #333.

Parameter tokens are intended to be interpreted by the connections stored within LDAP. This was previously done through explicitly using a `TokenFilter` and the `StandardTokens` class, however usage of `StandardTokens` is now deprecated and the values of tokens to be applied are now expected to be received through `connect()`. Usage of `StandardTokens` was removed from LDAP with commit 1210d56, but this is insufficient. An additional parameter must also be provided to the `SimpleConnection` constructor to enable its automatic token handling behavior.