### PR TITLE
GUACAMOLE-221: Client-side changes for parameter prompting

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -715,16 +715,16 @@ Guacamole.Client = function(tunnel) {
     this.onpipe = null;
     
     /**
-     * This method is fired when a prompt (required) instruction is received
-     * from the server, which indicates that guacd requires further information
+     * This method is fired when a required instruction is received from the
+     * server, which indicates that guacd requires additional parameters
      * from the client in order to continue the connection.
      * 
      * @event
-     * @param {String} parameter The name of a connection parameter that needs
+     * @param {String} parameters The names of connection parameters that need
      *      to be provided by the client to guacd before the connection can
      *      proceed.
      */
-    this.onprompt = null;
+    this.onrequired = null;
 
     /**
      * Fired whenever a sync instruction is received from the server, indicating
@@ -1350,8 +1350,8 @@ Guacamole.Client = function(tunnel) {
 
         },
                 
-        "required": function receivePrompt(parameters) {
-            if (guac_client.onprompt) guac_client.onprompt(parameters[0]);
+        "required": function required(parameters) {
+            if (guac_client.onrequired) guac_client.onrequired(parameters);
         },
         
         "reset": function(parameters) {

--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -713,6 +713,18 @@ Guacamole.Client = function(tunnel) {
      * @param {String} name The name of the pipe.
      */
     this.onpipe = null;
+    
+    /**
+     * This method is fired when a prompt (required) instruction is received
+     * from the server, which indicates that guacd requires further information
+     * from the client in order to continue the connection.
+     * 
+     * @event
+     * @param {String} parameter The name of a connection parameter that needs
+     *      to be provided by the client to guacd before the connection can
+     *      proceed.
+     */
+    this.onprompt = null;
 
     /**
      * Fired whenever a sync instruction is received from the server, indicating
@@ -1336,6 +1348,10 @@ Guacamole.Client = function(tunnel) {
 
             display.rect(layer, x, y, w, h);
 
+        },
+                
+        "required": function receivePrompt(parameters) {
+            if (guac_client.onprompt) guac_client.onprompt(parameters[0]);
         },
         
         "reset": function(parameters) {

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
@@ -42,6 +42,15 @@ public enum GuacamoleProtocolCapability {
     PROTOCOL_VERSION_DETECTION(GuacamoleProtocolVersion.VERSION_1_1_0),
     
     /**
+     * Support for the "required" instruction.  The "required" instruction
+     * allows the server to request additional information from the client
+     * during the course of a connection.  Support for this instruction was
+     * introduced in
+     * {@link GuacamoleProtocolVersion#VERSION_1_3_0}.
+     */
+    REQUIRED_INSTRUCTION(GuacamoleProtocolVersion.VERSION_1_3_0),
+    
+    /**
      * Support for the "timezone" handshake instruction. The "timezone"
      * instruction allows the client to request that the server forward their
      * local timezone for use within the remote desktop session. Support for

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
@@ -45,12 +45,19 @@ public class GuacamoleProtocolVersion {
      * for passing the client timezone to the server during the handshake.
      */
     public static final GuacamoleProtocolVersion VERSION_1_1_0 = new GuacamoleProtocolVersion(1, 1, 0);
+    
+    /**
+     * Protocol version 1.3.0, which introduces support for the "required"
+     * instruction, allowing the server to request additional required
+     * information from the client in the course of a connection.
+     */
+    public static final GuacamoleProtocolVersion VERSION_1_3_0 = new GuacamoleProtocolVersion(1, 3, 0);
 
     /**
      * The most recent version of the Guacamole protocol at the time this
      * version of GuacamoleProtocolVersion was built.
      */
-    public static final GuacamoleProtocolVersion LATEST = VERSION_1_1_0;
+    public static final GuacamoleProtocolVersion LATEST = VERSION_1_3_0;
     
     /**
      * A regular expression that matches the VERSION_X_Y_Z pattern, where

--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -39,6 +39,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     var dataSourceService      = $injector.get('dataSourceService');
     var guacClientManager      = $injector.get('guacClientManager');
     var guacNotification       = $injector.get('guacNotification');
+    var guacPrompt             = $injector.get('guacPrompt');
     var iconService            = $injector.get('iconService');
     var preferenceService      = $injector.get('preferenceService');
     var requestService         = $injector.get('requestService');
@@ -974,6 +975,23 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
         return path;
 
+    };
+    
+    /**
+     * Returns whether or not a prompt is available/populated.
+     * If there is no client defined, the answer is automatically
+     * false.  Otherwise, it returns the value from the
+     * guacPrompt service.
+     *
+     * @returns {Boolean|Prompt}
+     *     Returns either false if no prompt is available
+     *     or the Prompt object.
+     */
+    $scope.getPrompt = function getPrompt() {
+        if (!$scope.client)
+            return false;
+        
+        return guacPrompt.getPrompt();
     };
 
     /**

--- a/guacamole/src/main/webapp/app/client/templates/client.html
+++ b/guacamole/src/main/webapp/app/client/templates/client.html
@@ -45,6 +45,18 @@
     <div id="connection-warning" ng-show="isConnectionUnstable()">
         {{'CLIENT.TEXT_CLIENT_STATUS_UNSTABLE' | translate}}
     </div>
+    
+    <!-- Connection prompt dialog -->
+    <div id="connection-prompt"
+         ng-show="getPrompt()"
+         ng-class="{shown: getPrompt()}"
+         class="status-outer connection-parameters">
+        
+        <div class="status-middle">
+            <guac-prompt prompt="getPrompt()" client="client"></guac-prompt>
+        </div>
+        
+    </div>
 
     <!-- Menu -->
     <div class="menu" ng-class="{open: menu.shown}" id="guac-menu">

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -28,6 +28,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     var $window          = $injector.get('$window');
     var clipboardService = $injector.get('clipboardService');
     var guacNotification = $injector.get('guacNotification');
+    var guacPrompt       = $injector.get('guacPrompt');
 
     /**
      * The error that prevents the current page from rendering at all. If no
@@ -41,6 +42,11 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
      * The notification service.
      */
     $scope.guacNotification = guacNotification;
+    
+    /**
+     * The prompt service.
+     */
+    $scope.guacPrompt = guacPrompt;
 
     /**
      * The message to display to the user as instructions for the login

--- a/guacamole/src/main/webapp/app/prompt/directives/guacPrompt.js
+++ b/guacamole/src/main/webapp/app/prompt/directives/guacPrompt.js
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A directive for the guacamole client that handles prompting the user for
+ * information required to continue a connection.
+ */
+angular.module('prompt').directive('guacPrompt', [function guacPrompt() {
+
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+
+            /**
+             * The prompt to display.
+             *
+             * @type Prompt|Object 
+             */
+            prompt : '=',
+            
+            /**
+             * The client this prompt is linked to.
+             * 
+             * @type Client|Object
+             */
+            client : '<'
+
+        },
+
+        templateUrl: 'app/prompt/templates/guacPrompt.html',
+        controller: ['$scope', '$injector', function guacPromptController($scope, $injector) {
+
+            // Required services
+            var Protocol                 = $injector.get('Protocol');
+                
+            /**
+             * Responses to provided prompts.
+             * 
+             * @Type Object
+             */
+            $scope.responses = {};
+            
+            /**
+             * Return the translated namespace for the given protocol.
+             * 
+             * @param {String} protocolName
+             *     The name of the protocol.
+             *     
+             * @return The canonicalized name of the protocol, or null if
+             *     no protocol is provided.
+             */
+            $scope.getProtocolNamespace = Protocol.getNamespace;
+            
+            // Update responses as model changes
+            $scope.$watch('responses', function setModel(model) {
+                
+                // If model is defined, use it.
+                if (model)
+                    $scope.responses = model;
+                
+                // Otherwise use a blank object
+                else
+                    $scope.responses = {};
+                
+            });
+
+        }]
+
+    };
+}]);

