### PR TITLE
GUACAMOLE-302: Do not rely on $evalAsync() for assigning focus.

### DIFF
--- a/guacamole/src/main/webapp/app/element/directives/guacFocus.js
+++ b/guacamole/src/main/webapp/app/element/directives/guacFocus.js
@@ -20,7 +20,11 @@
 /**
  * A directive which allows elements to be manually focused / blurred.
  */
-angular.module('element').directive('guacFocus', ['$parse', function guacFocus($parse) {
+angular.module('element').directive('guacFocus', ['$injector', function guacFocus($injector) {
+
+    // Required services
+    var $parse   = $injector.get('$parse');
+    var $timeout = $injector.get('$timeout');
 
     return {
         restrict: 'A',
@@ -44,7 +48,7 @@ angular.module('element').directive('guacFocus', ['$parse', function guacFocus($
 
             // Set/unset focus depending on value of guacFocus
             $scope.$watch(guacFocus, function updateFocus(value) {
-                $scope.$evalAsync(function updateFocusAsync() {
+                $timeout(function updateFocusAfterRender() {
                     if (value)
                         element.focus();
                     else


### PR DESCRIPTION
It appears that we cannot rely on `focus()` working as expected unless its execution is deferred via `window.setTimeout()` or equivalent. If not deferred, the target element may not be ready to receive focus, and the attempt will silently fail.

Note that while there is a _chance_ that deferred execution will happen with the current usage of `$evalAsync()` within the `guacFocus` directive, this is not guaranteed. If it can, AngularJS will execute the function provided to `$evalAsync()` immediately after the current `$digest` loop and without control returning to the browser.