### PR TITLE
GUACAMOLE-955: Provide default translation string for all untranslated messages.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/APIError.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/APIError.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.rest;
 
 import java.util.Collection;
+import java.util.Collections;
 import org.apache.guacamole.GuacamoleClientException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleResourceNotFoundException;
@@ -36,6 +37,19 @@ import org.apache.guacamole.tunnel.GuacamoleStreamException;
  * Describes an error that occurred within a REST endpoint.
  */
 public class APIError {
+
+    /**
+     * The translation key of the generic translation string which should be
+     * used to display arbitrary messages which otherwise have no translation
+     * string.
+     */
+    private static final String UNTRANSLATED_MESSAGE_KEY = "APP.TEXT_UNTRANSLATED";
+
+    /**
+     * The name of the placeholder within the translation string associated with
+     * UNTRANSLATED_MESSAGE_KEY that should receive the raw, untranslated text.
+     */
+    private static final String UNTRANSLATED_MESSAGE_VARIABLE_NAME = "MESSAGE";
 
     /**
      * The human-readable error message.
@@ -187,8 +201,11 @@ public class APIError {
             Translatable translatable = (Translatable) exception;
             this.translatableMessage = translatable.getTranslatableMessage();
         }
+
+        // Use generic translation string if message is not translated
         else
-            this.translatableMessage = new TranslatableMessage(this.message);
+            this.translatableMessage = new TranslatableMessage(UNTRANSLATED_MESSAGE_KEY,
+                    Collections.singletonMap(UNTRANSLATED_MESSAGE_VARIABLE_NAME, this.message));
 
     }
 

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -46,7 +46,8 @@
         "INFO_ACTIVE_USER_COUNT" : "Currently in use by {USERS} {USERS, plural, one{user} other{users}}.",
 
         "TEXT_ANONYMOUS_USER"   : "Anonymous",
-        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
+        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}",
+        "TEXT_UNTRANSLATED" : "{MESSAGE}"
 
     },
 


### PR DESCRIPTION
This change defines a new `APP.TEXT_UNTRANSLATED` string which leverages variable substitution to provide a means of automatically defining strings for otherwise untranslated errors.