### PR TITLE
GUACAMOLE-774: Fix deprecation issue with Java 9 and up.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
@@ -57,6 +57,7 @@ public class RadiusAuthenticationProviderModule extends AbstractModule {
      *     If an error occurs while retrieving the Guacamole server
      *     environment.
      */
+    @SuppressWarnings("deprecation")
     public RadiusAuthenticationProviderModule(AuthenticationProvider authProvider)
             throws GuacamoleException {
 

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusAuthenticationProviderModule.java
@@ -20,18 +20,17 @@
 package org.apache.guacamole.auth.radius;
 
 import com.google.inject.AbstractModule;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.security.Provider;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.auth.radius.conf.ConfigurationService;
 import org.apache.guacamole.auth.radius.conf.RadiusAuthenticationProtocol;
 import org.apache.guacamole.auth.radius.conf.RadiusGuacamoleProperties;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.environment.LocalEnvironment;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
  * Guice module which configures RADIUS-specific injections.
@@ -75,26 +74,10 @@ public class RadiusAuthenticationProviderModule extends AbstractModule {
                     || innerProtocol == RadiusAuthenticationProtocol.MSCHAPv2) {
             
             try {
-                Provider md4Provider;
-                Constructor providerConstructor = Provider.class
-                        .getConstructor(String.class, String.class, String.class);
-                if (providerConstructor != null)
-                    md4Provider = (Provider) providerConstructor
-                            .newInstance("MD4", "0.00", "MD4 for MSCHAPv1/2 Support");
-                else
-                    md4Provider = (Provider) Provider.class
-                            .getConstructor(String.class, Double.class, String.class)
-                            .newInstance("MD4", 0.00, "MD4 for MSCHAPv1/2 Support");
-
-                assert(md4Provider != null);
-                md4Provider.put("MessageDigest.MD4", org.bouncycastle.jce.provider.JDKMessageDigest.MD4.class.getName());
-                Security.addProvider(md4Provider);
+                MessageDigest.getInstance("MD4");
             }
-            catch (IllegalAccessException
-                    | InstantiationException
-                    | InvocationTargetException
-                    | NoSuchMethodException e) {
-                throw new GuacamoleServerException("Unable to load MD4 support.", e);
+            catch (NoSuchAlgorithmException e) {
+                Security.addProvider(new BouncyCastleProvider());
             }
             
         }


### PR DESCRIPTION
This is probably not the best solution, but I'm having a hard time finding another.  The only `Provider` constructor present in Java 8 and lower is:

    Provider(String name, double version, String info)

In Java 9, that constructor is deprecated, and the recommended one is:

    Provider​(String name, String versionStr, String info)

Since the code introduced with that constructor is designed to handle MD4 requirements in *newer* versions of Java, it needs to work with newer versions.  Unless I'm missing some sort of way in Java you can say..."if running with Java version X and earlier, do this, else do this?"