### PR TITLE
GUACAMOLE-422: Correct non-short-circuit logic in null check.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
@@ -167,9 +167,9 @@ public class TunnelRequestService {
         if (imageMimetypes != null)
             info.getImageMimetypes().addAll(imageMimetypes);
         
-        // Get the timezone value
+        // Set timezone if provided
         String timezone = request.getTimezone();
-        if (timezone != null & !timezone.isEmpty())
+        if (timezone != null && !timezone.isEmpty())
             info.setTimezone(timezone);
 
         return info;


### PR DESCRIPTION
The changes introduced via #348 include a check of the form:

```java
if (timezone != null & !timezone.isEmpty()) {
   ...
}
```

This will result in a `NullPointerException` when `timezone` is null, as the `&` ensures `timezone.isEmpty()` will run in all cases. This change corrects the above null check such that proper short-circuit logic is used.