### PR TITLE
GUACAMOLE-769: Add back empty translation string.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-radius/src/main/resources/translations/en.json
@@ -5,7 +5,8 @@
     },
 
     "LOGIN" : {
-        "FIELD_HEADER_GUAC_RADIUS_STATE"              : ""
+        "FIELD_HEADER_GUAC_RADIUS_STATE"              : "",
+        "FIELD_HEADER_RADIUSCHALLENGE"                : ""
     }
 
 }


### PR DESCRIPTION
Got a little too delete-happy removing translation strings - turns out this one should be added back.