### PR TITLE
GUACAMOLE-821: Use Japanese word for the Japanese language as the name of the Japanese translation.

### DIFF
--- a/guacamole/src/main/webapp/translations/ja.json
+++ b/guacamole/src/main/webapp/translations/ja.json
@@ -1,6 +1,6 @@
 {
     
-    "NAME" : "Japanese",
+    "NAME" : "日本語",
     
     "APP" : {
 


### PR DESCRIPTION
The names of Guacamole's language options should be in the same language as the translation, not in English. This change updates the name of the Japanese translation such that the name itself is also in Japanese.

I don't speak Japanese at all, but I am reasonably confident this is correct.