### PR TITLE
GUACAMOLE-1048: Support server control commands during handshake

### DIFF
--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleServerErrorCommandException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleServerErrorCommandException.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole;
+
+import org.apache.guacamole.protocol.GuacamoleStatus;
+
+/**
+ * The exception thrown when the Guacamole server explicitly sends an error
+ * command to the client. The error message and status code reflect the arguments
+ * of the error command as determined by the server.
+ */
+public class GuacamoleServerErrorCommandException extends GuacamoleServerException {
+    /**
+     * The Guacamole protocol status code, as determined by the server;
+     */
+    private final GuacamoleStatus status;
+
+    /**
+     * Creates a new GuacamoleServerException with the given message and status.
+     *
+     * @param message The error message, as determined by the server where the error
+     *               originated.
+     * @param status The status code, as determined by the server where the error originated.
+     */
+    public GuacamoleServerErrorCommandException(String message, GuacamoleStatus status) {
+        super(message);
+        this.status = status;
+    }
+
+    @Override
+    public GuacamoleStatus getStatus() {
+        return status;
+    }
+}

--- a/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleServerErrorInstructionException.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/GuacamoleServerErrorInstructionException.java
@@ -23,23 +23,27 @@ import org.apache.guacamole.protocol.GuacamoleStatus;
 
 /**
  * The exception thrown when the Guacamole server explicitly sends an error
- * command to the client. The error message and status code reflect the arguments
- * of the error command as determined by the server.
+ * instruction to the client. The error message and status code reflect the arguments
+ * of the error instruction as determined by the server.
  */
-public class GuacamoleServerErrorCommandException extends GuacamoleServerException {
+public class GuacamoleServerErrorInstructionException extends GuacamoleServerException {
     /**
      * The Guacamole protocol status code, as determined by the server;
      */
     private final GuacamoleStatus status;
 
     /**
-     * Creates a new GuacamoleServerException with the given message and status.
+     * Creates a new GuacamoleServerErrorInstructionException with the given
+     * message and status.
      *
-     * @param message The error message, as determined by the server where the error
-     *               originated.
-     * @param status The status code, as determined by the server where the error originated.
+     * @param message
+     *     A human readable description of the exception that occurred.
+     *
+     * @param status
+     *     The status code, as determined by the server from which the
+     *     instruction originated.
      */
-    public GuacamoleServerErrorCommandException(String message, GuacamoleStatus status) {
+    public GuacamoleServerErrorInstructionException(String message, GuacamoleStatus status) {
         super(message);
         this.status = status;
     }

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
@@ -21,7 +21,7 @@ package org.apache.guacamole.protocol;
 
 import java.util.List;
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.GuacamoleServerErrorCommandException;
+import org.apache.guacamole.GuacamoleServerErrorInstructionException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.io.GuacamoleReader;
 import org.apache.guacamole.io.GuacamoleWriter;
@@ -66,27 +66,23 @@ public class ConfiguredGuacamoleSocket implements GuacamoleSocket {
             GuacamoleProtocolVersion.VERSION_1_0_0;
 
     /**
-     * Parses the arguments for the Guacamole "error" server command and returns
+     * Parses the arguments for the Guacamole "error" server instruction and returns
      * the corresponding exception.
-     * @param args The arguments as provided by the server command.
-     * @return An instance of {@link GuacamoleServerErrorCommandException} configured
-     *         with the server-provided arguments, or {@literal null} if the specified
-     *         arguments are invalid.
+     * @param args The arguments as provided by the server instruction.
+     * @return An instance of {@link GuacamoleServerErrorInstructionException} configured
+     *         with the server-provided arguments, or a generic {@link GuacamoleServerException} if
+     *         the specified arguments are invalid.
      */
-    private static GuacamoleServerErrorCommandException parseServerErrorCommandArgs(List<String> args) {
-        if (args == null || args.size() != 2)
-            return null;
-
-        int code;
+    private static GuacamoleServerException parseServerErrorInstructionArgs(List<String> args) {
         try {
-            code = Integer.parseInt(args.get(1));
-        } catch (NumberFormatException e) {
-            return null;
-        }
-        GuacamoleStatus status = GuacamoleStatus.fromGuacamoleStatusCode(code);
-        return (status == null)
-                ? null
-                : new GuacamoleServerErrorCommandException(args.get(0), status);
+            if (args.size() >= 2) {
+                int code = Integer.parseInt(args.get(1));
+                GuacamoleStatus status = GuacamoleStatus.fromGuacamoleStatusCode(code);
+                return new GuacamoleServerErrorInstructionException(args.get(0), status);
+            }
+        } catch (NumberFormatException ignored) {}
+
+        return new GuacamoleServerException("Invalid error instruction arguments received: " + args);
     }
 
     /**
@@ -94,7 +90,7 @@ public class ConfiguredGuacamoleSocket implements GuacamoleSocket {
      * instruction once it has been read. If the instruction is never read,
      * an exception is thrown.
      *
-     * Respects server control commands that are allowed during the handshake
+     * Respects server control instructions that are allowed during the handshake
      * phase, namely {@code error} and {@code disconnect}.
      *
      * @param reader The reader to read instructions from.
@@ -111,15 +107,11 @@ public class ConfiguredGuacamoleSocket implements GuacamoleSocket {
         if (instruction == null)
             throw new GuacamoleServerException("End of stream while waiting for \"" + opcode + "\".");
 
-        // Handle server control commands
+        // Handle server control instructions
         if ("disconnect".equals(instruction.getOpcode()))
             throw new GuacamoleServerException("Server disconnected while waiting for \"" + opcode + "\".");
-        if ("error".equals(instruction.getOpcode())) {
-            GuacamoleServerErrorCommandException e = parseServerErrorCommandArgs(instruction.getArgs());
-            if (e == null)
-                throw new GuacamoleServerException("Invalid command received from server: " + instruction);
-            throw e;
-        }
+        if ("error".equals(instruction.getOpcode()))
+            throw parseServerErrorInstructionArgs(instruction.getArgs());
 
         // Ensure instruction has expected opcode
         if (!instruction.getOpcode().equals(opcode))


### PR DESCRIPTION
There aren't many tests in `guacamole-common`; I have a separate utility class that can help test this, but it's way outside the scope and will be a separate PR once I've cleaned it up a bit.