### PR TITLE
GUACAMOLE-753: Add TOTP auth method to Docker image

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -127,12 +127,22 @@ if [ -f extensions/guacamole-auth-radius/target/guacamole-auth-radius*.jar ]; th
     cp extensions/guacamole-auth-radius/target/guacamole-auth-radius*.jar "$DESTINATION/radius"
 fi
 
+#
 # Copy OPENID auth extension and schema modifications
 #
 
 if [ -f extensions/guacamole-auth-openid/target/guacamole-auth-openid*.jar ]; then
     mkdir -p "$DESTINATION/openid"
     cp extensions/guacamole-auth-openid/target/guacamole-auth-openid*.jar "$DESTINATION/openid"
+fi
+
+#
+# Copy TOTP auth extension if it was built
+#
+
+if [ -f extensions/guacamole-auth-totp/target/guacamole-auth-totp*.jar ]; then
+    mkdir -p "$DESTINATION/totp"
+    cp extensions/guacamole-auth-totp/target/guacamole-auth-totp*.jar "$DESTINATION/totp"
 fi
 
 #

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -537,6 +537,21 @@ END
 }
 
 ##
+## Adds properties to guacamole.properties which configure the TOTP two-factor
+## authentication mechanism.
+##
+associate_totp() {
+    # Update config file
+    set_optional_property "totp-issuer"    "$TOTP_ISSUER"
+    set_optional_property "totp-digits"    "$TOTP_DIGITS"
+    set_optional_property "totp-period"    "$TOTP_PERIOD"
+    set_optional_property "totp-mode"      "$TOTP_MODE"
+
+    # Add required .jar files to GUACAMOLE_EXT
+    ln -s /opt/guacamole/totp/guacamole-auth-*.jar   "$GUACAMOLE_EXT"
+}
+
+##
 ## Adds properties to guacamole.properties which configure the Duo two-factor
 ## authentication service. Checks to see if all variables are defined and makes sure
 ## DUO_APPLICATION_KEY is >= 40 characters.
@@ -705,6 +720,11 @@ POSTGRES_DATABASE environment variables, or check Guacamole's Docker
 documentation regarding configuring LDAP and/or custom extensions.
 END
     exit 1;
+fi
+
+# Use TOTP if specified.
+if [ "$TOTP_ENABLED" = "true" ]; then
+    associate_totp
 fi
 
 # Use Duo if specified.


### PR DESCRIPTION
Hi,

This PR adds TOTP authentication method to the Docker image.
It's really helpful, making TOTP easy to use with Docker.

Let's merge this low-impact PR with #469 in a 1.1.1 Docker image ?

Many thanks 👍 