--- a/guacamole/src/main/webapp/app/prompt/promptModule.js
+++ b/guacamole/src/main/webapp/app/prompt/promptModule.js
@@ -18,22 +18,9 @@
  */
 
 /**
- * The module for the root of the application.
+ * The module for code used to prompt user for required information.
  */
-angular.module('index', [
-    'auth',
-    'client',
-    'clipboard',
-    'home',
-    'login',
-    'manage',
-    'navigation',
-    'ngRoute',
-    'ngTouch',
-    'notification',
-    'pascalprecht.translate',
-    'prompt',
+angular.module('prompt', [
     'rest',
-    'settings',
-    'templates-main'
+    'storage'
 ]);

--- a/guacamole/src/main/webapp/app/prompt/services/guacPrompt.js
+++ b/guacamole/src/main/webapp/app/prompt/services/guacPrompt.js
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Service for displaying prompt dialogs
+ */
+angular.module('prompt').factory('guacPrompt', ['$injector',
+        function guacPrompt($injector) {
+
+    // Required services
+    var $q                    = $injector.get('$q');
+    var $rootScope            = $injector.get('$rootScope');
+    var $window               = $injector.get('$window');
+    var sessionStorageFactory = $injector.get('sessionStorageFactory');
+
+    var service = {};
+
+    /**
+     * Getter/setter which retrieves or sets the current prompt,
+     * which may simply be false if no user input is currently required.
+     * 
+     * @type Function
+     */
+    var storedPrompt = sessionStorageFactory.create(false);
+
+    /**
+     * An action to be provided along with the object sent to showPrompt which
+     * closes the currently-shown prompt dialog.
+     *
+     * @type PromptAction
+     */
+    service.ACKNOWLEDGE_ACTION = {
+        name        : 'APP.ACTION_ACKNOWLEDGE',
+        callback    : function acknowledgeCallback() {
+            service.showPrompt(false);
+        }
+    };
+
+    /**
+     * Retrieves the current prompt, which may simply be false if no
+     * additional information is required.
+     * 
+     * @type Prompt|Boolean
+     */
+    service.getPrompt = function getPrompt() {
+        return storedPrompt();
+    };
+
+    /**
+     * Shows or hides the given prompt as a modal dialog. If a prompt
+     * is currently shown, no further prompts will be shown until the current
+     * one is resolved.
+     *
+     * @param {Prompt|Boolean|Object} prompt
+     *     The prompt to show.
+     */
+    service.showPrompt = function showPrompt(prompt) {
+        if (!storedPrompt() || !prompt)
+            storedPrompt(prompt);
+    };
+    
+    service.getUserInput = function getUserInput(responses) {
+        
+        var deferred = $q.defer();
+        
+        if (prompt === null || prompt === '')
+            deferred.resolve();
+        
+        else {
+            service.showPrompt({
+                'actions': [
+                    {
+                        'name': 'Connect',
+                        'callback': function connectPrompt() {
+                            deferred.resolve(responses);
+                            service.showPrompt(false);
+                        }
+                    },
+                    {
+                        'name': 'Cancel',
+                        'callback': function cancelPrompt() {
+                            deferred.reject();
+                            service.showPrompt(false);
+                        }
+                    }
+                ],
+                'responses': responses
+            });
+            
+            return deferred.promise;
+        }
+        
+    };
+    
+    /**
+     * Method to stop event propagation.
+     * 
+     * @param event
+     *     The event to prevent.
+     */
+    var preventEvent = function preventEvent(event) {
+        if (service.getPrompt())
+            event.stopPropagation();
+    };
+    
+    /* Add handlers to stop event propagation when prompt is present. */
+    $window.addEventListener('input', preventEvent, true);
+    $window.addEventListener('keydown', preventEvent, true);
+    $window.addEventListener('keypress', preventEvent, true);
+    $window.addEventListener('keyup', preventEvent, true);
+    $window.addEventListener('click', preventEvent, false);
+
+    // Hide prompt upon navigation
+    $rootScope.$on('$routeChangeSuccess', function() {
+        service.showPrompt(false);
+    });
+
+    return service;
+
+}]);

--- a/guacamole/src/main/webapp/app/prompt/styles/prompt.css
+++ b/guacamole/src/main/webapp/app/prompt/styles/prompt.css
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.prompt {
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.125);
+    background: white;
+    color: black;
+    margin: 0 auto;
+    max-width: 75%;
+}
+
+.prompt .body {
+    margin: 0.5em;
+}
+
+.prompt .buttons {
+    margin: 0.5em;
+}
+
+.prompt .fields,
+.prompt .parameters {
+    border: none;
+    box-shadow: none;
+}
+
+.prompt .fields {
+    display: table;
+    width: 100%;
+}
+
+.prompt .fields .labeled-field {
+    display: table-row;
+    text-align: center;
+}
+
+.prompt .fields .field-header {
+    padding-right: 1em;
+    text-align: right;
+}
+
+.prompt .fields .form-field {
+    text-align: left;
+}
+
+.prompt .fields .field-header,
+.prompt .fields .form-field {
+    display: table-cell;
+    padding: .125em;
+    vertical-align: top;
+}
+
+.prompt .parameters {
+    width: 100%;
+}
+
+.prompt .title-bar {
+    font-size: 1.25em;
+    font-weight: bold;
+
+    text-transform: uppercase;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.125);
+    background: rgba(0, 0, 0, 0.04);
+
+    padding: 0.5em;
+    margin-bottom: 1em;
+}

