### PR TITLE
GUACAMOLE-817: Reset keyboard state on navigation and form submission.

### DIFF
--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -138,6 +138,12 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
         keyboard.reset();
     };
 
+    // Release all keys upon form submission (there may not be corresponding
+    // keyup events for key presses involved in submitting a form)
+    $document.on('submit', function formSubmitted() {
+        keyboard.reset();
+    });
+
     /**
      * Checks whether the clipboard data has changed, firing a new
      * "guacClipboard" event if it has.
@@ -186,6 +192,11 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
         $scope.page.title = 'APP.NAME';
         $scope.page.bodyClassName = '';
         $scope.fatalError = error;
+    });
+
+    // Ensure new pages always start with clear keyboard state
+    $scope.$on('$routeChangeStart', function routeChanging() {
+        keyboard.reset();
     });
 
     // Update title and CSS class upon navigation


### PR DESCRIPTION
Firefox, and perhaps other browsers, does not fire a keyup event for keys involved in submitting a form. This results in the enter key being stuck in a pressed state if it is used to submit Guacamole's login form.

Keyboard state should be reset whenever keyboard state cannot be reliably maintained. This is already done for loss of window focus, but should also be done for form submission (this specific case) and navigation to a different page (generic catch-all).