### PR TITLE
Modify the start time of the history session to match the GUAC_DATE and GUAC_TIME in the parameter tokens

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ COPY guacamole-docker/bin/ /opt/guacamole/bin/
 COPY . "$BUILD_DIR"
 
 # Run the build itself
+RUN ["chmod", "777", "/opt/guacamole/bin/build-guacamole.sh"]
+RUN ["chmod", "777", "/opt/guacamole/bin/start.sh"]
+
 RUN /opt/guacamole/bin/build-guacamole.sh "$BUILD_DIR" /opt/guacamole "$BUILD_PROFILE"
 
 # For the runtime image, we start with the official Tomcat distribution

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ActiveConnectionRecord.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ActiveConnectionRecord.java
@@ -68,7 +68,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
     /**
      * The time this connection record was created.
      */
-    private final Date startDate = new Date();
+    private Date startDate = new Date();
 
     /**
      * The UUID that will be assigned to the underlying tunnel.
@@ -81,7 +81,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
      * is the ID that must be supplied to guacd if joining this connection.
      */
     private String connectionID;
-    
+
     /**
      * The GuacamoleTunnel used by the connection associated with this
      * connection record.
@@ -143,7 +143,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
         this.connection = connection;
         this.sharingProfile = sharingProfile;
     }
-   
+
     /**
      * Initializes this connection record, associating it with the given user,
      * connection, and balancing connection group. The given balancing
@@ -209,6 +209,10 @@ public class ActiveConnectionRecord implements ConnectionRecord {
             ModeledSharingProfile sharingProfile) {
         init(user, null, activeConnection.getConnection(), sharingProfile);
         this.connectionID = activeConnection.getConnectionID();
+    }
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
     }
 
     /**
@@ -330,7 +334,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
 
         // Active connections have not yet ended
         return null;
-        
+
     }
 
     @Override
@@ -384,7 +388,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
             public GuacamoleSocket getSocket() {
                 return socket;
             }
-            
+
             @Override
             public UUID getUUID() {
                 return uuid;
@@ -398,7 +402,7 @@ public class ActiveConnectionRecord implements ConnectionRecord {
 
         // Return newly-created tunnel
         return this.tunnel;
-        
+
     }
 
     /**

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/StandardTokenMap.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/StandardTokenMap.java
@@ -73,7 +73,7 @@ public class StandardTokenMap extends HashMap<String, String> {
      * The date format that should be used for the time token. This format must
      * be compatible with Java's SimpleDateFormat.
      */
-    private static final String TIME_FORMAT = "HHmmss";
+    private static final String TIME_FORMAT = "HHmmss-SSS";
 
     /**
      * Creates a new StandardTokenMap which is pre-populated with the


### PR DESCRIPTION
Modify the start time of the history session to match the GUAC_DATE and GUAC_TIME in the parameter tokens. This historical session can correspond to screen recording files using GUAC_DATE and GUAC_TIME.