### PR TITLE
GUACAMOLE-234: Fix bind issue that occurs using try-with-resources.

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -129,7 +129,8 @@ public class LDAPConnectionService {
             throws GuacamoleException {
 
         // Get ldapConnection and try to connect and bind.
-        try (LdapNetworkConnection ldapConnection = createLDAPConnection()) {
+        LdapNetworkConnection ldapConnection = createLDAPConnection();
+        try {
 
             // Connect to LDAP server
             ldapConnection.connect();
@@ -155,6 +156,7 @@ public class LDAPConnectionService {
 
         // Disconnect if an error occurs during bind
         catch (LdapException e) {
+            ldapConnection.close();
             logger.debug("Unable to bind to LDAP server.", e);
             throw new GuacamoleInvalidCredentialsException(
                     "Unable to bind to the LDAP server.",


### PR DESCRIPTION
This fixes an issue that occurs when using `try with resources`, because the connection gets automatically closed at the end of the first bind/search, which is undesirable.  As far as I can tell, the alternative to this is to take the code in the `bindAs()` method and replicate it into every method where we do any sort of LDAP operation, which doesn't seem terribly efficient.