### PR TITLE
GUACAMOLE-919: Implement PostgreSQL defaultStatementTimeout and socketTimeout

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
@@ -72,7 +72,7 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
 
         // Only set if > 0. Underlying backend does not take 0 as not-set.
         int defaultStatementTimeout = environment.getPostgreSQLDefaultStatementTimeout();
-        if(defaultStatementTimeout > 0) {
+        if (defaultStatementTimeout > 0) {
             myBatisProperties.setProperty("mybatis.configuration.defaultStatementTimeout", String.valueOf(defaultStatementTimeout));
         }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
@@ -69,7 +69,12 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
         myBatisProperties.setProperty("JDBC.autoCommit", "false");
         myBatisProperties.setProperty("mybatis.pooled.pingEnabled", "true");
         myBatisProperties.setProperty("mybatis.pooled.pingQuery", "SELECT 1");
-        myBatisProperties.setProperty("mybatis.configuration.defaultStatementTimeout", environment.getPostgreSQLDefaultStatementTimeout());
+
+        // Only set if > 0. Underlying backend does not take 0 as not-set.
+        int defaultStatementTimeout = environment.getPostgreSQLDefaultStatementTimeout();
+        if(defaultStatementTimeout > 0) {
+            myBatisProperties.setProperty("mybatis.configuration.defaultStatementTimeout", String.valueOf(defaultStatementTimeout));
+        }
 
         // Use UTF-8 in database
         driverProperties.setProperty("characterEncoding", "UTF-8");

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
@@ -111,6 +111,9 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
             
         }
 
+        // Handle case where TCP connection to database is silently dropped
+        driverProperties.setProperty("socketTimeout", String.valueOf(environment.getPostgreSQLSocketTimeout()));
+
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
@@ -69,6 +69,7 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
         myBatisProperties.setProperty("JDBC.autoCommit", "false");
         myBatisProperties.setProperty("mybatis.pooled.pingEnabled", "true");
         myBatisProperties.setProperty("mybatis.pooled.pingQuery", "SELECT 1");
+        myBatisProperties.setProperty("mybatis.configuration.defaultStatementTimeout", environment.getPostgreSQLDefaultStatementTimeout());
 
         // Use UTF-8 in database
         driverProperties.setProperty("characterEncoding", "UTF-8");

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/PostgreSQLAuthenticationProviderModule.java
@@ -73,7 +73,10 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
         // Only set if > 0. Underlying backend does not take 0 as not-set.
         int defaultStatementTimeout = environment.getPostgreSQLDefaultStatementTimeout();
         if (defaultStatementTimeout > 0) {
-            myBatisProperties.setProperty("mybatis.configuration.defaultStatementTimeout", String.valueOf(defaultStatementTimeout));
+            myBatisProperties.setProperty(
+                "mybatis.configuration.defaultStatementTimeout",
+                String.valueOf(defaultStatementTimeout)
+            );
         }
 
         // Use UTF-8 in database
@@ -117,7 +120,10 @@ public class PostgreSQLAuthenticationProviderModule implements Module {
         }
 
         // Handle case where TCP connection to database is silently dropped
-        driverProperties.setProperty("socketTimeout", String.valueOf(environment.getPostgreSQLSocketTimeout()));
+        driverProperties.setProperty(
+            "socketTimeout",
+            String.valueOf(environment.getPostgreSQLSocketTimeout())
+        );
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
@@ -49,17 +49,18 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     private static final int DEFAULT_PORT = 5432;
 
     /**
-     * The default defaultStatementTimeout (in seconds),
-     * if POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT is not specified.
-     * Default to 0 (no timeout, property won't be set)
-     * https://mybatis.org/mybatis-3/configuration.html
+     * The default number of seconds the driver will wait for a response from
+     * the database. A value of 0 (the default) means the timeout is disabled.
      */
