### PR TITLE
GUACAMOLE-998: Do not retrieve all groups from LDAP

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
@@ -87,9 +87,9 @@ public class UserGroupService {
         if (confService.getConfigurationBaseDN() != null)
             return new NotNode(new EqualityNode("objectClass","guacConfigGroup"));
 
-        // Read any object as a group if LDAP is not being used for connection
+        // Read any object containing "ldap-member-attribute" attribute as a group if LDAP is not being used for connection
         // storage (guacConfigGroup)
-        return new PresenceNode("objectClass");
+        return new PresenceNode(confService.getMemberAttribute());
 
     }
 


### PR DESCRIPTION
[GUACAMOLE-998](https://issues.apache.org/jira/browse/GUACAMOLE-998
)
Hi, I have been using Guacamole since 0.9.14. As we use ActiveDirectory LDAP to authenticate every user I found something which might have an explanation but in my scenario is quite undesired.

Our LDAP is a WorldWide DB and so contains a huge ammount of users and groups.

According to the original code if we do not use (as in our case) LDAP for storing configuration, then anything containing objectClass attribute (users, computer, groups, etc) will be loaded into Guacamole as a group.

I do not see clearly why this is done this way, also ldap-group-base-dn attribute is not respected at all in this scenario but fortunately at least seems to honor ldap-user-base-dn.

So I modificated this line to, retrieve any object containing the attribute defined by ldap-member-attribute which by default is member.

 

Attached patch does work as spected (by me at least), I am pretty newie with java, so I might be missing something...