### PR TITLE
GUACAMOLE-889: Fix mismatching attribute names

### DIFF
--- a/extensions/guacamole-auth-ldap/schema/guacConfigGroup.schema
+++ b/extensions/guacamole-auth-ldap/schema/guacConfigGroup.schema
@@ -26,6 +26,6 @@ attributetype ( 1.3.6.1.4.1.38971.1.1.2 NAME 'guacConfigParameter'
 objectClass ( 1.3.6.1.4.1.38971.1.2.1 NAME 'guacConfigGroup'
     DESC 'Guacamole configuration group'
     SUP groupOfNames
-    MUST protocol
-    MAY parameter )
+    MUST guacConfigProtocol
+    MAY guacConfigParameter )
 


### PR DESCRIPTION
This patch targets the following error message:

`line 30 objectClass: AttributeType not found: "protocol"`