-    private static final int DEFAULT_DEFAULT_STATEMENT_TIMEOUT = 0;
+    private static final int DEFAULT_STATEMENT_TIMEOUT = 0;
 
     /**
-     * The default socketTimeout (in seconds), if POSTGRESQL_SOCKET_TIMEOUT is not specified.
-     * Default to 0 (no timeout)
-     * https://jdbc.postgresql.org/documentation/head/connect.html
+     * The default timeout (in seconds) used for socket read operations.
+     * If reading from the server takes longer than this value, the
+     * connection is closed. This can be used to handle network problems
+     * such as a dropped connection to the database. Similar to 
+     * DEFAULT_STATEMENT_TIMEOUT, it will also abort queries that take too 
+     * long. The value 0 (the default) means the timeout is disabled.
      */
     private static final int DEFAULT_SOCKET_TIMEOUT = 0;
 
@@ -279,7 +280,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     public int getPostgreSQLDefaultStatementTimeout() throws GuacamoleException {
         return getProperty(
             PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT,
-            DEFAULT_DEFAULT_STATEMENT_TIMEOUT
+            DEFAULT_STATEMENT_TIMEOUT
         );
     }
     

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
@@ -50,17 +50,14 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
 
     /**
      * The default number of seconds the driver will wait for a response from
-     * the database. A value of 0 (the default) means the timeout is disabled.
+     * the database, before aborting the query.
+     * A value of 0 (the default) means the timeout is disabled.
      */
     private static final int DEFAULT_STATEMENT_TIMEOUT = 0;
 
     /**
-     * The default timeout (in seconds) used for socket read operations.
-     * If reading from the server takes longer than this value, the
-     * connection is closed. This can be used to handle network problems
-     * such as a dropped connection to the database. Similar to 
-     * DEFAULT_STATEMENT_TIMEOUT, it will also abort queries that take too 
-     * long. The value 0 (the default) means the timeout is disabled.
+     * The default number of seconds to wait for socket read operations.
+     * A value of 0 (the default) means the timeout is disabled.
      */
     private static final int DEFAULT_SOCKET_TIMEOUT = 0;
 
@@ -268,7 +265,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     
     /**
      * Returns the defaultStatementTimeout set for PostgreSQL connections.
-     * If unspecified, this will be the default 0,
+     * If unspecified, this will default to 0,
      * and should not be passed through to the backend.
      * 
      * @return
@@ -286,7 +283,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     
     /**
      * Returns the socketTimeout property to set on PostgreSQL connections.
-     * If unspecified, this will be the default to 0 (no timeout)
+     * If unspecified, this will default to 0 (no timeout)
      * 
      * @return
      *     The socketTimeout to use when waiting on read operations (in seconds)

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
@@ -57,6 +57,13 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     private static final String DEFAULT_DEFAULT_STATEMENT_TIMEOUT = "null";
 
     /**
+     * The default socketTimeout (in seconds), if POSTGRESQL_SOCKET_TIMEOUT is not specified.
+     * Default to 0 (no timeout)
+     * https://jdbc.postgresql.org/documentation/head/connect.html
+     */
+    private static final int DEFAULT_SOCKET_TIMEOUT = 0;
+
+    /**
      * Whether a database user account is required by default for authentication
      * to succeed.
      */
@@ -257,7 +264,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     public String getPostgreSQLPassword() throws GuacamoleException {
         return getRequiredProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_PASSWORD);
     }
