### PR TITLE
GUACAMOLE-822: Correct retrieval of client identifier for connection groups.

### DIFF
--- a/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
+++ b/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
@@ -1,4 +1,4 @@
 <span class="home-connection-group name">
-    <a ng-show="item.balancing" ng-href="#/client/{{ getClientIdentifier() }}">{{item.name}}</a>
+    <a ng-show="item.balancing" ng-href="#/client/{{ item.getClientIdentifier() }}">{{item.name}}</a>
     <span ng-show="!item.balancing">{{item.name}}</span>
 </span>


### PR DESCRIPTION
Commit f92bf9c moved the `getClientIdentifier()` function to the `GroupListItem` class, thus making the function available as `item.getClientIdentifier()` within the connection or connection group templates referenced by an instance of the `guacGroupList` directive (see #391). That commit correctly updated all but the connection group template for the home screen, which was _incorrectly_ updated to reference the function as if it were directly on the scope. As such a function doesn't exist, AngularJS didn't substitute any value, resulting in non-functional connection group links.

This change updates the home screen connection group template to retrieve the client identifier using `item.getClientIdentifier()`, as originally intended.