### PR TITLE
GUACAMOLE-723: Automatically close menus upon click unless explicitly marked as interactive.

### DIFF
--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -54,7 +54,7 @@
             <div class="header">
                 <h2 ng-hide="rootConnectionGroups">{{client.name}}</h2>
                 <h2 class="connection-select-menu" ng-show="rootConnectionGroups">
-                    <guac-menu menu-title="client.name">
+                    <guac-menu menu-title="client.name" interactive="true">
                         <div class="all-connections">
                             <guac-group-list-filter connection-groups="rootConnectionGroups"
                                 filtered-connection-groups="filteredRootConnectionGroups"

--- a/guacamole/src/main/webapp/app/navigation/directives/guacMenu.js
+++ b/guacamole/src/main/webapp/app/navigation/directives/guacMenu.js
@@ -34,7 +34,16 @@ angular.module('navigation').directive('guacMenu', [function guacMenu() {
              *
              * @type String
              */
-            menuTitle : '='
+            menuTitle : '=',
+
+            /**
+             * Whether the menu should remain open while the user interacts
+             * with the contents of the menu. By default, the menu will close
+             * if the user clicks within the menu contents.
+             *
+             * @type Boolean
+             */
+            interactive : '='
 
         },
 
@@ -81,21 +90,19 @@ angular.module('navigation').directive('guacMenu', [function guacMenu() {
                 $scope.menuShown = !$scope.menuShown;
             };
 
-            // Close menu when use clicks anywhere else
-            document.body.addEventListener('click', function clickOutsideMenu() {
+            // Close menu when user clicks anywhere outside this specific menu
+            document.body.addEventListener('click', function clickOutsideMenu(e) {
                 $scope.$apply(function closeMenu() {
-                    $scope.menuShown = false;
+                    if (e.target !== element && !element.contains(e.target))
+                        $scope.menuShown = false;
                 });
             }, false);
 
-            // Prevent click within menu from triggering the outside-menu handler
-            element.addEventListener('click', function clickInsideMenu(e) {
-                e.stopPropagation();
-            }, false);
-
-            // Prevent click within menu contents from toggling menu visibility
+            // Prevent clicks within menu contents from toggling menu visibility
+            // if the menu contents are intended to be interactive
             contents.addEventListener('click', function clickInsideMenuContents(e) {
-                e.stopPropagation();
+                if ($scope.interactive)
+                    e.stopPropagation();
             }, false);
 
         }] // end controller


### PR DESCRIPTION
This change addresses the menu behavior regression [noted on GUACAMOLE-723](https://issues.apache.org/jira/browse/GUACAMOLE-723?focusedCommentId=16864910&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16864910), automatically closing open menus if the menu contents are clicked or any other part of the page is clicked.

As the connection selection menu is intended to be interactive and thus should remain open while the user is clicking on its contents, a `interactive` attribute has been added to the `guacMenu` directive allow this intent to be explicitly stated. If set to `true`, clicks within the menu contents will not close the menu.