--- a/guacamole/src/main/webapp/app/prompt/templates/guacPrompt.html
+++ b/guacamole/src/main/webapp/app/prompt/templates/guacPrompt.html
@@ -1,0 +1,18 @@
+<div class="prompt" ng-class="prompt.className">
+    <div class="body">
+        <!-- Parameters -->
+        <div class="prompt connection-parameters">
+            <guac-form
+                namespace="getProtocolNamespace(client.protocol)"
+                content="client.forms"
+                model="prompt.responses"
+                model-only="true"></guac-form>
+        </div>
+    </div>
+    <!-- Buttons -->
+    <div ng-show="prompt.actions.length" class="buttons">
+        <button ng-repeat="action in prompt.actions"
+                ng-click="action.callback()"
+                ng-class="action.className">{{action.name | translate}}</button>
+    </div>
+</div>

--- a/guacamole/src/main/webapp/app/prompt/types/Prompt.js
+++ b/guacamole/src/main/webapp/app/prompt/types/Prompt.js
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides the Prompt class definition.
+ */
+angular.module('prompt').factory('Prompt', [function definePrompt() {
+
+    /**
+     * Creates a new Prompt, where the properties of that Prompt are set to
+     * the corresponding properties of the given template.
+     *
+     * @constructor
+     * @param {Prompt|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     Prompt.
+     */
+    var Prompt = function Prompt(template) {
+
+        // Use empty object by default
+        template = template || {};
+
+        /**
+         * The CSS class to associate with the prompt, if any.
+         *
+         * @type String
+         */
+        this.className = template.className;
+        
+        /**
+         * The object that stores response to the prompts.
+         * 
+         * @type Object{String, String}
+         */
+        this.responses = template.responses;
+
+        /**
+         * An array of all actions available to the user in response to this
+         * prompt.
+         *
+         * @type PromptAction[]
+         */
+        this.actions = template.actions || [];
+
+    };
+
+    return Prompt;
+
+}]);

