### PR TITLE
GUACAMOLE-989: Implement keyboard lock menu item.

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -33,6 +33,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
     // Required services
     var $location              = $injector.get('$location');
+    var $log                   = $injector.get('$log');
     var authenticationService  = $injector.get('authenticationService');
     var connectionGroupService = $injector.get('connectionGroupService');
     var clipboardService       = $injector.get('clipboardService');
@@ -895,9 +896,24 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         className : 'danger disconnect',
         callback  : $scope.disconnect
     };
+    
+    /**
+     * Action that locks the keyboard using the Keyboard Lock API within the
+     * current client, and then closes the menu.
+     */
+    var KEYBOARD_LOCK_MENU_ACTION = {
+        name      : 'CLIENT.ACTION_KEYBOARD_LOCK',
+        callback  : function keyboardLock() {
+            if (navigator.keyboard) {
+                navigator.keyboard.lock();
+                $scope.menu.shown = false;
+            }
+        }
+    };
 
     // Set client-specific menu actions
-    $scope.clientMenuActions = [ DISCONNECT_MENU_ACTION ];
+    $scope.clientMenuActions = [ DISCONNECT_MENU_ACTION,
+        KEYBOARD_LOCK_MENU_ACTION ];
 
     /**
      * @borrows Protocol.getNamespace

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -56,6 +56,7 @@
         "ACTION_ACKNOWLEDGE"               : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CLEAR_COMPLETED_TRANSFERS" : "Clear",
         "ACTION_DISCONNECT"                : "Disconnect",
+        "ACTION_KEYBOARD_LOCK"             : "Lock Keyboard",
         "ACTION_LOGOUT"                    : "@:APP.ACTION_LOGOUT",
         "ACTION_NAVIGATE_BACK"             : "@:APP.ACTION_NAVIGATE_BACK",
         "ACTION_NAVIGATE_HOME"             : "@:APP.ACTION_NAVIGATE_HOME",


### PR DESCRIPTION
One potential solution for attempting to use Keyboard Lock within Guacamole Client.  I'm not sure how much it actually helps - Guacamole already intercepts just about all of the keys it can, so I'm not certain this is actually going to provide any additional functionality, but maybe it's worth a shot.  Anyw testing that anyone wants to do would be welcome.

Also, if this menu isn't the right place for it we can find some other place.  Just seemed like a convenient place to stash it :-).