### PR TITLE
GUACAMOLE-361: CAS global logout

### DIFF
--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
@@ -63,6 +63,7 @@ public class CASGuacamoleProperties {
      */
     public static final URIGuacamoleProperty CAS_LOGOUT_URI =
             new URIGuacamoleProperty() {
+
         @Override
         public String getName() { return "cas-logout-uri"; }
 

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
@@ -58,6 +58,17 @@ public class CASGuacamoleProperties {
     };
 
     /**
+     * The URI that Guacamole should redirect to in order to
+     * log the current user out of CAS
+     */
+    public static final URIGuacamoleProperty CAS_LOGOUT_URI =
+            new URIGuacamoleProperty() {
+        @Override
+        public String getName() { return "cas-logout-uri"; }
+
+    };
+
+    /**
      * The location of the private key file used to retrieve the
      * password if CAS is configured to support ClearPass.
      */

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
@@ -69,6 +69,21 @@ public class ConfigurationService {
     public URI getRedirectURI() throws GuacamoleException {
         return environment.getRequiredProperty(CASGuacamoleProperties.CAS_REDIRECT_URI);
     }
+    /**
+     * Returns the URI that Guacamole redirects the clients browswer to in 
+     * order to log the current user out of CAS
+     *
+     * @return
+     *     The URI to redirect the client to log out of CAS
+     *     as configured in guacamole.properties.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed, or if the redirect URI
+     *     property is missing.
+     */
+    public URI getLogoutURI() throws GuacamoleException {
+        return environment.getRequiredProperty(CASGuacamoleProperties.CAS_LOGOUT_URI);
+    }
 
     /**
      * Returns the PrivateKey used to decrypt the credential object

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
@@ -69,8 +69,9 @@ public class ConfigurationService {
     public URI getRedirectURI() throws GuacamoleException {
         return environment.getRequiredProperty(CASGuacamoleProperties.CAS_REDIRECT_URI);
     }
+
     /**
-     * Returns the URI that Guacamole redirects the clients browswer to in 
+     * Returns the URI that Guacamole redirects the client browswer to in 
      * order to log the current user out of CAS
      *
      * @return

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/form/CASLogoutField.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/form/CASLogoutField.java
@@ -23,8 +23,6 @@ import javax.ws.rs.core.UriBuilder;
 import org.apache.guacamole.form.Field;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.cas.conf.ConfigurationService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -32,24 +30,15 @@ import org.slf4j.LoggerFactory;
  */
 public class CASLogoutField extends Field {
 
-    private static final Logger logger = LoggerFactory.getLogger(CASLogoutField.class);
-
+   /**
+    *  A parameter name for the field
+    */
     public static final String PARAMETER_NAME = "logout";
-
-    /**
-     * The standard URI name for the CAS logout resource.
-     */
-    private static final String CAS_LOGOUT_URI = "logout";
 
     /**
      * The full URI which the field should link to.
      */
     private final URI logoutURI;
-
-    /**
-     * Service for retrieving CAS configuration information.
-     */
-    private ConfigurationService confService;
 
     /**
      * Mimics the CAS ticket routine but calls logout...
@@ -66,6 +55,7 @@ public class CASLogoutField extends Field {
         // Init base field properties
         super(PARAMETER_NAME, "GUAC_CAS_LOGOUT");
         this.logoutURI = logoutURI;
+
     }
 
 

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/form/CASLogoutField.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/form/CASLogoutField.java
@@ -1,0 +1,82 @@
+/* * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.cas.form;
+
+import java.net.URI;
+import javax.ws.rs.core.UriBuilder;
+import org.apache.guacamole.form.Field;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.cas.conf.ConfigurationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Field definition used to redirect a user to CAS logout
+ */
+public class CASLogoutField extends Field {
+
+    private static final Logger logger = LoggerFactory.getLogger(CASLogoutField.class);
+
+    public static final String PARAMETER_NAME = "logout";
+
+    /**
+     * The standard URI name for the CAS logout resource.
+     */
+    private static final String CAS_LOGOUT_URI = "logout";
+
+    /**
+     * The full URI which the field should link to.
+     */
+    private final URI logoutURI;
+
+    /**
+     * Service for retrieving CAS configuration information.
+     */
+    private ConfigurationService confService;
+
+    /**
+     * Mimics the CAS ticket routine but calls logout...
+     *
+     * @param authorizationEndpoint
+     *     The full URL of the CAS logout URI
+     *
+     * @param logoutURI
+     *     The URI that Guacamole should redirect the user's browser to 
+     *     in order to logout
+     */
+    public CASLogoutField(URI logoutURI) {
+
+        // Init base field properties
+        super(PARAMETER_NAME, "GUAC_CAS_LOGOUT");
+        this.logoutURI = logoutURI;
+    }
+
+
+    /**
+     * Returns the full URI that this field should link to logging out
+     *
+     * @return
+     *     The full URI that this field should link to.
+     */
+    public String getlogoutURI() {
+        return logoutURI.toString();
+    }
+
+}

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
@@ -30,6 +30,7 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -38,7 +39,12 @@ import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.auth.cas.conf.ConfigurationService;
 import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.credentials.CredentialsInfo;
+import org.apache.guacamole.net.auth.credentials.GuacamoleInvalidCredentialsException;
+import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.token.TokenName;
+import org.apache.guacamole.form.Field;
+import org.apache.guacamole.auth.cas.form.CASLogoutField;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.Cas20ProxyTicketValidator;
@@ -134,7 +140,13 @@ public class TicketValidationService {
 
         } 
         catch (TicketValidationException e) {
-            throw new GuacamoleException("Ticket validation failed.", e);
+            throw new GuacamoleInvalidCredentialsException("Ticket validation failed.",
+                new CredentialsInfo(Arrays.asList(new Field[] {
+                 // Will automatically redirect the user
+                 // to the CAS logout page
+                 new CASLogoutField(confService.getLogoutURI())
+
+             })));
         }
 
     }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/user/CASAuthenticatedUser.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/user/CASAuthenticatedUser.java
@@ -22,9 +22,15 @@ package org.apache.guacamole.auth.cas.user;
 import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.guacamole.auth.cas.conf.ConfigurationService;
+import org.apache.guacamole.auth.cas.form.CASLogoutField;
+import org.apache.guacamole.form.Field;
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An CAS-specific implementation of AuthenticatedUser, associating a
@@ -33,12 +39,19 @@ import org.apache.guacamole.net.auth.Credentials;
  */
 public class CASAuthenticatedUser extends AbstractAuthenticatedUser {
 
+    private static final Logger logger = LoggerFactory.getLogger(CASAuthenticatedUser.class);
     /**
      * Reference to the authentication provider associated with this
      * authenticated user.
      */
     @Inject
     private AuthenticationProvider authProvider;
+
+    /**
+     * Service for retrieving CAS configuration information.
+     */
+    @Inject
+    private ConfigurationService confService;
 
     /**
      * The credentials provided when this user was authenticated.
@@ -107,4 +120,12 @@ public class CASAuthenticatedUser extends AbstractAuthenticatedUser {
         return credentials;
     }
 
+   @Override
+   public void invalidate() {
+	try {
+             new CASLogoutField(confService.getLogoutURI());
+        } catch (GuacamoleException e)  {
+             logger.debug("Need to set cas-logout-uri");
+        }
+   }
 }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/user/CASAuthenticatedUser.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/user/CASAuthenticatedUser.java
@@ -39,7 +39,12 @@ import org.slf4j.LoggerFactory;
  */
 public class CASAuthenticatedUser extends AbstractAuthenticatedUser {
 
+
+    /**
+     * Adding a logger for this class
+     */
     private static final Logger logger = LoggerFactory.getLogger(CASAuthenticatedUser.class);
+
     /**
      * Reference to the authentication provider associated with this
      * authenticated user.

--- a/extensions/guacamole-auth-cas/src/main/resources/config/casConfig.js
+++ b/extensions/guacamole-auth-cas/src/main/resources/config/casConfig.js
@@ -29,5 +29,11 @@ angular.module('guacCAS').config(['formServiceProvider',
         controller    : 'guacCASController',
         module        : 'guacCAS'
     });
+    // Define field for Logout from CAS service
+    formServiceProvider.registerFieldType("GUAC_CAS_LOGOUT", {
+        templateUrl   : 'app/ext/guac-cas/templates/casLogoutField.html',
+        controller    : 'guacCASLogoutController',
+        module        : 'guacCAS'
+    });
 
 }]);

--- a/extensions/guacamole-auth-cas/src/main/resources/config/casConfig.js
+++ b/extensions/guacamole-auth-cas/src/main/resources/config/casConfig.js
@@ -29,6 +29,7 @@ angular.module('guacCAS').config(['formServiceProvider',
         controller    : 'guacCASController',
         module        : 'guacCAS'
     });
+
     // Define field for Logout from CAS service
     formServiceProvider.registerFieldType("GUAC_CAS_LOGOUT", {
         templateUrl   : 'app/ext/guac-cas/templates/casLogoutField.html',

--- a/extensions/guacamole-auth-cas/src/main/resources/controllers/casController.js
+++ b/extensions/guacamole-auth-cas/src/main/resources/controllers/casController.js
@@ -28,3 +28,16 @@ angular.module('guacCAS').controller('guacCASController', ['$scope',
         window.location = $scope.field.authorizationURI;
 
 }]);
+/**
+ * Controller for the "GUAC_CAS_LOGOUT" field which deletes the GUAC_AUTH
+ * token in localStorage and redirects the user immediately to the CAS 
+ * logout URI
+ */
+angular.module('guacCAS').controller('guacCASLogoutController', ['$scope', 
+    function guacCASLogoutController($scope) {
+
+        // Redirect to logout URI
+        window.localStorage.removeItem("GUAC_AUTH");
+        window.location = $scope.field.logoutURI;
+
+}]);

--- a/extensions/guacamole-auth-cas/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-cas/src/main/resources/guac-manifest.json
@@ -24,7 +24,8 @@
     ],
 
     "resources" : {
-        "templates/casTicketField.html" : "text/html"
+        "templates/casTicketField.html" : "text/html",
+        "templates/casLogoutField.html" : "text/html"
     }
 
 }

--- a/extensions/guacamole-auth-cas/src/main/resources/styles/cas.css
+++ b/extensions/guacamole-auth-cas/src/main/resources/styles/cas.css
@@ -33,3 +33,19 @@
     vertical-align: middle;
     text-align: center;
 }
+.cas-logout-field-container {
+    height: 100%;
+    width: 100%;
+    position: fixed;
+    left: 0;
+    top: 0;
+    display: table;
+    background: white;
+}
+
+.cas-logout-field {
+    width: 100%;
+    display: table-cell;
+    vertical-align: middle;
+    text-align: center;
+}

--- a/extensions/guacamole-auth-cas/src/main/resources/styles/cas.css
+++ b/extensions/guacamole-auth-cas/src/main/resources/styles/cas.css
@@ -33,6 +33,7 @@
     vertical-align: middle;
     text-align: center;
 }
+
 .cas-logout-field-container {
     height: 100%;
     width: 100%;

--- a/extensions/guacamole-auth-cas/src/main/resources/templates/casLogoutField.html
+++ b/extensions/guacamole-auth-cas/src/main/resources/templates/casLogoutField.html
@@ -1,0 +1,5 @@
+<div class="cas-logout-field-container">
+    <div class="cas-logout-field">
+        <p>{{ 'LOGOUT.INFO_CAS_REDIRECT_PENDING' | translate }}</p>
+    </div>
+</div>

--- a/extensions/guacamole-auth-cas/src/main/resources/translations/de.json
+++ b/extensions/guacamole-auth-cas/src/main/resources/translations/de.json
@@ -7,6 +7,11 @@
     "LOGIN" : {
         "FIELD_HEADER_TICKET"        : "",
         "INFO_CAS_REDIRECT_PENDING"  : "Bitte warten, Sie werden zur CAS-Authentifizierung weitergeleitet..."
+    },
+
+    "LOGOUT" : {
+        "FIELD_HEADER_TICKET"        : "",
+        "INFO_CAS_REDIRECT_PENDING"  : "Bitte warten Sie, Sie werden zur CAS-Abmeldung weitergeleitet ..."
     }
 
 }

--- a/extensions/guacamole-auth-cas/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-cas/src/main/resources/translations/en.json
@@ -7,6 +7,11 @@
     "LOGIN" : {
         "FIELD_HEADER_TICKET"        : "",
         "INFO_CAS_REDIRECT_PENDING"  : "Please wait, redirecting to CAS authentication..."
-    }
+    },
+
+    "LOGOUT" : {
+        "FIELD_HEADER_TICKET"        : "",
+        "INFO_CAS_REDIRECT_PENDING"  : "Please wait, redirecting to CAS to logout..."
+    },
 
 }

--- a/extensions/guacamole-auth-cas/src/main/resources/translations/ja.json
+++ b/extensions/guacamole-auth-cas/src/main/resources/translations/ja.json
@@ -2,6 +2,11 @@
 
     "LOGIN" : {
         "INFO_CAS_REDIRECT_PENDING"  : "CAS認証にリダイレクトしています。"
-    }
+    },
+
+
+    "LOGOUT" : {
+        "INFO_CAS_REDIRECT_PENDING"  : "CASログアウトにリダイレクトしています。"
+    },
 
 }


### PR DESCRIPTION
Here's a somewhat functional (but probably less than stellar) attempt to make a CAS global logout.  There's much in Guacamole that I'm still unclear about and so my methodology might not be sound (basically, I mimic the login flow but redirect towards logout - I'm pretty sure I've done some slightly bizarre things along the way by including things I didn't fully understand...), but it works for logout from the connections screen menu!  It does not work from the "DISCONNECT" dialog that a user with, for example, a single RDP connection would get upon disconnecting from their RDP session, and choosing the LOGOUT button (that results in a redirect towards login that beats (timing) my attempt to redirect to the CAS logout page.