### PR TITLE
GUACAMOLE-583: Add ability to configure SQL Server instance name.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerAuthenticationProviderModule.java
@@ -69,6 +69,11 @@ public class SQLServerAuthenticationProviderModule implements Module {
         myBatisProperties.setProperty("JDBC.schema", environment.getSQLServerDatabase());
         myBatisProperties.setProperty("JDBC.username", environment.getSQLServerUsername());
         myBatisProperties.setProperty("JDBC.password", environment.getSQLServerPassword());
+        
+        String instance = environment.getSQLServerInstance();
+        if (instance != null)
+            myBatisProperties.setProperty("JDBC.instanceName", instance);
+        
         myBatisProperties.setProperty("JDBC.autoCommit", "false");
         myBatisProperties.setProperty("mybatis.pooled.pingEnabled", "true");
         myBatisProperties.setProperty("mybatis.pooled.pingQuery", "SELECT 1");

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerEnvironment.java
@@ -173,6 +173,23 @@ public class SQLServerEnvironment extends JDBCEnvironment {
     }
     
     /**
+     * Returns the instance name of the SQL Server installation hosting the
+     * Guacamole database, if any.  If unspecified it will be null.
+     * 
+     * @return
+     *     The instance name of the SQL Server install hosting the Guacamole
+     *     database, or null if undefined.
+     * 
+     * @throws GuacamoleException
+     *     If an error occurs reading guacamole.properties.
+     */
+    public String getSQLServerInstance() throws GuacamoleException {
+        return getProperty(
+            SQLServerGuacamoleProperties.SQLSERVER_INSTANCE
+        );
+    }
+    
+    /**
      * Returns the port number of the SQLServer server hosting the Guacamole
      * authentication tables. If unspecified, this will be the default
      * SQLServer port of 5432.

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerGuacamoleProperties.java
@@ -43,6 +43,17 @@ public class SQLServerGuacamoleProperties {
         public String getName() { return "sqlserver-hostname"; }
 
     };
+    
+    /**
+     * The instance name of the SQL Server where the Guacamole database is running.
+     */
+    public static final StringGuacamoleProperty SQLSERVER_INSTANCE =
+            new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "sqlserver-instance"; }
+                
+    };
 
     /**
      * The port of the SQLServer server hosting the Guacamole authentication


### PR DESCRIPTION
This change adds a configuration option for the instance name for SQL server and sets the correct property in the JDBC driver properties.