### PR TITLE
GUACAMOLE-723: Allow connection name to overflow cleanly in Guacamole menu.

### DIFF
--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+#guac-menu .header h2.connection-select-menu {
+    overflow: visible;
+}
+
 .connection-select-menu {
     padding: 0;
     min-width: 0;

--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -18,6 +18,7 @@
  */
 
 .connection-select-menu {
+    padding: 0;
     min-width: 0;
 }
 

--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -30,13 +30,6 @@
     border: none;
 }
 
-.connection-select-menu .menu-dropdown .menu-title {
-    white-space: nowrap;
-    overflow: hidden;
-    width: 100%;
-    text-overflow: ellipsis;
-}
-
 .connection-select-menu .menu-dropdown .menu-contents {
     font-weight: normal;
     font-size: 0.8em;

--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.connection-select-menu .menu-dropdown {
+    border: none;
+}
+
+.connection-select-menu .menu-contents {
+    font-weight: normal;
+    font-size: 0.8em;
+}
+
+.connection-select-menu .filter input {
+    border-bottom: 1px solid rgba(0,0,0,0.125);
+    border-left: none;
+}
+
+.connection-select-menu .filter {
+    margin-bottom: 0.5em;
+    padding: 0;
+}

--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -17,21 +17,34 @@
  * under the License.
  */
 
+.connection-select-menu {
+    min-width: 0;
+}
+
 .connection-select-menu .menu-dropdown {
     border: none;
 }
 
-.connection-select-menu .menu-contents {
-    font-weight: normal;
-    font-size: 0.8em;
+.connection-select-menu .menu-dropdown .menu-title {
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    text-overflow: ellipsis;
 }
 
-.connection-select-menu .filter input {
+.connection-select-menu .menu-dropdown .menu-contents {
+    font-weight: normal;
+    font-size: 0.8em;
+    right: auto;
+    left: 0;
+}
+
+.connection-select-menu .menu-dropdown .menu-contents .filter input {
     border-bottom: 1px solid rgba(0,0,0,0.125);
     border-left: none;
 }
 
-.connection-select-menu .filter {
+.connection-select-menu .menu-dropdown .menu-contents .filter {
     margin-bottom: 0.5em;
     padding: 0;
 }

--- a/guacamole/src/main/webapp/app/client/styles/guac-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/guac-menu.css
@@ -65,6 +65,13 @@
     margin-top: 1em;
 }
 
+#guac-menu .header h2 {
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    text-overflow: ellipsis;
+}
+
 #guac-menu #mouse-settings .choice {
     text-align: center;
 }

--- a/guacamole/src/main/webapp/app/client/styles/guac-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/guac-menu.css
@@ -65,10 +65,6 @@
     margin-top: 1em;
 }
 
-#guac-menu .header h2 {
-    padding: 0;
-}
-
 #guac-menu #mouse-settings .choice {
     text-align: center;
 }

--- a/guacamole/src/main/webapp/app/client/styles/guac-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/guac-menu.css
@@ -69,25 +69,6 @@
     padding: 0;
 }
 
-#guac-menu .header h2 .menu-dropdown {
-    border: none;
-}
-
-#guac-menu .header h2 .menu-contents {
-    font-weight: normal;
-    font-size: 0.8em;
-}
-
-#guac-menu .header .filter input {
-    border-bottom: 1px solid rgba(0,0,0,0.125);
-    border-left: none;
-}
-
-#guac-menu .header .filter {
-    margin-bottom: 0.5em;
-    padding: 0;
-}
-
 #guac-menu #mouse-settings .choice {
     text-align: center;
 }

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -53,7 +53,7 @@
             <!-- Stationary header -->
             <div class="header">
                 <h2 ng-hide="rootConnectionGroups">{{client.name}}</h2>
-                <h2 ng-show="rootConnectionGroups">
+                <h2 class="connection-select-menu" ng-show="rootConnectionGroups">
                     <guac-menu menu-title="client.name">
                         <div class="all-connections">
                             <guac-group-list-filter connection-groups="rootConnectionGroups"

--- a/guacamole/src/main/webapp/app/navigation/styles/menu.css
+++ b/guacamole/src/main/webapp/app/navigation/styles/menu.css
@@ -68,6 +68,11 @@
     padding: 0.5em;
     padding-right: 2em;
 
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    text-overflow: ellipsis;
+
     -ms-flex: 0 0 auto;
     -moz-box-flex: 0;
     -webkit-box-flex: 0;


### PR DESCRIPTION
With the recent changes from #391, the name of the connection within the Guacamole menu can overflow past the edge of the header, covering the share and user menus. These changes correct this, using ellipsis to represent the remaining portion of the connection name if it would otherwise overflow.