### PR TITLE
GUACAMOLE-846: tunnel.uuid not initialized if tunnel becomes UNSTABLE

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -1015,7 +1015,7 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
                     var opcode = elements.shift();
 
                     // Update state and UUID when first instruction received
-                    if (tunnel.state === Guacamole.Tunnel.State.CONNECTING) {
+                    if (tunnel.uuid === null) {
 
                         // Associate tunnel UUID if received
                         if (opcode === Guacamole.Tunnel.INTERNAL_DATA_OPCODE)


### PR DESCRIPTION
This patch will set the `tunnel.uuid` if it's undefined.