-        
+    
     /**
      * Returns the defaultStatementTimeout set for PostgreSQL connections.
      * If unspecified, this will be the default "null" (no timeout)
@@ -272,6 +279,23 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
         return getProperty(
             PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT,
             DEFAULT_DEFAULT_STATEMENT_TIMEOUT
+        );
+    }
+    
+    /**
+     * Returns the socketTimeout property to set on PostgreSQL connections.
+     * If unspecified, this will be the default to 0 (no timeout)
+     * 
+     * @return
+     *     The socketTimeout to use when waiting on read operations (in seconds)
+     *
+     * @throws GuacamoleException 
+     *     If an error occurs while retrieving the property value.
+     */
+    public int getPostgreSQLSocketTimeout() throws GuacamoleException {
+        return getProperty(
+            PostgreSQLGuacamoleProperties.POSTGRESQL_SOCKET_TIMEOUT,
+            DEFAULT_SOCKET_TIMEOUT
         );
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
@@ -49,6 +49,14 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     private static final int DEFAULT_PORT = 5432;
 
     /**
+     * The default defaultStatementTimeout (in seconds),
+     * if POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT is not specified.
+     * Default to null (no timeout)
+     * https://mybatis.org/mybatis-3/configuration.html
+     */
+    private static final String DEFAULT_DEFAULT_STATEMENT_TIMEOUT = "null";
+
+    /**
      * Whether a database user account is required by default for authentication
      * to succeed.
      */
@@ -248,6 +256,23 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
      */
     public String getPostgreSQLPassword() throws GuacamoleException {
         return getRequiredProperty(PostgreSQLGuacamoleProperties.POSTGRESQL_PASSWORD);
+    }
+        
+    /**
+     * Returns the defaultStatementTimeout set for PostgreSQL connections.
+     * If unspecified, this will be the default "null" (no timeout)
+     * 
+     * @return
+     *     The statement timeout (in seconds)
+     *
+     * @throws GuacamoleException 
+     *     If an error occurs while retrieving the property value.
+     */
+    public String getPostgreSQLDefaultStatementTimeout() throws GuacamoleException {
+        return getProperty(
+            PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT,
+            DEFAULT_DEFAULT_STATEMENT_TIMEOUT
+        );
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLEnvironment.java
@@ -51,10 +51,10 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     /**
      * The default defaultStatementTimeout (in seconds),
      * if POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT is not specified.
-     * Default to null (no timeout)
+     * Default to 0 (no timeout, property won't be set)
      * https://mybatis.org/mybatis-3/configuration.html
      */
-    private static final String DEFAULT_DEFAULT_STATEMENT_TIMEOUT = "null";
+    private static final int DEFAULT_DEFAULT_STATEMENT_TIMEOUT = 0;
 
     /**
      * The default socketTimeout (in seconds), if POSTGRESQL_SOCKET_TIMEOUT is not specified.
@@ -267,7 +267,8 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
     
     /**
      * Returns the defaultStatementTimeout set for PostgreSQL connections.
-     * If unspecified, this will be the default "null" (no timeout)
+     * If unspecified, this will be the default 0,
+     * and should not be passed through to the backend.
      * 
      * @return
      *     The statement timeout (in seconds)
@@ -275,7 +276,7 @@ public class PostgreSQLEnvironment extends JDBCEnvironment {
      * @throws GuacamoleException 
      *     If an error occurs while retrieving the property value.
      */
-    public String getPostgreSQLDefaultStatementTimeout() throws GuacamoleException {
+    public int getPostgreSQLDefaultStatementTimeout() throws GuacamoleException {
         return getProperty(
             PostgreSQLGuacamoleProperties.POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT,
             DEFAULT_DEFAULT_STATEMENT_TIMEOUT

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -95,6 +95,18 @@ public class PostgreSQLGuacamoleProperties {
     };
 
     /**
+     * Sets the number of seconds the driver will wait for
+     * a response from the database.
+     */
+    public static final StringGuacamoleProperty
+            POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT = new StringGuacamoleProperty(){
+
+        @Override
+        public String getName() { return "postgresql-default-statement-timeout"; }
+
+    };
+
+    /**
      * Whether a user account within the database is required for authentication
      * to succeed, even if the user has been authenticated via another
      * authentication provider.

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -95,7 +95,7 @@ public class PostgreSQLGuacamoleProperties {
     };
 
     /**
-     * Sets the number of seconds the driver will wait for
+     * The number of seconds the driver will wait for
      * a response from the database.
      */
     public static final IntegerGuacamoleProperty
@@ -107,7 +107,7 @@ public class PostgreSQLGuacamoleProperties {
     };
 
     /**
-     * Sets the number of seconds the driver will wait in a read() call
+     * The number of seconds the driver will wait in a read() call
      * on the TCP connection to the database.
      */
     public static final IntegerGuacamoleProperty

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -95,11 +95,12 @@ public class PostgreSQLGuacamoleProperties {
     };
 
     /**
-     * The number of seconds the driver will wait for
-     * a response from the database.
+     * The number of seconds the driver will wait for a response from
+     * the database, before aborting the query.
+     * A value of 0 (the default) means the timeout is disabled.
      */
     public static final IntegerGuacamoleProperty
-            POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT = new IntegerGuacamoleProperty(){
+            POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT = new IntegerGuacamoleProperty() {
 
         @Override
         public String getName() { return "postgresql-default-statement-timeout"; }
@@ -107,11 +108,16 @@ public class PostgreSQLGuacamoleProperties {
     };
 
     /**
-     * The number of seconds the driver will wait in a read() call
-     * on the TCP connection to the database.
+     * The number of seconds to wait for socket read operations.
+     * If reading from the server takes longer than this value, the
+     * connection will be closed. This can be used to handle network problems
+     * such as a dropped connection to the database. Similar to 
+     * postgresql-default-statement-timeout, it will have the effect of
+     * aborting queries that take too long.
+     * A value of 0 (the default) means the timeout is disabled.
      */
     public static final IntegerGuacamoleProperty
-            POSTGRESQL_SOCKET_TIMEOUT = new IntegerGuacamoleProperty(){
+            POSTGRESQL_SOCKET_TIMEOUT = new IntegerGuacamoleProperty() {
 
         @Override
         public String getName() { return "postgresql-socket-timeout"; }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -107,6 +107,18 @@ public class PostgreSQLGuacamoleProperties {
     };
 
     /**
+     * Sets the number of seconds the driver will wait in a read() call
+     * on the TCP connection to the database.
+     */
+    public static final IntegerGuacamoleProperty
+            POSTGRESQL_SOCKET_TIMEOUT = new IntegerGuacamoleProperty(){
+
+        @Override
+        public String getName() { return "postgresql-socket-timeout"; }
+
+    };
+
+    /**
      * Whether a user account within the database is required for authentication
      * to succeed, even if the user has been authenticated via another
      * authentication provider.

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/java/org/apache/guacamole/auth/postgresql/conf/PostgreSQLGuacamoleProperties.java
@@ -98,8 +98,8 @@ public class PostgreSQLGuacamoleProperties {
      * Sets the number of seconds the driver will wait for
      * a response from the database.
      */
-    public static final StringGuacamoleProperty
-            POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT = new StringGuacamoleProperty(){
+    public static final IntegerGuacamoleProperty
+            POSTGRESQL_DEFAULT_STATEMENT_TIMEOUT = new IntegerGuacamoleProperty(){
 
         @Override
         public String getName() { return "postgresql-default-statement-timeout"; }

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -362,6 +362,10 @@ END
         "postgresql-user-required" \
         "$POSTGRES_USER_REQUIRED"
 
+    set_optional_property               \
+        "postgresql-socket-timeout" \
+        "$POSTGRES_SOCKET_TIMEOUT"
+
     set_optional_property      \
         "postgresql-ssl-mode"  \
         "$POSTGRESQL_SSL_MODE"

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -354,7 +354,7 @@ END
         "postgresql-default-max-group-connections-per-user" \
         "$POSTGRES_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER"
 
-    set_optional_property               \
+    set_optional_property                      \
         "postgresql-default-statement-timeout" \
         "$POSTGRES_DEFAULT_STATEMENT_TIMEOUT"
 
@@ -362,7 +362,7 @@ END
         "postgresql-user-required" \
         "$POSTGRES_USER_REQUIRED"
 
-    set_optional_property               \
+    set_optional_property           \
         "postgresql-socket-timeout" \
         "$POSTGRES_SOCKET_TIMEOUT"
 

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -354,6 +354,10 @@ END
         "postgresql-default-max-group-connections-per-user" \
         "$POSTGRES_DEFAULT_MAX_GROUP_CONNECTIONS_PER_USER"
 
+    set_optional_property               \
+        "postgresql-default-statement-timeout" \
+        "$POSTGRES_DEFAULT_STATEMENT_TIMEOUT"
+
     set_optional_property          \
         "postgresql-user-required" \
         "$POSTGRES_USER_REQUIRED"


### PR DESCRIPTION
Pass through environment variables to set `defaultStatementTimeout` and `socketTimeout`. See issue GUACAMOLE-919 for details.

If the TCP connection to the database is silently dropped (not closed), doing a ping query "SELECT 1;" will hang indefinitely. The socketTimeout option will put a timeout on this.

`defaultStatementTimeout` is not relevant to this issue. I thought it might have been at first. I've left this in incase having the option exposed is useful for other reasons.