### PR TITLE
GUACAMOLE-852: Support either MySQL or MariaDB JDBC drivers

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLDriver.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLDriver.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.mysql;
+
+/**
+ * The possible JDBC drivers to use when talking to a MySQL-compatible database
+ * server.
+ */
+public enum MySQLDriver {
+
+    /**
+     * MySQL driver.
+     */
+    MYSQL,
+
+    /**
+     * MariaDB driver.
+     */
+    MARIADB;
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLDriverProperty.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLDriverProperty.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.mysql;
+
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.properties.GuacamoleProperty;
+
+/**
+ * A property whose value is a MySQL-compatible JDBC driver.  The string values
+ * of either "mysql" or "mariadb" are parsed into the corresponding MySQLDriver
+ * enum value. Any values that are not valid result in a parse error.
+ */
+public abstract class MySQLDriverProperty implements GuacamoleProperty<MySQLDriver> {
+
+    @Override
+    public MySQLDriver parseValue(String value) throws GuacamoleException {
+
+        // If no value provided, return null.
+        if (value == null)
+            return null;
+
+        // MySQL Driver
+        if (value.equals("mysql"))
+            return MySQLDriver.MYSQL;
+
+        // MariaDB Driver
+        if (value.equals("mariadb"))
+            return MySQLDriver.MARIADB;
+
+        throw new GuacamoleServerException("MySQL driver must be one of \"mysql\" or \"mariadb\".");
+
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLEnvironment.java
@@ -52,6 +52,11 @@ public class MySQLEnvironment extends JDBCEnvironment {
     private static final MySQLVersion MYSQL_SUPPORTS_CTE = new MySQLVersion(8, 0, 1, false);
 
     /**
+     * The default MySQL-compatible driver to use, if not specified.
+     */
+    private static final MySQLDriver DEFAULT_DRIVER = MySQLDriver.MYSQL;
+    
+    /**
      * The default host to connect to, if MYSQL_HOSTNAME is not specified.
      */
     private static final String DEFAULT_HOSTNAME = "localhost";
@@ -164,6 +169,25 @@ public class MySQLEnvironment extends JDBCEnvironment {
         return new MySQLPasswordPolicy(this);
     }
 
+    /**
+     * Returns the MySQL driver that will be used to talk to the MySQL-compatible
+     * database server hosting the Guacamole Client database.  If unspecified
+     * a default value of MySQL will be used.
+     * 
+     * @return
+     *     The MySQL driver that will be used to communicate with the MySQL-
+     *     compatible server.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed.
+     */
+    public MySQLDriver getMySQLDriver() throws GuacamoleException {
+        return getProperty(
+            MySQLGuacamoleProperties.MYSQL_DRIVER,
+            DEFAULT_DRIVER
+        );
+    }
+    
     /**
      * Returns the hostname of the MySQL server hosting the Guacamole
      * authentication tables. If unspecified, this will be "localhost".

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLGuacamoleProperties.java
@@ -32,6 +32,17 @@ public class MySQLGuacamoleProperties {
      * This class should not be instantiated.
      */
     private MySQLGuacamoleProperties() {}
+    
+    /**
+     * The JDBC driver that should be used to talk to MySQL-compatible servers.
+     */
+    public static final MySQLDriverProperty MYSQL_DRIVER =
+            new MySQLDriverProperty() {
+
+        @Override
+        public String getName() { return "mysql-driver"; }
+
+    };
 
     /**
      * The hostname of the MySQL server hosting the Guacamole authentication 


### PR DESCRIPTION
This pull request implements the necessary properties and logic to support both the MySQL JDBC driver and the Maria JDBC driver.  Similar to the way the SQL Server module supports various drivers, it adds a guacamole.properties entry for `mysql-driver` which can have the value either `mysql` or `mariadb`, and calls the necessary JdbcHelper for the configured driver.  The default stays at MySQL.