### PR TITLE
GUACAMOLE-302: Refocus relevant in-progress login fields after auth failure

### DIFF
--- a/guacamole/src/main/webapp/app/element/directives/guacFocus.js
+++ b/guacamole/src/main/webapp/app/element/directives/guacFocus.js
@@ -52,20 +52,6 @@ angular.module('element').directive('guacFocus', ['$parse', function guacFocus($
                 });
             });
 
-            // Set focus flag when focus is received
-            element.addEventListener('focus', function focusReceived() {
-                $scope.$evalAsync(function setGuacFocusAsync() {
-                    guacFocus.assign($scope, true);
-                });
-            });
-
-            // Unset focus flag when focus is lost
-            element.addEventListener('blur', function focusLost() {
-                $scope.$evalAsync(function unsetGuacFocusAsync() {
-                    guacFocus.assign($scope, false);
-                });
-            });
-
         } // end guacFocus link function
 
     };


### PR DESCRIPTION
Note: There were two parts of this issue this time around. The first(error message) has been fixed and described in the commit itself. As far as the inconsistency in focusing the username field on the initial page load is concerned, that seems to no longer happen as a result of this fix. I do not understand why that is the case, but that is the behavior I have observed. For that reason, I am uncertain whether we can deem that part as resolved.