### PR TITLE
GUACAMOLE-939: Make the guacamole docker integration easier

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -128,7 +128,7 @@ if [ -n "$GUACAMOLE_HOME" ]; then
         echo "No guacamole.properties file found in GUACAMOLE_HOME directory"
     fi
 else
-        echo "No GUACAMOLE_HOME Directory define."
+    echo "No GUACAMOLE_HOME Directory define."
 fi
 echo ""
 ##

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -41,10 +41,10 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ## GUACD_HOSTNAME and GUACD_PORT
 ##
 	GUACD_HOSTNAME=$(grep -i GUACD_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-	if [ -n "GUACD_HOSTNAME" ]; then
+	if [ -n "$GUACD_HOSTNAME" ]; then
 	    echo "Import GUACD_HOSTNAME with value $GUACD_HOSTNAME"
 	    GUACD_PORT=$(grep -i GUACD_PORT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "GUACD_PORT" ]; then
+            if [ -n "$GUACD_PORT" ]; then
                 echo "Import GUACD_PORT with value $GUACD_PORT"
             else
                 echo "GUACD_PORT not found in guacamole.properties"
@@ -56,10 +56,10 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ## MYSQL_DATABASE and MYSQL_DATABASE_FILE
 ##
         MYSQL_DATABASE=$(grep -i MYSQL_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "MYSQL_DATABASE" ]; then
+        if [ -n "$MYSQL_DATABASE" ]; then
             echo "Import MYSQL_DATABASE with value $MYSQL_DATABASE"
 	    MYSQL_DATABASE_FILE=$(grep -i MYSQL_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "MYSQL_DATABASE_FILE" ]; then
+            if [ -n "$MYSQL_DATABASE_FILE" ]; then
                 echo "Import MYSQL_DATABASE_FILE with value $MYSQL_DATABASE_FILE"
             else
                 echo "MYSQL_DATABASE_FILE not found in guacamole.properties"
@@ -71,10 +71,10 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ## POSTGRES_DATABASE and POSTGRES_DATABASE_FILE
 ##
         POSTGRES_DATABASE=$(grep -i POSTGRES_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "POSTGRES_DATABASE" ]; then
+        if [ -n "$POSTGRES_DATABASE" ]; then
             echo "Import POSTGRES_DATABASE with value $POSTGRES_DATABASE"
             POSTGRES_DATABASE_FILE=$(grep -i POSTGRES_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "POSTGRES_DATABASE_FILE" ]; then
+            if [ -n "$POSTGRES_DATABASE_FILE" ]; then
                 echo "Import POSTGRES_DATABASE_FILE with value $POSTGRES_DATABASE_FILE"
             else
                 echo "POSTGRES_DATABASE_FILE not found in guacamole.properties"
@@ -86,10 +86,10 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ## LDAP_HOSTNAME and LDAP_USER_BASE_DN
 ##
         LDAP_HOSTNAME=$(grep -i LDAP_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "LDAP_HOSTNAME" ]; then
+        if [ -n "$LDAP_HOSTNAME" ]; then
             echo "Import LDAP_HOSTNAME with value $LDAP_HOSTNAME"
 	    LDAP_USER_BASE_DN=$(grep -i LDAP_USER_BASE_DN $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2-99)
-            if [ -n "LDAP_USER_BASE_DN" ]; then
+            if [ -n "$LDAP_USER_BASE_DN" ]; then
                 echo "Import LDAP_USER_BASE_DN with value $LDAP_USER_BASE_DN"
             else
                 echo "LDAP_USER_BASE_DN not found in guacamole.properties"
@@ -101,7 +101,7 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ## RADIUS_SHARED_SECRET
 ##
         RADIUS_SHARED_SECRET=$(grep -i RADIUS_SHARED_SECRET $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "RADIUS_SHARED_SECRET" ]; then
+        if [ -n "$RADIUS_SHARED_SECRET" ]; then
             echo "Import RADIUS_SHARED_SECRET with value $RADIUS_SHARED_SECRET"
         else
             echo "RADIUS_SHARED_SECRET not found in guacamole.properties"
@@ -110,7 +110,7 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ## OPENID_AUTHORIZATION_ENDPOINT
 ##
         OPENID_AUTHORIZATION_ENDPOINT=$(grep -i OPENID_AUTHORIZATION_ENDPOINT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "OPENID_AUTHORIZATION_ENDPOINT" ]; then
+        if [ -n "$OPENID_AUTHORIZATION_ENDPOINT" ]; then
             echo "Import OPENID_AUTHORIZATION_ENDPOINT with value $OPENID_AUTHORIZATION_ENDPOINT"
         else
             echo "OPENID_AUTHORIZATION_ENDPOINT not found in guacamole.properties"

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -28,6 +28,103 @@
 ## script, running in the foreground until terminated.
 ##
 
+## pre read GUACAMOLE_PROPERTIES if exists
+## and get all variable that needed to start guacamole
+## like docker run -v /etc/guacamole:/config -e GUACAMOLE_HOME=/config 
+##
+
+if [ -n "$GUACAMOLE_HOME" ]; then
+    echo "Debug: check $GUACAMOLE_HOME/guacamole.properies file exists"
+    if [ -f "$GUACAMOLE_HOME/guacamole.properties" ]; then
+        echo "Try to import default values from guacamole.properties"
+##
+## GUACD_HOSTNAME and GUACD_PORT
+##
+	GUACD_HOSTNAME=$(grep -i GUACD_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+	if [ -n "GUACD_HOSTNAME" ]; then
+	    echo "Import GUACD_HOSTNAME with value $GUACD_HOSTNAME"
+	    GUACD_PORT=$(grep -i GUACD_PORT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+            if [ -n "GUACD_PORT" ]; then
+                echo "Import GUACD_PORT with value $GUACD_PORT"
+            else
+                echo "GUACD_PORT not found in guacamole.properties"
+            fi
+	else
+	    echo "GUACD_HOSTNAME not found in guacamole.properties"
+	fi
+##
+## MYSQL_DATABASE and MYSQL_DATABASE_FILE
+##
+        MYSQL_DATABASE=$(grep -i MYSQL_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "MYSQL_DATABASE" ]; then
+            echo "Import MYSQL_DATABASE with value $MYSQL_DATABASE"
+	    MYSQL_DATABASE_FILE=$(grep -i MYSQL_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+            if [ -n "MYSQL_DATABASE_FILE" ]; then
+                echo "Import MYSQL_DATABASE_FILE with value $MYSQL_DATABASE_FILE"
+            else
+                echo "MYSQL_DATABASE_FILE not found in guacamole.properties"
+            fi
+        else
+            echo "MYSQL_DATABASE not found in guacamole.properties"
+        fi
+##
+## POSTGRES_DATABASE and POSTGRES_DATABASE_FILE
+##
+        POSTGRES_DATABASE=$(grep -i POSTGRES_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "POSTGRES_DATABASE" ]; then
+            echo "Import POSTGRES_DATABASE with value $POSTGRES_DATABASE"
+            POSTGRES_DATABASE_FILE=$(grep -i POSTGRES_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+            if [ -n "POSTGRES_DATABASE_FILE" ]; then
+                echo "Import POSTGRES_DATABASE_FILE with value $POSTGRES_DATABASE_FILE"
+            else
+                echo "POSTGRES_DATABASE_FILE not found in guacamole.properties"
+            fi
+        else
+            echo "POSTGRES_DATABASE not found in guacamole.properties"
+        fi
+##
+## LDAP_HOSTNAME and LDAP_USER_BASE_DN
+##
+        LDAP_HOSTNAME=$(grep -i LDAP_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "LDAP_HOSTNAME" ]; then
+            echo "Import LDAP_HOSTNAME with value $LDAP_HOSTNAME"
+	    LDAP_USER_BASE_DN=$(grep -i LDAP_USER_BASE_DN $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2-99)
+            if [ -n "LDAP_USER_BASE_DN" ]; then
+                echo "Import LDAP_USER_BASE_DN with value $LDAP_USER_BASE_DN"
+            else
+                echo "LDAP_USER_BASE_DN not found in guacamole.properties"
+            fi
+        else
+            echo "LDAP_HOSTNAME not found in guacamole.properties"
+        fi
+##
+## RADIUS_SHARED_SECRET
+##
+        RADIUS_SHARED_SECRET=$(grep -i RADIUS_SHARED_SECRET $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "RADIUS_SHARED_SECRET" ]; then
+            echo "Import RADIUS_SHARED_SECRET with value $RADIUS_SHARED_SECRET"
+        else
+            echo "RADIUS_SHARED_SECRET not found in guacamole.properties"
+        fi
+##
+## OPENID_AUTHORIZATION_ENDPOINT
+##
+        OPENID_AUTHORIZATION_ENDPOINT=$(grep -i OPENID_AUTHORIZATION_ENDPOINT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "OPENID_AUTHORIZATION_ENDPOINT" ]; then
+            echo "Import OPENID_AUTHORIZATION_ENDPOINT with value $OPENID_AUTHORIZATION_ENDPOINT"
+        else
+            echo "OPENID_AUTHORIZATION_ENDPOINT not found in guacamole.properties"
+        fi
+##
+## end import
+##
+    else
+	echo "No guacamole.properties file found in GUACAMOLE_HOME directory"
+    fi
+fi
+
+## end: pre read
+
 GUACAMOLE_HOME_TEMPLATE="$GUACAMOLE_HOME"
 
 GUACAMOLE_HOME="$HOME/.guacamole"

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -40,14 +40,14 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 ## GUACD_HOSTNAME and GUACD_PORT
 ##
-	GUACD_HOSTNAME_CHECK=$(grep -i GUACD_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-	if [ -n "$GUACD_HOSTNAME_CHECK" ]; then
-	    echo " - import GUACD_HOSTNAME with value $GUACD_HOSTNAME_CHECK"
-	    GUACD_HOSTNAME=$GUACD_HOSTNAME_CHECK
-	    GUACD_PORT_CHECK=$(grep -i GUACD_PORT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "$GUACD_PORT_CHECK" ]; then
-                echo " - import GUACD_PORT with value $GUACD_PORT_CHECK"
-		GUACD_PORT=$GUACD_PORT_CHECK
+	CHECK_GUACD_HOSTNAME=$(grep -i GUACD_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+	if [ -n "$CHECK_GUACD_HOSTNAME" ]; then
+	    echo " - import GUACD_HOSTNAME with value $CHECK_GUACD_HOSTNAME"
+	    GUACD_HOSTNAME=$CHECK_GUACD_HOSTNAME
+	    CHECK_GUACD_PORT=$(grep -i GUACD_PORT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+            if [ -n "$CHECK_GUACD_PORT" ]; then
+                echo " - import GUACD_PORT with value $CHECK_GUACD_PORT"
+		GUACD_PORT=$CHECK_GUACD_PORT
             else
                 echo " - GUACD_PORT not found in guacamole.properties"
             fi
@@ -87,14 +87,14 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 ## LDAP_HOSTNAME and LDAP_USER_BASE_DN
 ##
-        LDAP_HOSTNAME_CHECK=$(grep -i LDAP_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$LDAP_HOSTNAME_CHECK" ]; then
-            echo " - import LDAP_HOSTNAME with value $LDAP_HOSTNAME_CHECK"
-	    LDAP_HOSTNAME=$LDAP_HOSTNAME_CHECK
-	    LDAP_USER_BASE_DN_CHECK=$(grep -i LDAP_USER_BASE_DN $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2-99)
-            if [ -n "$LDAP_USER_BASE_DN_CHECL" ]; then
-                echo " - import LDAP_USER_BASE_DN_CHECK with value $LDAP_USER_BASE_DN_CHECK"
-		LDAP_USER_BASE_DN=$LDAP_USER_BASE_DN_CHECK
+        CHECK_LDAP_HOSTNAME=$(grep -i LDAP_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "$CHECK_LDAP_HOSTNAME" ]; then
+            echo " - import LDAP_HOSTNAME with value $CHECK_LDAP_HOSTNAME"
+	    LDAP_HOSTNAME=$CHECK_LDAP_HOSTNAME
+	    CHECK_LDAP_USER_BASE_DN=$(grep -i LDAP_USER_BASE_DN $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2-99)
+            if [ -n "$CHECK_LDAP_USER_BASE_DN" ]; then
+                echo " - import CHECK_LDAP_USER_BASE_DN with value $CHECK_LDAP_USER_BASE_DN"
+		LDAP_USER_BASE_DN=$CHECK_LDAP_USER_BASE_DN
             else
                 echo " - LDAP_USER_BASE_DN not found in guacamole.properties"
             fi

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -31,7 +31,6 @@
 ## pre read GUACAMOLE_PROPERTIES if exists
 ## and get all variable that needed to start guacamole
 ## - like docker run -v /etc/guacamole:/config -e GUACAMOLE_HOME=/config 
-## - DEBUG_LEVEL = info, in guacamole.properies file
 
 if [ -n "$GUACAMOLE_HOME" ]; then
     echo "Found $GUACAMOLE_HOME/guacamole.properies file."
@@ -44,14 +43,13 @@ if [ -n "$GUACAMOLE_HOME" ]; then
         mkdir -p $GUACAMOLE_HOME-tmp
         cp -r $GUACAMOLE_HOME/* $GUACAMOLE_HOME-tmp/
         GUACAMOLE_HOME=$GUACAMOLE_HOME-tmp
-	echo " - new GUACAMOLE_HOME directory is $GUACAMOLE_HOME"
+	    echo " - new GUACAMOLE_HOME directory is $GUACAMOLE_HOME"
 ##
 ## read guaacamole.properties
 ##
         while IFS= read -r line; do
             # echo "Text read from file: $line"
             # echo "Debug: line:$line - value $(echo $line | cut -d':' -f2 | tr '[:lower:]' '[:upper:]')"
-	    # keyname="$(echo $line  | cut -d':' -f1 | tr '[:lower:]' '[:upper:]')"
             case $(echo $line  | cut -d':' -f1 | tr '[:lower:]' '[:upper:]') in
 ##
 ## GUACD_HOSTNAME and GUACD_PORT
@@ -101,11 +99,6 @@ if [ -n "$GUACAMOLE_HOME" ]; then
                     sed -i '/LDAP_USER_BASE_DN/Id;/LDAP-USER-BASE-DN/Id' $GUACAMOLE_HOME/guacamole.properties
                     echo " - LDAP_USER_BASE_DN is set to $LDAP_USER_BASE_DN"
                 ;;
-	        DEBUG_LEVEL|DEBUG-LEVEL)
-                    DEBUG_LEVEL=$(echo $line | cut -d: -f2)
-                    sed -i 's/<root level.*/<root level=\"$DEBUG_LEVEL\">/' /usr/local/tomcat/webapps/guacamole/WEB-INF/classes/logback.xml
-		    echo " - DEBUG_LEVEL is set to $DEBUG_LEVEL i /usr/local/tomcat/webapps/guacamole/WEB-INF/classes/logback.xml"
-		;;
             esac
         done < $GUACAMOLE_HOME/guacamole.properties
 

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -34,7 +34,7 @@
 ##
 
 if [ -n "$GUACAMOLE_HOME" ]; then
-    echo "Debug: check $GUACAMOLE_HOME/guacamole.properies file exists"
+    echo "Found $GUACAMOLE_HOME/guacamole.properies file."
     if [ -f "$GUACAMOLE_HOME/guacamole.properties" ]; then
         echo "Try to import default values from guacamole.properties"
 ##
@@ -42,78 +42,78 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 	GUACD_HOSTNAME=$(grep -i GUACD_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
 	if [ -n "$GUACD_HOSTNAME" ]; then
-	    echo "Import GUACD_HOSTNAME with value $GUACD_HOSTNAME"
+	    echo " - import GUACD_HOSTNAME with value $GUACD_HOSTNAME"
 	    GUACD_PORT=$(grep -i GUACD_PORT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
             if [ -n "$GUACD_PORT" ]; then
-                echo "Import GUACD_PORT with value $GUACD_PORT"
+                echo " - import GUACD_PORT with value $GUACD_PORT"
             else
-                echo "GUACD_PORT not found in guacamole.properties"
+                echo " - GUACD_PORT not found in guacamole.properties"
             fi
 	else
-	    echo "GUACD_HOSTNAME not found in guacamole.properties"
+	    echo " - GUACD_HOSTNAME not found in guacamole.properties"
 	fi
 ##
 ## MYSQL_DATABASE and MYSQL_DATABASE_FILE
 ##
         MYSQL_DATABASE=$(grep -i MYSQL_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
         if [ -n "$MYSQL_DATABASE" ]; then
-            echo "Import MYSQL_DATABASE with value $MYSQL_DATABASE"
+            echo " - import MYSQL_DATABASE with value $MYSQL_DATABASE"
 	    MYSQL_DATABASE_FILE=$(grep -i MYSQL_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
             if [ -n "$MYSQL_DATABASE_FILE" ]; then
-                echo "Import MYSQL_DATABASE_FILE with value $MYSQL_DATABASE_FILE"
+                echo " - import MYSQL_DATABASE_FILE with value $MYSQL_DATABASE_FILE"
             else
-                echo "MYSQL_DATABASE_FILE not found in guacamole.properties"
+                echo " - MYSQL_DATABASE_FILE not found in guacamole.properties"
             fi
         else
-            echo "MYSQL_DATABASE not found in guacamole.properties"
+            echo " - MYSQL_DATABASE not found in guacamole.properties"
         fi
 ##
 ## POSTGRES_DATABASE and POSTGRES_DATABASE_FILE
 ##
         POSTGRES_DATABASE=$(grep -i POSTGRES_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
         if [ -n "$POSTGRES_DATABASE" ]; then
-            echo "Import POSTGRES_DATABASE with value $POSTGRES_DATABASE"
+            echo " - import POSTGRES_DATABASE with value $POSTGRES_DATABASE"
             POSTGRES_DATABASE_FILE=$(grep -i POSTGRES_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
             if [ -n "$POSTGRES_DATABASE_FILE" ]; then
-                echo "Import POSTGRES_DATABASE_FILE with value $POSTGRES_DATABASE_FILE"
+                echo " - import POSTGRES_DATABASE_FILE with value $POSTGRES_DATABASE_FILE"
             else
-                echo "POSTGRES_DATABASE_FILE not found in guacamole.properties"
+                echo " - POSTGRES_DATABASE_FILE not found in guacamole.properties"
             fi
         else
-            echo "POSTGRES_DATABASE not found in guacamole.properties"
+            echo " - POSTGRES_DATABASE not found in guacamole.properties"
         fi
 ##
 ## LDAP_HOSTNAME and LDAP_USER_BASE_DN
 ##
         LDAP_HOSTNAME=$(grep -i LDAP_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
         if [ -n "$LDAP_HOSTNAME" ]; then
-            echo "Import LDAP_HOSTNAME with value $LDAP_HOSTNAME"
+            echo " - import LDAP_HOSTNAME with value $LDAP_HOSTNAME"
 	    LDAP_USER_BASE_DN=$(grep -i LDAP_USER_BASE_DN $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2-99)
             if [ -n "$LDAP_USER_BASE_DN" ]; then
-                echo "Import LDAP_USER_BASE_DN with value $LDAP_USER_BASE_DN"
+                echo " - import LDAP_USER_BASE_DN with value $LDAP_USER_BASE_DN"
             else
-                echo "LDAP_USER_BASE_DN not found in guacamole.properties"
+                echo " - LDAP_USER_BASE_DN not found in guacamole.properties"
             fi
         else
-            echo "LDAP_HOSTNAME not found in guacamole.properties"
+            echo " - LDAP_HOSTNAME not found in guacamole.properties"
         fi
 ##
 ## RADIUS_SHARED_SECRET
 ##
         RADIUS_SHARED_SECRET=$(grep -i RADIUS_SHARED_SECRET $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
         if [ -n "$RADIUS_SHARED_SECRET" ]; then
-            echo "Import RADIUS_SHARED_SECRET with value $RADIUS_SHARED_SECRET"
+            echo " - import RADIUS_SHARED_SECRET with value $RADIUS_SHARED_SECRET"
         else
-            echo "RADIUS_SHARED_SECRET not found in guacamole.properties"
+            echo " - RADIUS_SHARED_SECRET not found in guacamole.properties"
         fi
 ##
 ## OPENID_AUTHORIZATION_ENDPOINT
 ##
         OPENID_AUTHORIZATION_ENDPOINT=$(grep -i OPENID_AUTHORIZATION_ENDPOINT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
         if [ -n "$OPENID_AUTHORIZATION_ENDPOINT" ]; then
-            echo "Import OPENID_AUTHORIZATION_ENDPOINT with value $OPENID_AUTHORIZATION_ENDPOINT"
+            echo " - import OPENID_AUTHORIZATION_ENDPOINT with value $OPENID_AUTHORIZATION_ENDPOINT"
         else
-            echo "OPENID_AUTHORIZATION_ENDPOINT not found in guacamole.properties"
+            echo " - OPENID_AUTHORIZATION_ENDPOINT not found in guacamole.properties"
         fi
 ##
 ## end import
@@ -122,7 +122,7 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 	echo "No guacamole.properties file found in GUACAMOLE_HOME directory"
     fi
 fi
-
+echo ""
 ## end: pre read
 
 GUACAMOLE_HOME_TEMPLATE="$GUACAMOLE_HOME"

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -57,12 +57,14 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 ## MYSQL_DATABASE and MYSQL_DATABASE_FILE
 ##
-        MYSQL_DATABASE=$(grep -i MYSQL_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$MYSQL_DATABASE" ]; then
-            echo " - import MYSQL_DATABASE with value $MYSQL_DATABASE"
-	    MYSQL_DATABASE_FILE=$(grep -i MYSQL_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "$MYSQL_DATABASE_FILE" ]; then
-                echo " - import MYSQL_DATABASE_FILE with value $MYSQL_DATABASE_FILE"
+        CHECK_MYSQL_DATABASE=$(grep -i MYSQL_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "$CHECK_MYSQL_DATABASE" ]; then
+            echo " - import MYSQL_DATABASE with value $CHECK_MYSQL_DATABASE"
+	    MYSQL_DATABASE=$CHECK_MYSQL_DATABASE
+	    CHECK_MYSQL_DATABASE_FILE=$(grep -i MYSQL_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+            if [ -n "$CHECK_MYSQL_DATABASE_FILE" ]; then
+                echo " - import MYSQL_DATABASE_FILE with value $CHECK_MYSQL_DATABASE_FILE"
+		MYSQL_DATABASE_FILE=$CHECK_MYSQL_DATABASE_FILE
             else
                 echo " - MYSQL_DATABASE_FILE not found in guacamole.properties"
             fi
@@ -72,12 +74,14 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 ## POSTGRES_DATABASE and POSTGRES_DATABASE_FILE
 ##
-        POSTGRES_DATABASE=$(grep -i POSTGRES_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$POSTGRES_DATABASE" ]; then
-            echo " - import POSTGRES_DATABASE with value $POSTGRES_DATABASE"
-            POSTGRES_DATABASE_FILE=$(grep -i POSTGRES_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "$POSTGRES_DATABASE_FILE" ]; then
-                echo " - import POSTGRES_DATABASE_FILE with value $POSTGRES_DATABASE_FILE"
+        CHECK_POSTGRES_DATABASE=$(grep -i POSTGRES_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "$CHECK_POSTGRES_DATABASE" ]; then
+            echo " - import POSTGRES_DATABASE with value $CHECK_POSTGRES_DATABASE"
+	    POSTGRES_DATABASE=$CHECK_POSTGRES_DATABASE
+            CHECK_POSTGRES_DATABASE_FILE=$(grep -i POSTGRES_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+            if [ -n "$CHECK_POSTGRES_DATABASE_FILE" ]; then
+                echo " - import POSTGRES_DATABASE_FILE with value $CHECK_POSTGRES_DATABASE_FILE"
+		POSTGRES_DATABASE_FILE=$CHECK_POSTGRES_DATABASE_FILE
             else
                 echo " - POSTGRES_DATABASE_FILE not found in guacamole.properties"
             fi
@@ -104,18 +108,20 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 ## RADIUS_SHARED_SECRET
 ##
-        RADIUS_SHARED_SECRET=$(grep -i RADIUS_SHARED_SECRET $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$RADIUS_SHARED_SECRET" ]; then
-            echo " - import RADIUS_SHARED_SECRET with value $RADIUS_SHARED_SECRET"
+        CHECK_RADIUS_SHARED_SECRET=$(grep -i RADIUS_SHARED_SECRET $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "$CHECK_RADIUS_SHARED_SECRET" ]; then
+            echo " - import RADIUS_SHARED_SECRET with value $CHECK_RADIUS_SHARED_SECRET"
+	    RADIUS_SHARED_SECRET=$CHECK_RADIUS_SHARED_SECRET
         else
             echo " - RADIUS_SHARED_SECRET not found in guacamole.properties"
         fi
 ##
 ## OPENID_AUTHORIZATION_ENDPOINT
 ##
-        OPENID_AUTHORIZATION_ENDPOINT=$(grep -i OPENID_AUTHORIZATION_ENDPOINT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$OPENID_AUTHORIZATION_ENDPOINT" ]; then
-            echo " - import OPENID_AUTHORIZATION_ENDPOINT with value $OPENID_AUTHORIZATION_ENDPOINT"
+        CHECK_OPENID_AUTHORIZATION_ENDPOINT=$(grep -i OPENID_AUTHORIZATION_ENDPOINT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "$CHECK_OPENID_AUTHORIZATION_ENDPOINT" ]; then
+            echo " - import OPENID_AUTHORIZATION_ENDPOINT with value $CHECK_OPENID_AUTHORIZATION_ENDPOINT"
+	    OPENID_AUTHORIZATION_ENDPOINT=$CHECK_OPENID_AUTHORIZATION_ENDPOINT
         else
             echo " - OPENID_AUTHORIZATION_ENDPOINT not found in guacamole.properties"
         fi

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -40,12 +40,14 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 ## GUACD_HOSTNAME and GUACD_PORT
 ##
-	GUACD_HOSTNAME=$(grep -i GUACD_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-	if [ -n "$GUACD_HOSTNAME" ]; then
-	    echo " - import GUACD_HOSTNAME with value $GUACD_HOSTNAME"
-	    GUACD_PORT=$(grep -i GUACD_PORT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "$GUACD_PORT" ]; then
-                echo " - import GUACD_PORT with value $GUACD_PORT"
+	GUACD_HOSTNAME_CHECK=$(grep -i GUACD_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+	if [ -n "$GUACD_HOSTNAME_CHECK" ]; then
+	    echo " - import GUACD_HOSTNAME with value $GUACD_HOSTNAME_CHECK"
+	    GUACD_HOSTNAME=$GUACD_HOSTNAME_CHECK
+	    GUACD_PORT_CHECK=$(grep -i GUACD_PORT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+            if [ -n "$GUACD_PORT_CHECK" ]; then
+                echo " - import GUACD_PORT with value $GUACD_PORT_CHECK"
+		GUACD_PORT=$GUACD_PORT_CHECK
             else
                 echo " - GUACD_PORT not found in guacamole.properties"
             fi
@@ -85,12 +87,14 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
 ## LDAP_HOSTNAME and LDAP_USER_BASE_DN
 ##
-        LDAP_HOSTNAME=$(grep -i LDAP_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$LDAP_HOSTNAME" ]; then
-            echo " - import LDAP_HOSTNAME with value $LDAP_HOSTNAME"
-	    LDAP_USER_BASE_DN=$(grep -i LDAP_USER_BASE_DN $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2-99)
-            if [ -n "$LDAP_USER_BASE_DN" ]; then
-                echo " - import LDAP_USER_BASE_DN with value $LDAP_USER_BASE_DN"
+        LDAP_HOSTNAME_CHECK=$(grep -i LDAP_HOSTNAME $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
+        if [ -n "$LDAP_HOSTNAME_CHECK" ]; then
+            echo " - import LDAP_HOSTNAME with value $LDAP_HOSTNAME_CHECK"
+	    LDAP_HOSTNAME=$LDAP_HOSTNAME_CHECK
+	    LDAP_USER_BASE_DN_CHECK=$(grep -i LDAP_USER_BASE_DN $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2-99)
+            if [ -n "$LDAP_USER_BASE_DN_CHECL" ]; then
+                echo " - import LDAP_USER_BASE_DN_CHECK with value $LDAP_USER_BASE_DN_CHECK"
+		LDAP_USER_BASE_DN=$LDAP_USER_BASE_DN_CHECK
             else
                 echo " - LDAP_USER_BASE_DN not found in guacamole.properties"
             fi

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -125,9 +125,10 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ## end import
 ##
     else
-	    echo "No guacamole.properties file found in GUACAMOLE_HOME directory"
+        echo "No guacamole.properties file found in GUACAMOLE_HOME directory"
     fi
-    echo "No GUACAMOLE_HOME Directory define."
+else
+        echo "No GUACAMOLE_HOME Directory define."
 fi
 echo ""
 ##

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -69,10 +69,12 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
                 MYSQL_DATABASE)
                     MYSQL_DATABASE=$(echo $line | cut -d= -f2)
+                    sed -i '/MYSQL_DATABASE/Id;/MYSQL_DATABASE/Id' $GUACAMOLE_HOME/guacamole.properties
                     echo " - MYSQL_DATABASE is set to $MYSQL_DATABASE"
                 ;;
                 MYSQL_DATABASE_FILE)
                     MYSQL_DATABASE_FILE=$(echo $line | cut -d= -f2)
+                    sed -i '/MYSQL_DATABASE_FILE/Id;/MYSQL_DATABASE_FILE/Id' $GUACAMOLE_HOME/guacamole.properties
                     echo " - MYSQL_DATABASE_FILE is set to $MYSQL_DATABASE_FILE)"
                 ;;
 ##
@@ -80,10 +82,12 @@ if [ -n "$GUACAMOLE_HOME" ]; then
 ##
                 POSTGRES_DATABASE)
                     POSTGRES_DATABASE=$(echo $line | cut -d= -f2)
+                    sed -i '/POSTGRES_DATABASE/Id;/POSTGRES_DATABASE/Id' $GUACAMOLE_HOME/guacamole.properties
                     echo " - POSTGRES_DATABASE is set to $POSTGRES_DATABASE)"
                 ;;
                 POSTGRES_DATABASE_FILE)
                     POSTGRES_DATABASE_FILE=$(echo $line | cut -d= -f2)
+                    sed -i '/POSTGRES_DATABASE_FILE/Id;/POSTGRES_DATABASE_FILE/Id' $GUACAMOLE_HOME/guacamole.properties
                     echo " - POSTGRES_DATABASE_FILE is set to $POSTGRES_DATABASE_FILE"
                 ;;
 ##
@@ -99,74 +103,36 @@ if [ -n "$GUACAMOLE_HOME" ]; then
                     sed -i '/LDAP_USER_BASE_DN/Id;/LDAP-USER-BASE-DN/Id' $GUACAMOLE_HOME/guacamole.properties
                     echo " - LDAP_USER_BASE_DN is set to $LDAP_USER_BASE_DN"
                 ;;
-            esac
-        done < $GUACAMOLE_HOME/guacamole.properties
-
-
-##
-## MYSQL_DATABASE and MYSQL_DATABASE_FILE
-##
-        CHECK_MYSQL_DATABASE=$(grep -i MYSQL_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$CHECK_MYSQL_DATABASE" ]; then
-            echo " - import MYSQL_DATABASE with value $CHECK_MYSQL_DATABASE"
-	    MYSQL_DATABASE=$CHECK_MYSQL_DATABASE
-	    CHECK_MYSQL_DATABASE_FILE=$(grep -i MYSQL_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "$CHECK_MYSQL_DATABASE_FILE" ]; then
-                echo " - import MYSQL_DATABASE_FILE with value $CHECK_MYSQL_DATABASE_FILE"
-		MYSQL_DATABASE_FILE=$CHECK_MYSQL_DATABASE_FILE
-            else
-                echo " - MYSQL_DATABASE_FILE not found in guacamole.properties"
-            fi
-        else
-            echo " - MYSQL_DATABASE not found in guacamole.properties"
-        fi
-##
-## POSTGRES_DATABASE and POSTGRES_DATABASE_FILE
-##
-        CHECK_POSTGRES_DATABASE=$(grep -i POSTGRES_DATABASE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$CHECK_POSTGRES_DATABASE" ]; then
-            echo " - import POSTGRES_DATABASE with value $CHECK_POSTGRES_DATABASE"
-	    POSTGRES_DATABASE=$CHECK_POSTGRES_DATABASE
-            CHECK_POSTGRES_DATABASE_FILE=$(grep -i POSTGRES_DATABASE_FILE $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-            if [ -n "$CHECK_POSTGRES_DATABASE_FILE" ]; then
-                echo " - import POSTGRES_DATABASE_FILE with value $CHECK_POSTGRES_DATABASE_FILE"
-		POSTGRES_DATABASE_FILE=$CHECK_POSTGRES_DATABASE_FILE
-            else
-                echo " - POSTGRES_DATABASE_FILE not found in guacamole.properties"
-            fi
-        else
-            echo " - POSTGRES_DATABASE not found in guacamole.properties"
-        fi
 ##
 ## RADIUS_SHARED_SECRET
 ##
-        CHECK_RADIUS_SHARED_SECRET=$(grep -i RADIUS_SHARED_SECRET $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$CHECK_RADIUS_SHARED_SECRET" ]; then
-            echo " - import RADIUS_SHARED_SECRET with value $CHECK_RADIUS_SHARED_SECRET"
-	    RADIUS_SHARED_SECRET=$CHECK_RADIUS_SHARED_SECRET
-        else
-            echo " - RADIUS_SHARED_SECRET not found in guacamole.properties"
-        fi
+                RADIUS_SHARED_SECRET|RADIUS-SHARED-SECRET)
+                    RADIUS_SHARED_SECRET=$(echo $line | cut -d: -f2)
+                    sed -i '/RADIUS_SHARED_SECRET/Id;/RADIUS-SHARED-SECRET/Id' $GUACAMOLE_HOME/guacamole.properties
+                    echo " - RADIUS_SHARED_SECRET is set to $RADIUS_SHARED_SECRET"
+                ;;
 ##
 ## OPENID_AUTHORIZATION_ENDPOINT
 ##
-        CHECK_OPENID_AUTHORIZATION_ENDPOINT=$(grep -i OPENID_AUTHORIZATION_ENDPOINT $GUACAMOLE_HOME/guacamole.properties | cut -d= -f2)
-        if [ -n "$CHECK_OPENID_AUTHORIZATION_ENDPOINT" ]; then
-            echo " - import OPENID_AUTHORIZATION_ENDPOINT with value $CHECK_OPENID_AUTHORIZATION_ENDPOINT"
-	    OPENID_AUTHORIZATION_ENDPOINT=$CHECK_OPENID_AUTHORIZATION_ENDPOINT
-        else
-            echo " - OPENID_AUTHORIZATION_ENDPOINT not found in guacamole.properties"
-        fi
+                OPENID_AUTHORIZATION_ENDPOINT|OPENID_AUTHORIZATION_ENDPOINT)
+                    OPENID_AUTHORIZATION_ENDPOINT=$(echo $line | cut -d: -f2)
+                    sed -i '/OPENID_AUTHORIZATION_ENDPOINT/Id;/OPENID-AUTHORIZATION-ENDPOINT/Id' $GUACAMOLE_HOME/guacamole.properties
+                    echo " - OPENID_AUTHORIZATION_ENDPOINT is set to $OPENID_AUTHORIZATION_ENDPOINT"
+                ;;
+            esac
+        done < $GUACAMOLE_HOME/guacamole.properties
 ##
 ## end import
 ##
     else
-	echo "No guacamole.properties file found in GUACAMOLE_HOME directory"
+	    echo "No guacamole.properties file found in GUACAMOLE_HOME directory"
     fi
     echo "No GUACAMOLE_HOME Directory define."
 fi
 echo ""
+##
 ## end: pre read
+##
 
 GUACAMOLE_HOME_TEMPLATE="$GUACAMOLE_HOME"
 


### PR DESCRIPTION
Patch 1

The new start.sh file pre read required varible from guacamole.properties to configure the tomcat web interface.
This make it mutch easier to start the docker container without so many options.

Thomas