### PR TITLE
GUACAMOLE-723: Display connection selection menu only if multiple connections are available.

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -280,9 +280,12 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     })(guacClientManager.getManagedClients());
 
     /**
-     * Map of data source identifier to the root connection group of that data
-     * source, or null if the connection group hierarchy has not yet been
-     * loaded.
+     * The root connection groups of the connection hierarchy that should be
+     * presented to the user for selecting a different connection, as a map of
+     * data source identifier to the root connection group of that data
+     * source. This will be null if the connection group hierarchy has not yet
+     * been loaded or if the hierarchy is inapplicable due to only one
+     * connection or balancing group being available.
      *
      * @type Object.<String, ConnectionGroup>
      */
@@ -313,7 +316,13 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         ConnectionGroup.ROOT_IDENTIFIER
     )
     .then(function rootGroupsRetrieved(rootConnectionGroups) {
-        $scope.rootConnectionGroups = rootConnectionGroups;
+
+        // Store retrieved groups only if there are multiple connections or
+        // balancing groups available
+        var clientPages = userPageService.getClientPages(rootConnectionGroups);
+        if (clientPages.length > 1)
+            $scope.rootConnectionGroups = rootConnectionGroups;
+
     }, requestService.WARN);
 
     /**


### PR DESCRIPTION
This change alters the behavior of the connection selection menu such that it is displayed only if multiple choices would be available within that menu. If only one connection or balancing group is available, the connection selection menu does not render, replaced by a simple `<h2>` header.

Part of this involved adding logic which recursively crawls the connection hierarchy. With that logic being added within `userPageService`, this change effectively addresses the intent of #370. If the user has only one connection or balancing group available, that will automatically be opened as their home page, regardless of how deeply that object is nested or whether there are other empty connection groups present.