### PR TITLE
GUACAMOLE-1025: Allow QuickConnect module to configure allowed and/or denied parameters

### DIFF
--- a/extensions/guacamole-auth-quickconnect/pom.xml
+++ b/extensions/guacamole-auth-quickconnect/pom.xml
@@ -191,6 +191,18 @@
             <version>1.3.0</version>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- Guice -->
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+            <version>3.0</version>
+        </dependency>
 
         <!-- Jersey - JAX-RS Implementation -->
         <dependency>

--- a/extensions/guacamole-auth-quickconnect/src/licenses/guice-3.0/COPYING
+++ b/extensions/guacamole-auth-quickconnect/src/licenses/guice-3.0/COPYING
@@ -200,15 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
-==============================================================================
-
-
-Google Guice (https://github.com/google/guice)
-----------------------------------------------
-
-    Version: 3.0
-    From: 'Google Inc.' (http://www.google.com/)
-    License(s):
-        Apache v2.0 (bundled/guice-3.0/COPYING)

--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectAuthenticationProvider.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectAuthenticationProvider.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.auth.quickconnect;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
@@ -31,6 +33,20 @@ import org.apache.guacamole.net.auth.UserContext;
  */
 public class QuickConnectAuthenticationProvider extends AbstractAuthenticationProvider {
 
+    /**
+     * Injector which will manage the object graph of this authentication
+     * provider.
+     */
+    private final Injector injector;
+    
+    public QuickConnectAuthenticationProvider() throws GuacamoleException {
+
+        // Set up Guice injector.
+        injector = Guice.createInjector(
+            new QuickConnectAuthenticationProviderModule(this)
+        );
+    }
+    
     @Override
     public String getIdentifier() {
         return "quickconnect";
@@ -40,9 +56,13 @@ public class QuickConnectAuthenticationProvider extends AbstractAuthenticationPr
     public UserContext getUserContext(AuthenticatedUser authenticatedUser)
             throws GuacamoleException {
 
-        return new QuickConnectUserContext(this,
-                authenticatedUser.getIdentifier());
-
+        QuickConnectUserContext userContext = 
+                injector.getInstance(QuickConnectUserContext.class);
+        
+        userContext.init(authenticatedUser.getIdentifier());
+        
+        return userContext;
+        
     }
 
 }

--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectAuthenticationProviderModule.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.quickconnect;
+
+import com.google.inject.AbstractModule;
+import org.apache.guacamole.auth.quickconnect.conf.ConfigurationService;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.environment.Environment;
+import org.apache.guacamole.environment.LocalEnvironment;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+
+/**
+ * Guice module which configures QuickConnect-specific injections.
+ */
+public class QuickConnectAuthenticationProviderModule extends AbstractModule {
+
+    /**
+     * Guacamole server environment.
+     */
+    private final Environment environment;
+
+    /**
+     * A reference to the QuickConnectAuthenticationProvider on behalf of which
+     * this module has configured injection.
+     */
+    private final AuthenticationProvider authProvider;
+
+    /**
+     * Creates a new QuickConnect authentication provider module which
+     * configures injection for the QuickConnectAuthenticationProvider.
+     *
+     * @param authProvider
+     *     The AuthenticationProvider for which injection is being configured.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the Guacamole server
+     *     environment.
+     */
+    public QuickConnectAuthenticationProviderModule(
+            AuthenticationProvider authProvider) throws GuacamoleException {
+
+        // Get local environment
+        this.environment = new LocalEnvironment();
+
+        // Store associated auth provider
+        this.authProvider = authProvider;
+
+    }
+
+    @Override
+    protected void configure() {
+
+        // Bind core implementations of guacamole-ext classes
+        bind(AuthenticationProvider.class).toInstance(authProvider);
+        bind(Environment.class).toInstance(environment);
+
+        // Bind QuickConnect-specific services
+        bind(ConfigurationService.class);
+        bind(QuickConnectUserContext.class);
+        bind(QuickConnectDirectory.class);
+
+    }
+
+}

--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectDirectory.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectDirectory.java
@@ -19,11 +19,13 @@
 
 package org.apache.guacamole.auth.quickconnect;
 
+import com.google.inject.Inject;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.quickconnect.utility.QCParser;
+import org.apache.guacamole.auth.quickconnect.conf.ConfigurationService;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.simple.SimpleConnection;
 import org.apache.guacamole.net.auth.simple.SimpleDirectory;
@@ -35,40 +37,46 @@ import org.apache.guacamole.protocol.GuacamoleConfiguration;
  * completely in memory.
  */
 public class QuickConnectDirectory extends SimpleDirectory<Connection> {
-
+    
+    /**
+     * The configuration service for the QuickConnect module.
+     */
+    @Inject
+    private ConfigurationService confService;
+    
     /**
      * The connections to store.
      */
     private final Map<String, Connection> connections =
-            new ConcurrentHashMap<String, Connection>();
+            new ConcurrentHashMap<>();
 
     /**
      * The root connection group for this directory.
      */
-    private final QuickConnectionGroup rootGroup;
+    private QuickConnectionGroup rootGroup;
 
     /**
      * The internal counter for connection IDs.
      */
-    private final AtomicInteger connectionId;
+    private AtomicInteger connectionId;
 
     /**
-     * Creates a new QuickConnectDirectory with the default
-     * empty Map for Connection objects, and the specified
-     * ConnectionGroup at the root of the directory.
+     * Initialize the QuickConnectDirectory with the default empty Map for
+     * Connection objects, and the specified ConnectionGroup at the root of
+     * the directory.
      *
      * @param rootGroup
      *     A group that should be at the root of this directory.
      */
-    public QuickConnectDirectory(ConnectionGroup rootGroup) {
+    public void init(ConnectionGroup rootGroup) {
         this.rootGroup = (QuickConnectionGroup)rootGroup;
         this.connectionId = new AtomicInteger();
         super.setObjects(this.connections);
+        
     }
 
     /**
-     * Returns the current connection identifier counter and
-     * then increments it.
+     * Returns the current connection identifier counter and then increments it.
      *
      * @return
      *     An int representing the next available connection
@@ -84,13 +92,14 @@ public class QuickConnectDirectory extends SimpleDirectory<Connection> {
     }
 
     /**
-     * Create a SimpleConnection object from a GuacamoleConfiguration,
-     * obtain an identifier, and place it on the tree, returning the
-     * identifier value of the new connection.
+     * Taking a URI, parse the URI into a GuacamoleConfiguration object and
+     * then use the configuration to create a SimpleConnection object, obtain
+     * an identifier, and place it on the tree, returning the identifier value
+     * of the new connection.
      *
-     * @param config
-     *     The GuacamoleConfiguration object to use to create the
-     *     SimpleConnection object.
+     * @param uri
+     *     The URI to parse into a GuacamoleConfiguration, which will then be
+     *     used to generate the SimpleConnection.
      *
      * @return
      *     The identifier of the connection created in the directory.
@@ -98,13 +107,20 @@ public class QuickConnectDirectory extends SimpleDirectory<Connection> {
      * @throws GuacamoleException
      *     If an error occurs adding the object to the tree.
      */
-    public String create(GuacamoleConfiguration config) throws GuacamoleException {
+    public String create(String uri) throws GuacamoleException {
 
         // Get the next available connection identifier.
         String newConnectionId = Integer.toString(getNextConnectionID());
 
+        // Get a new QCParser
+        QCParser parser = new QCParser(confService.getAllowedParameters(),
+                                        confService.getDeniedParameters());
+        
+        // Parse the URI into a configuration
+        GuacamoleConfiguration config = parser.getConfiguration(uri);
+
         // Generate a name for the configuration.
-        String name = QCParser.getName(config);
+        String name = parser.getName(config);
 
         // Create a new connection and set the parent identifier.
         Connection connection = new SimpleConnection(name, newConnectionId, config, true);

--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectUserContext.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/QuickConnectUserContext.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.auth.quickconnect;
 
+import com.google.inject.Inject;
 import java.util.Collections;
 import org.apache.guacamole.auth.quickconnect.rest.QuickConnectREST;
 import org.apache.guacamole.GuacamoleException;
@@ -45,32 +46,29 @@ public class QuickConnectUserContext extends AbstractUserContext {
     /**
      * The AuthenticationProvider that created this UserContext.
      */
-    private final AuthenticationProvider authProvider;
+    @Inject
+    private AuthenticationProvider authProvider;
 
     /**
      * Reference to the user whose permissions dictate the configurations
      * accessible within this UserContext.
      */
-    private final User self;
+    private User self;
 
     /**
      * The Directory with access to all connections within the root group
      * associated with this UserContext.
      */
-    private final QuickConnectDirectory connectionDirectory;
+    @Inject
+    private QuickConnectDirectory connectionDirectory;
 
     /**
      * The root connection group.
      */
-    private final ConnectionGroup rootGroup;
+    private ConnectionGroup rootGroup;
 
     /**
-     * Construct a QuickConnectUserContext using the authProvider and
-     * the username.
-     *
-     * @param authProvider
-     *     The authentication provider module instantiating this
-     *     this class.
+     * Initialize a QuickConnectUserContext using the provided username.
      *
      * @param username
      *     The name of the user logging in that will be associated
@@ -80,8 +78,7 @@ public class QuickConnectUserContext extends AbstractUserContext {
      *     If errors occur initializing the ConnectionGroup,
      *     ConnectionDirectory, or User.
      */
-    public QuickConnectUserContext(AuthenticationProvider authProvider,
-            String username) throws GuacamoleException {
+    public void init(String username) throws GuacamoleException {
 
         // Initialize the rootGroup to a QuickConnectionGroup with a
         // single root identifier.
@@ -91,7 +88,7 @@ public class QuickConnectUserContext extends AbstractUserContext {
         );
 
         // Initialize the connection directory
-        this.connectionDirectory = new QuickConnectDirectory(this.rootGroup);
+        this.connectionDirectory.init(this.rootGroup);
 
         // Initialize the user to a SimpleUser with the provided username,
         // no connections, and the single root group.
@@ -108,9 +105,6 @@ public class QuickConnectUserContext extends AbstractUserContext {
             }
 
         };
-
-        // Set the authProvider to the calling authProvider object.
-        this.authProvider = authProvider;
 
     }
 

--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/conf/ConfigurationService.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.quickconnect.conf;
+
+import com.google.inject.Inject;
+import java.util.List;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.environment.Environment;
+import org.apache.guacamole.properties.StringListProperty;
+
+/**
+ * Configuration options to control the QuickConnect module.
+ */
+public class ConfigurationService {
+   
+    /**
+     * The environment of the Guacamole Server.
+     */ 
+    @Inject
+    private Environment environment;
+    
+    /**
+     * A list of parameters that, if set, will limit the parameters allowed to
+     * be defined by connections created using the QuickConnect module to only
+     * the parameters defined in this list.  Defaults to null (all parameters
+     * are allowed).
+     */
+    public static final StringListProperty QUICKCONNECT_ALLOWED_PARAMETERS = new StringListProperty() {
+        
+        @Override
+        public String getName() { return "quickconnect-allowed-parameters"; }
+        
+    };
+    
+    /**
+     * A list of parameters that, if set, will limit the parameters allowed to
+     * be defined by connections created using the QuickConnect module to any
+     * except the ones defined in this list.  Defaults to null (all parameters
+     * are allowed).
+     */
+    public static final StringListProperty QUICKCONNECT_DENIED_PARAMETERS = new StringListProperty() {
+        
+        @Override
+        public String getName() { return "quickconnect-denied-parameters"; }
+        
+    };
+    
+    /**
+     * Return the list of allowed parameters to be set by connections created
+     * using the QuickConnect module, or null if none are defined (thereby
+     * allowing all parameters to be set).
+     * 
+     * @return 
+     *    The list of allowed parameters to be set by connections crated using
+     *    the QuickConnect module.
+     * 
+     * @throws GuacamoleException
+     *    If guacamole.properties cannot be parsed.
+     */
+    public List<String> getAllowedParameters() throws GuacamoleException {
+        return environment.getProperty(QUICKCONNECT_ALLOWED_PARAMETERS);
+    }
+    
+    /**
+     * Return the list of denied parameters for connections created using the
+     * QuickConnect module, or null if none are defined (thereby allowing all
+     * parameters to be set).
+     * 
+     * @return
+     *     The list of parameters that cannot be set by connections created
+     *     using the QuickConnect module.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed.
+     */
+    public List<String> getDeniedParameters() throws GuacamoleException {
+        return environment.getProperty(QUICKCONNECT_DENIED_PARAMETERS);
+    }
+    
+}

--- a/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/rest/QuickConnectREST.java
+++ b/extensions/guacamole-auth-quickconnect/src/main/java/org/apache/guacamole/auth/quickconnect/rest/QuickConnectREST.java
@@ -36,7 +36,7 @@ import org.apache.guacamole.auth.quickconnect.utility.QCParser;
  */
 @Produces(MediaType.APPLICATION_JSON)
 public class QuickConnectREST {
-
+    
     /**
      * The connection directory for this REST endpoint.
      */
@@ -74,8 +74,7 @@ public class QuickConnectREST {
     public Map<String, String> create(@FormParam("uri") String uri) 
             throws GuacamoleException {
 
-        return Collections.singletonMap("identifier",
-                directory.create(QCParser.getConfiguration(uri)));
+        return Collections.singletonMap("identifier", directory.create(uri));
  
     }
 

--- a/extensions/guacamole-auth-quickconnect/src/test/java/org/apache/guacamole/auth/quickconnect/utility/QCParserTest.java
+++ b/extensions/guacamole-auth-quickconnect/src/test/java/org/apache/guacamole/auth/quickconnect/utility/QCParserTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.guacamole.auth.quickconnect.utility;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.Collections;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.protocol.GuacamoleConfiguration;
 import org.junit.Test;
@@ -33,89 +33,85 @@ import static org.junit.Assert.assertNull;
 public class QCParserTest {
 
     /**
-     * Verify that the parseQueryString() method functions as designed.
-     * 
-     * @throws UnsupportedEncodingException
-     *     If Java lacks UTF-8 support.
-     */
-    @Test
-    public void testParseQueryString() throws UnsupportedEncodingException {
-
-        final String queryString = "param1=value1&param2=value2=3&param3=value%3D3&param4=value%264";
-        Map<String, String> queryMap = QCParser.parseQueryString(queryString);
-
-        assertEquals("value1", queryMap.get("param1"));
-        assertEquals("value2=3", queryMap.get("param2"));
-        assertEquals("value=3", queryMap.get("param3"));
-        assertEquals("value&4", queryMap.get("param4"));
-
-    }
-
-    /**
-     * Verify that the parseUserInfo() method functions as designed.
-     * 
-     * @throws UnsupportedEncodingException
-     *     If Java lacks UTF-8 support.
-     */
-    @Test
-    public void testParseUserInfo() throws UnsupportedEncodingException {
-
-        Map<String, String> userInfoMap;
-
-        GuacamoleConfiguration config1 = new GuacamoleConfiguration();
-        QCParser.parseUserInfo("guacuser:secretpw", config1);
-        assertEquals("guacuser", config1.getParameter("username"));
-        assertEquals("secretpw", config1.getParameter("password"));
-
-        GuacamoleConfiguration config2 = new GuacamoleConfiguration();
-        QCParser.parseUserInfo("guacuser", config2);
-        assertEquals("guacuser", config2.getParameter("username"));
-        assertNull(config2.getParameter("password"));
-
-        GuacamoleConfiguration config3 = new GuacamoleConfiguration();
-        QCParser.parseUserInfo("guacuser:P%40ssw0rd%21", config3);
-        assertEquals("guacuser", config3.getParameter("username"));
-        assertEquals("P@ssw0rd!", config3.getParameter("password"));
-
-        GuacamoleConfiguration config4 = new GuacamoleConfiguration();
-        QCParser.parseUserInfo("domain%5cguacuser:domain%2fpassword", config4);
-        assertEquals("domain\\guacuser", config4.getParameter("username"));
-        assertEquals("domain/password", config4.getParameter("password"));
-
-    }
-
-    /**
      * Verify that the getConfiguration() method returns the expected
      * GuacamoleConfiguration object.
      * 
      * @throws GuacamoleException
-     *     If the configuration cannot be parsed from the given URI.
+     *     If the configuration cannot be parsed from the given URI or Java
+     *     unexpectedly lacks UTF-8 support.
      */
     @Test
     public void testGetConfiguration() throws GuacamoleException {
 
-        String uri1 = "ssh://guacuser:guacpassword@hostname1.domain.local/?param1=value1&param2=value2";
-        GuacamoleConfiguration config1 = QCParser.getConfiguration(uri1);
-        assertEquals("ssh", config1.getProtocol());
-        assertEquals("hostname1.domain.local", config1.getParameter("hostname"));
-        assertEquals("guacuser", config1.getParameter("username"));
-        assertEquals("guacpassword", config1.getParameter("password"));
-        assertEquals("value1", config1.getParameter("param1"));
-        assertEquals("value2", config1.getParameter("param2"));
+        // Initialize the parser, first with no lists so all parameters are allowed
+        QCParser parser = new QCParser();
+        
+        // Create some empty objects to test
+        GuacamoleConfiguration guacConfig;
+        String uri;
+        
+        // Test a standard SSH URI, with username and password, and parameters and values
+        uri = "ssh://guacuser:guacpassword@hostname1.domain.local/?param1=value1&param2=value2";
+        guacConfig = parser.getConfiguration(uri);
+        assertEquals("ssh", guacConfig.getProtocol());
+        assertEquals("hostname1.domain.local", guacConfig.getParameter("hostname"));
+        assertEquals("guacuser", guacConfig.getParameter("username"));
+        assertEquals("guacpassword", guacConfig.getParameter("password"));
+        assertEquals("value1", guacConfig.getParameter("param1"));
+        assertEquals("value2", guacConfig.getParameter("param2"));
 
-        String uri2 = "rdp://domain%5cguacuser:adPassword123@windows1.domain.tld/?enable-sftp=true";
-        GuacamoleConfiguration config2 = QCParser.getConfiguration(uri2);
-        assertEquals("rdp", config2.getProtocol());
-        assertEquals("windows1.domain.tld", config2.getParameter("hostname"));
-        assertEquals("domain\\guacuser", config2.getParameter("username"));
-        assertEquals("adPassword123", config2.getParameter("password"));
-        assertEquals("true", config2.getParameter("enable-sftp"));
+        // Test a standard RDP URI, with username/password and a parameter/value pair.
+        uri = "rdp://domain%5cguacuser:adPassword123@windows1.domain.tld/?enable-sftp=true";
+        guacConfig = parser.getConfiguration(uri);
+        assertEquals("rdp", guacConfig.getProtocol());
+        assertEquals("windows1.domain.tld", guacConfig.getParameter("hostname"));
+        assertEquals("domain\\guacuser", guacConfig.getParameter("username"));
+        assertEquals("adPassword123", guacConfig.getParameter("password"));
+        assertEquals("true", guacConfig.getParameter("enable-sftp"));
 
-        String uri3 = "vnc://mirror1.example.com:5910/";
-        GuacamoleConfiguration config3 = QCParser.getConfiguration(uri3);
-        assertEquals("vnc", config3.getProtocol());
-        assertEquals("mirror1.example.com", config3.getParameter("hostname"));
-        assertEquals("5910", config3.getParameter("port"));
+        // Test a VNC URI with no parameters/values
+        uri = "vnc://mirror1.example.com:5910/";
+        guacConfig = parser.getConfiguration(uri);
+        assertEquals("vnc", guacConfig.getProtocol());
+        assertEquals("mirror1.example.com", guacConfig.getParameter("hostname"));
+        assertEquals("5910", guacConfig.getParameter("port"));
+        
+        // Test a telnet URI with no parameters/values
+        uri = "telnet://old1.example.com:23/";
+        guacConfig = parser.getConfiguration(uri);
+        assertEquals("telnet", guacConfig.getProtocol());
+        assertEquals("old1.example.com", guacConfig.getParameter("hostname"));
+        assertEquals("23", guacConfig.getParameter("port"));
+        
+        // Re-initialize parser with only allowed parameters, and test
+        parser = new QCParser(Arrays.asList("hostname", "username", "password", "port"), Collections.emptyList());
+        uri = "rdp://domain%5cguacuser:adPassword123@windows1.domain.tld/?enable-sftp=true";
+        guacConfig = parser.getConfiguration(uri);
+        assertEquals("rdp", guacConfig.getProtocol());
+        assertEquals("windows1.domain.tld", guacConfig.getParameter("hostname"));
+        assertEquals("domain\\guacuser", guacConfig.getParameter("username"));
+        assertEquals("adPassword123", guacConfig.getParameter("password"));
+        assertNull(guacConfig.getParameter("enable-sftp"));
+        
+        // Re-initialize parser with denied parameters, and test
+        parser = new QCParser(Collections.emptyList(), Arrays.asList("password"));
+        uri = "rdp://domain%5cguacuser:adPassword123@windows1.domain.tld/?enable-sftp=true";
+        guacConfig = parser.getConfiguration(uri);
+        assertEquals("rdp", guacConfig.getProtocol());
+        assertEquals("windows1.domain.tld", guacConfig.getParameter("hostname"));
+        assertEquals("domain\\guacuser", guacConfig.getParameter("username"));
+        assertNull(guacConfig.getParameter("password"));
+        assertEquals("true", guacConfig.getParameter("enable-sftp"));
+        
+        // Re-initialize parser with both allowed and denied parameters, and test
+        parser = new QCParser(Arrays.asList("hostname", "username", "password", "port"), Arrays.asList("password"));
+        uri = "rdp://domain%5cguacuser:adPassword123@windows1.domain.tld/?enable-sftp=true";
+        guacConfig = parser.getConfiguration(uri);
+        assertEquals("rdp", guacConfig.getProtocol());
+        assertEquals("windows1.domain.tld", guacConfig.getParameter("hostname"));
+        assertEquals("domain\\guacuser", guacConfig.getParameter("username"));
+        assertNull(guacConfig.getParameter("password"));
+        assertNull(guacConfig.getParameter("enable-sftp"));
 
     }
 


### PR DESCRIPTION
This implements the necessary bits to allow someone to specify in the guacamole.properties file a list of either explicitly allowed parameters or a list of explicitly denied parameters for the QuickConnect module.  In specifying either or both of these options, an administrator can control what functionality or access end users have access to while still allowing the flexibility of ad-hoc connections.