### PR TITLE
add ability to reuse the classes from the `guacamole` module

### DIFF
--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -78,6 +78,8 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.6</version>
                 <configuration>
+                    <attachClasses>true</attachClasses>
+                    <classesClassifier>classes</classesClassifier>
 
                     <webResources>
 


### PR DESCRIPTION
Hello Guacamole Team,

The purpose of this PR is to enable reuse of the classes from the guacamole module.  What I found was it was not possible before because everything is deployed in a self-contained `.war` file.  Now, with this PR, you can see a `guacamole-1.2.0-classes.jar` file in your `.m2/repository` directory tree that can be now used for development of other custom servlets.