### PR TITLE
GUACAMOLE-1001: Add Client IP and NAS attributes to RADIUS requests.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/AuthenticationProviderService.java
@@ -159,7 +159,9 @@ public class AuthenticationProviderService {
 
             try {
                 radPack = radiusService.authenticate(credentials.getUsername(),
-                                                credentials.getPassword(), null);
+                                                credentials.getPassword(),
+                                                credentials.getRemoteAddress(),
+                                                null);
             }
             catch (GuacamoleException e) {
                 logger.error("Cannot configure RADIUS server: {}", e.getMessage());
@@ -180,6 +182,7 @@ public class AuthenticationProviderService {
                 byte[] stateBytes = BaseEncoding.base16().decode(stateString);
                 radPack = radiusService.sendChallengeResponse(credentials.getUsername(),
                                                               challengeResponse,
+                                                              credentials.getRemoteAddress(),
                                                               stateBytes);
             }
             catch (IllegalArgumentException e) {

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
@@ -33,6 +33,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import net.jradius.client.RadiusClient;
 import net.jradius.dictionary.Attr_CleartextPassword;
+import net.jradius.dictionary.Attr_ClientIPAddress;
+import net.jradius.dictionary.Attr_NASIPAddress;
+import net.jradius.dictionary.Attr_NASPortType;
 import net.jradius.dictionary.Attr_ReplyMessage;
 import net.jradius.dictionary.Attr_State;
 import net.jradius.dictionary.Attr_UserName;
@@ -182,6 +185,10 @@ public class RadiusConnectionService {
      * @param secret
      *     The secret, usually a password or challenge response, to send
      *     to authenticate to the RADIUS server.
+     * 
+     * @param clientAddress
+     *     The IP address of the client, if known, which will be set in as
+     *     the RADIUS client address.
      *
      * @param state
      *     The previous state of the RADIUS connection
@@ -192,7 +199,8 @@ public class RadiusConnectionService {
      * @throws GuacamoleException
      *     If an error occurs while talking to the server.
      */
-    public RadiusPacket authenticate(String username, String secret, byte[] state)
+    public RadiusPacket authenticate(String username, String secret, 
+                String clientAddress, byte[] state)
             throws GuacamoleException {
 
         // If a username wasn't passed, we quit
@@ -224,6 +232,9 @@ public class RadiusConnectionService {
         try {
             AttributeList radAttrs = new AttributeList();
             radAttrs.add(new Attr_UserName(username));
+            radAttrs.add(new Attr_ClientIPAddress(InetAddress.getByName(clientAddress)));
+            radAttrs.add(new Attr_NASIPAddress(InetAddress.getLocalHost()));
+            radAttrs.add(new Attr_NASPortType(Attr_NASPortType.Virtual));
             if (state != null && state.length > 0)
                 radAttrs.add(new Attr_State(state));
             radAttrs.add(new Attr_UserPassword(secret));
@@ -267,6 +278,11 @@ public class RadiusConnectionService {
             logger.debug("Unknown RADIUS algorithm.", e);
             return null;
         }
+        catch (UnknownHostException e) {
+            logger.error("Could not resolve address: {}", e.getMessage());
+            logger.debug("Exxception resolving host address.", e);
+            return null;
+        }
         finally {
             radiusClient.close();
         }
@@ -282,6 +298,10 @@ public class RadiusConnectionService {
      * @param response
      *     The response phrase to send to the RADIUS server in response to the
      *     challenge previously provided.
+     * 
+     * @param clientAddress
+     *     The IP address of the client, if known, which will be set in as
+     *     the RADIUS client address.
      *
      * @param state
      *     The state data provided by the RADIUS server in order to continue
@@ -295,7 +315,7 @@ public class RadiusConnectionService {
      *     If an error is encountered trying to talk to the RADIUS server.
      */
     public RadiusPacket sendChallengeResponse(String username, String response,
-            byte[] state) throws GuacamoleException {
+            String clientAddress, byte[] state) throws GuacamoleException {
 
         if (username == null || username.isEmpty()) {
             logger.error("Challenge/response to RADIUS requires a username.");
@@ -312,7 +332,7 @@ public class RadiusConnectionService {
             return null;
         }
 
-        return authenticate(username,response,state);
+        return authenticate(username, response, clientAddress, state);
 
     }
 


### PR DESCRIPTION
This pull request attempts to fix a couple of minor issues with missing attributes on RADIUS packets, providing the NAS IP address (of the server running Guacamole Client), NAS Type (Virtual), and Client IP address (from authentication request).