### PR TITLE
GUACAMOLE-930: Remove unnecessary $scope.$apply().

### DIFF
--- a/guacamole/src/main/webapp/app/form/controllers/languageFieldController.js
+++ b/guacamole/src/main/webapp/app/form/controllers/languageFieldController.js
@@ -40,9 +40,7 @@ angular.module('form').controller('languageFieldController', ['$scope', '$inject
 
     // Retrieve defined languages
     languageService.getLanguages().then(function languagesRetrieved(languages) {
-        $scope.$apply(function updateLanguageOptions() {
-            $scope.languages = languages;
-        });
+        $scope.languages = languages;
     }, requestService.DIE);
 
     // Interpret undefined/null as empty string


### PR DESCRIPTION
As noted on #453, a `[$rootScope:infdig]` error occurs on recent builds from git which prevents the language selection field from rendering. This is a regression from [GUACAMOLE-630](https://issues.apache.org/jira/browse/GUACAMOLE-630), specifically from commit 93ba19ac26a3509878023886eee0140bcf3face9, which changed the way that the injectors for fields are produced.

This change removes the `$apply()` call entirely, as it is unnecessary. Promises returned by the `$q` and `$http` services, including the promise returned by `languageService.getLanguages()`, will implicitly `$apply()` when needed.

It's not fully clear why this was not a problem before this commit. It may be that the way field injectors were produced in the past somehow did not satisfy the conditions which would normally result in an automatic `$apply()` for promises returned by `$http`.