### PR TITLE
GUACAMOLE-234: Make LDAP user and group identifiers lowercase.

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
@@ -132,7 +132,8 @@ public class UserGroupService {
 
             // Translate entry into UserGroup object having proper identifier
             try {
-                String name = queryService.getIdentifier(entry, attributes);
+                String name =
+                        queryService.getIdentifier(entry, attributes).toLowerCase();
                 if (name != null)
                     return new SimpleUserGroup(name);
             }
@@ -218,7 +219,8 @@ public class UserGroupService {
 
             // Determine unique identifier for user group
             try {
-                String name = queryService.getIdentifier(entry, attributes);
+                String name =
+                        queryService.getIdentifier(entry, attributes).toLowerCase();
                 if (name != null)
                     identifiers.add(name);
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/LDAPAuthenticatedUser.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/LDAPAuthenticatedUser.java
@@ -87,7 +87,7 @@ public class LDAPAuthenticatedUser extends AbstractAuthenticatedUser {
         this.tokens = Collections.unmodifiableMap(tokens);
         this.effectiveGroups = effectiveGroups;
         this.bindDn = bindDn;
-        setIdentifier(credentials.getUsername());
+        setIdentifier(credentials.getUsername().toLowerCase());
     }
     
     /**

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/user/UserService.java
@@ -95,7 +95,8 @@ public class UserService {
 
             // Get username from record
             try {
-                String username = queryService.getIdentifier(entry, attributes);
+                String username =
+                        queryService.getIdentifier(entry, attributes).toLowerCase();
                 if (username == null) {
                     logger.warn("User \"{}\" is missing a username attribute "
                             + "and will be ignored.", entry.getDn().toString());


### PR DESCRIPTION
Not sure this is the right place/time to do this, or if it merits its own more comprehensive JIRA issue, but case sensitivity seems to cause some issues/confusion in the link between LDAP and JDBC modules.  Since LDAP is, in general, case insensitive, one possible solution is to push the LDAP username and group identifiers all to lower-case.