### PR TITLE
GUACAMOLE-944: Restore ability to use UPN-style usernames in search bind credentials

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -119,18 +119,19 @@ public class AuthenticationProviderService {
 
         // If a search DN is provided, search the LDAP directory for the DN
         // corresponding to the given username
-        Dn searchBindDN = confService.getSearchBindDN();
-        if (searchBindDN != null) {
+        String searchBindLogon = confService.getSearchBindDN();
+        if (searchBindLogon != null) {
 
             // Create an LDAP connection using the search account
             LdapNetworkConnection searchConnection = ldapService.bindAs(
-                searchBindDN,
+                searchBindLogon,
                 confService.getSearchBindPassword()
             );
 
             // Warn of failure to find
             if (searchConnection == null) {
-                logger.error("Unable to bind using search DN \"{}\"", searchBindDN);
+                logger.error("Unable to bind using search DN \"{}\"",
+                        searchBindLogon);
                 return null;
             }
 
@@ -203,7 +204,8 @@ public class AuthenticationProviderService {
         }
         
         // Attempt bind
-        LdapNetworkConnection ldapConnection = ldapService.bindAs(bindDn, password);
+        LdapNetworkConnection ldapConnection =
+                ldapService.bindAs(bindDn.getName(), password);
         if (ldapConnection == null)
             throw new GuacamoleInvalidCredentialsException("Invalid login.",
                     CredentialsInfo.USERNAME_PASSWORD);
@@ -315,7 +317,8 @@ public class AuthenticationProviderService {
         if (authenticatedUser instanceof LDAPAuthenticatedUser) {
 
             Dn bindDn = ((LDAPAuthenticatedUser) authenticatedUser).getBindDn();
-            LdapNetworkConnection ldapConnection = ldapService.bindAs(bindDn, credentials.getPassword());
+            LdapNetworkConnection ldapConnection =
+                    ldapService.bindAs(bindDn.getName(), credentials.getPassword());
             if (ldapConnection == null) {
                 logger.debug("LDAP bind succeeded for \"{}\" during "
                         + "authentication but failed during data retrieval.",

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/LDAPConnectionService.java
@@ -239,11 +239,11 @@ public class LDAPConnectionService {
      *     bound.
      */
     private LdapNetworkConnection bindAs(LdapNetworkConnection ldapConnection,
-            Dn userDN, String password) {
+            String bindUser, String password) {
 
         // Add credentials to existing config
         LdapConnectionConfig config = ldapConnection.getConfig();
-        config.setName(userDN.getName());
+        config.setName(bindUser);
         config.setCredentials(password);
 
         try {
@@ -255,7 +255,8 @@ public class LDAPConnectionService {
         // only at the debug level (such failures are expected)
         catch (LdapAuthenticationException e) {
             ldapConnection.close();
-            logger.debug("Bind attempt with LDAP server as user \"{}\" failed.", userDN, e);
+            logger.debug("Bind attempt with LDAP server as user \"{}\" failed.",
+                    bindUser, e);
             return null;
         }
 
@@ -264,7 +265,8 @@ public class LDAPConnectionService {
         catch (LdapException e) {
             ldapConnection.close();
             logger.error("Binding with the LDAP server at \"{}\" as user "
-                    + "\"{}\" failed: {}", config.getLdapHost(), userDN, e.getMessage());
+                    + "\"{}\" failed: {}", config.getLdapHost(), bindUser,
+                    e.getMessage());
             logger.debug("Unable to bind to LDAP server.", e);
             return null;
         }
@@ -318,7 +320,7 @@ public class LDAPConnectionService {
         }
 
         // Bind using username/password from existing connection
-        return bindAs(ldapConnection, userDN, password);
+        return bindAs(ldapConnection, userDN.getName(), password);
 
     }
 
@@ -327,8 +329,8 @@ public class LDAPConnectionService {
      * hostname, port, and encryption method of the LDAP server are determined
      * from guacamole.properties.
      *
-     * @param userDN
-     *     The DN of the user to bind as, or null to bind anonymously.
+     * @param bindUser
+     *     The DN or UPN of the user to bind as, or null to bind anonymously.
      *
      * @param password
      *     The password to use when binding as the specified user, or null to
@@ -342,9 +344,9 @@ public class LDAPConnectionService {
      *     If an error occurs while parsing guacamole.properties, or if the
      *     configured encryption method is actually not implemented (a bug).
      */
-    public LdapNetworkConnection bindAs(Dn userDN, String password)
+    public LdapNetworkConnection bindAs(String bindUser, String password)
             throws GuacamoleException {
-        return bindAs(createLDAPConnection(), userDN, password);
+        return bindAs(createLDAPConnection(), bindUser, password);
     }
 
     /**

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
@@ -171,7 +171,7 @@ public class ConfigurationService {
     }
 
     /**
-     * Returns the DN that should be used when searching for the DNs of users
+     * Returns the login that should be used when searching for the DNs of users
      * attempting to authenticate. If no such search should be performed, null
      * is returned.
      *
@@ -183,7 +183,7 @@ public class ConfigurationService {
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
      */
-    public Dn getSearchBindDN() throws GuacamoleException {
+    public String getSearchBindDN() throws GuacamoleException {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_SEARCH_BIND_DN
         );

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
@@ -126,13 +126,13 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
-     * The DN of the user that the LDAP authentication should bind as when
-     * searching for the user accounts of users attempting to log in. If not
-     * specified, the DNs of users attempting to log in will be derived from
-     * the LDAP_BASE_DN and LDAP_USERNAME_ATTRIBUTE directly.
+     * The user that the LDAP extension should bind as when searching for the
+     * accounts of users attempting to log in, in either UPN or DN format.
+     * If not specified, the DNs of users attempting to log in will be derived
+     * from the LDAP_BASE_DN and LDAP_USERNAME_ATTRIBUTE directly.
      */
-    public static final LdapDnGuacamoleProperty LDAP_SEARCH_BIND_DN =
-            new LdapDnGuacamoleProperty() {
+    public static final LdapBindGuacamoleProperty LDAP_SEARCH_BIND_DN =
+            new LdapBindGuacamoleProperty() {
 
         @Override
         public String getName() { return "ldap-search-bind-dn"; }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LdapBindGuacamoleProperty.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LdapBindGuacamoleProperty.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.ldap.conf;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+import org.apache.guacamole.properties.GuacamoleProperty;
+
+/**
+ * A GuacamoleProperty that checks a string to a verify that it is a valid
+ * LDAP bind format - either an Active Directory UPN or a LDAP DN.  An exception
+ * is thrown if the provided value is invalid.
+ */
+public abstract class LdapBindGuacamoleProperty implements GuacamoleProperty<String> {
+
+    /**
+     * An expression that matches valid Active Directory UPN values, in one of
+     * two formats - either <DOMAIN>\<USERNAME> or <USERNAME>@<DOMAIN>.
+     */
+    private static final Pattern LDAP_UPN_PATTERN = Pattern.compile("^(?:(?<adusername>[^@]+)@(?<addomain>.+)|(?<nbdomain>[^\\\\]+)\\\\(?<nbusername>.+))$");
+    
+    @Override
+    public String parseValue(String value) throws GuacamoleException {
+
+        if (value == null)
+            return null;
+
+        // Check input value against UPN regex matcher
+        Matcher upnMatcher = LDAP_UPN_PATTERN.matcher(value);
+        if (upnMatcher.matches())
+            return value;
+        
+        // If UPN matcher doesn't work, verify the DN
+        if (Dn.isValid(value))
+            return value;
+        
+        throw new GuacamoleServerException("The DN \"" + value + "\" is invalid.");
+
+    }
+
+}


### PR DESCRIPTION
This restores the ability to use UPN-style usernames in guacamole.properties for the search bind user, which was broken when we moved over to the Apache Directory API.  I went ahead and based this against staging/1.2.0, but that's up for discussion as to whether this is truly a regression or not.  It certainly can be worked around even if it's less convenient - either way is fine with me.