### PR TITLE
GUACAMOLE-723: Allow connection names to cleanly overflow in connection selection menu.

### DIFF
--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -35,7 +35,8 @@
     font-size: 0.8em;
     right: auto;
     left: 0;
-    max-width: 100%;
+    max-width: 100vw;
+    width: 400px;
 }
 
 .connection-select-menu .menu-dropdown .menu-contents .filter input {

--- a/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
+++ b/guacamole/src/main/webapp/app/client/styles/connection-select-menu.css
@@ -35,6 +35,7 @@
     font-size: 0.8em;
     right: auto;
     left: 0;
+    max-width: 100%;
 }
 
 .connection-select-menu .menu-dropdown .menu-contents .filter input {
@@ -45,4 +46,11 @@
 .connection-select-menu .menu-dropdown .menu-contents .filter {
     margin-bottom: 0.5em;
     padding: 0;
+}
+
+.connection-select-menu .menu-dropdown .menu-contents .group-list .caption {
+    display: inline-block;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }


### PR DESCRIPTION
Following up on #414, this change additionally allows the connection names _within_ the connection selection menu to cleanly overflow if they cannot otherwise fit within the menu.

For this to work, the connection selection menu has to have a defined width. I opted for generally wide menu which is still bounded by the Guacamole menu.