--- a/guacamole/src/main/webapp/app/prompt/types/PromptAction.js
+++ b/guacamole/src/main/webapp/app/prompt/types/PromptAction.js
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides the PromptAction class definition.
+ */
+angular.module('prompt').factory('PromptAction', [function definePromptAction() {
+
+    /**
+     * Creates a new PromptAction, which pairs an arbitrary callback with
+     * an action name. The name of this action will ultimately be presented to
+     * the user when the user is prompted to choose among available actions.
+     *
+     * @constructor
+     * @param {String} name The name of this action.
+     *
+     * @param {Function} callback
+     *     The callback to call when the user elects to perform this action.
+     * 
+     * @param {String} className
+     *     The CSS class to associate with this action, if any.
+     */
+    var PromptAction = function PromptAction(name, callback, className) {
+
+        /**
+         * Reference to this PromptAction.
+         *
+         * @type PromptAction
+         */
+        var action = this;
+
+        /**
+         * The CSS class associated with this action.
+         * 
+         * @type String
+         */
+        this.className = className;
+
+        /**
+         * The name of this action.
+         *
+         * @type String
+         */
+        this.name = name;
+
+        /**
+         * The callback to call when this action is performed.
+         *
+         * @type Function
+         */
+        this.callback = callback;
+
+    };
+
+    return PromptAction;
+
+}]);


### PR DESCRIPTION
This is a re-work of the client-side changes required to get parameter prompting going.  Very much a work-in-progress at this point, but I'd appreciate some pointers getting things finished up.  This matches with the changes in apache/guacamole-server#228.

As with the changes on the server-side, this does not handle multiple parameters concurrently, but does one at a time.  That can probably stand to be fixed, plus the style needs a little work.