### PR TITLE
GUACAMOLE-827: If the FileReader object is busy, don't continue with …

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/BlobWriter.js
+++ b/guacamole-common-js/src/main/webapp/modules/BlobWriter.js
@@ -110,6 +110,10 @@ Guacamole.BlobWriter = function BlobWriter(stream) {
         var offset = 0;
         var reader = new FileReader();
 
+        var sleep = function sleep(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
         /**
          * Reads the next chunk of the blob provided to
          * [sendBlob()]{@link Guacamole.BlobWriter#sendBlob}. The chunk itself
@@ -119,6 +123,12 @@ Guacamole.BlobWriter = function BlobWriter(stream) {
          * @private
          */
         var readNextChunk = function readNextChunk() {
+
+            while (reader.readyState == 1) {
+                // The reader is busy so give it time to finish before proceeding.
+                // 1 second might be a bit generous, but it seems functional.
+                await sleep(1000);
+            }
 
             // If no further chunks remain, inform of completion and stop
             if (offset >= blob.size) {


### PR DESCRIPTION
…the next block of blob data when transferring files to remote server until it is free to continue.

I've demonstrated this problem and solution in two separate projects, which combined, provide a web client to a local guacamole server that allows file transfers to a remote RDP Windows Desktop.  The new BlobWriter.js does not throw errors when transferring files resulting in complete file transfers.

To test, run these projects using the existing BlobWriter.js code and transfer image files of decent size (>800kb or so) to the remote desktop by drag-and-drop of local files to the remote desktop:

https://github.com/jcaple/guacamole-webclient-test

https://github.com/jcaple/guacamole-server-test