### PR TITLE
GUACAOMLE-893: Fix regression in LDAP filter with null value

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
@@ -142,16 +142,21 @@ public class ObjectQueryService {
         AndNode searchFilter = new AndNode();
         searchFilter.addNode(filter);
 
-        // Include all attributes within OR clause if there are more than one
+        // If no attributes provided, we're done.
+        if (attributes.size() < 1)
+            return searchFilter;
+
+        // Include all attributes within OR clause
         OrNode attributeFilter = new OrNode();
-       
+
         // Add equality comparison for each possible attribute
         attributes.forEach(attribute ->
-            attributeFilter.addNode(new EqualityNode(attribute, attributeValue))
+            attributeFilter.addNode(new EqualityNode(attribute, 
+                    (attributeValue != null ? attributeValue : "*")))
         );
 
         searchFilter.addNode(attributeFilter);
-        
+
         return searchFilter;
 
     }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ObjectQueryService.java
@@ -37,6 +37,7 @@ import org.apache.directory.api.ldap.model.filter.AndNode;
 import org.apache.directory.api.ldap.model.filter.EqualityNode;
 import org.apache.directory.api.ldap.model.filter.ExprNode;
 import org.apache.directory.api.ldap.model.filter.OrNode;
+import org.apache.directory.api.ldap.model.filter.PresenceNode;
 import org.apache.directory.api.ldap.model.message.Referral;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.name.Dn;
@@ -149,14 +150,25 @@ public class ObjectQueryService {
         // Include all attributes within OR clause
         OrNode attributeFilter = new OrNode();
 
-        // Add equality comparison for each possible attribute
-        attributes.forEach(attribute ->
-            attributeFilter.addNode(new EqualityNode(attribute, 
-                    (attributeValue != null ? attributeValue : "*")))
-        );
+        // If value is defined, check each attribute for that value.
+        if (attributeValue != null) {
+            attributes.forEach(attribute ->
+                attributeFilter.addNode(new EqualityNode(attribute,
+                        attributeValue))
+            );
+        }
+        
+        // If no value is defined, just check for presence of attribute.
+        else {
+            attributes.forEach(attribute ->
+                attributeFilter.addNode(new PresenceNode(attribute))
+            );            
+        }
 
         searchFilter.addNode(attributeFilter);
 
+        logger.trace("Sending LDAP filter: \"{}\"", searchFilter.toString());
+        
         return searchFilter;
 
     }


### PR DESCRIPTION
This fixes a regression introduced in GUACAMOLE-234 where undefined attribute values are passed through rather than being checked and changed to wildcards, as was the behavior prior to swapping over to the Apache LDAP API.

I've requested this go into the staging/1.1.0 branch since it is a regression introduced by changes in that branch.