### PR TITLE
GUACAMOLE-1082: Add guacamole-auth-cas to docker Script

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -168,3 +168,19 @@ if [ -f extensions/guacamole-auth-header/target/guacamole-auth-header*.jar ]; th
     mkdir -p "$DESTINATION/header"
     cp extensions/guacamole-auth-header/target/guacamole-auth-header*.jar "$DESTINATION/header"
 fi
+
+#
+# Copy CAS auth extension if it was built
+#
+
+if [ -f extensions/guacamole-auth-cas/target/*.tar.gz ]; then
+    mkdir -p "$DESTINATION/cas"
+    tar -xzf extensions/guacamole-auth-cas/target/*.tar.gz  \
+    -C "$DESTINATION/cas/"                                  \
+    --wildcards                                             \
+    --no-anchored                                           \
+    --no-wildcards-match-slash                              \
+    --strip-components=1                                    \
+    "*.jar"
+fi
+

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -653,6 +653,38 @@ associate_header() {
 }
 
 ##
+## Adds properties to guacamole.properties witch configure the CAS
+## authentication service.
+##
+associate_cas() {
+    # Verify required parameters are present
+    if [ -z "$CAS_AUTHORIZATION_ENDPOINT" ] || \
+       [ -z "$CAS_REDIRECT_URI" ]
+    then
+        cat <<END
+FATAL: Missing required environment variables
+-----------------------------------------------------------------------------------
+If using the CAS authentication extension, you must provide each of the
+following environment variables:
+
+    CAS_AUTHORIZATION_ENDPOINT      The URL of the CAS authentication server.
+
+    CAS_REDIRECT_URI                The URI to redirect back to upon successful authentication.
+
+END
+        exit 1;
+    fi
+
+    # Update config file
+    set_property            "cas-authorization-endpoint"       "$CAS_AUTHORIZATION_ENDPOINT"
+    set_property            "cas-redirect-uri"                 "$CAS_REDIRECT_URI"
+    set_optional_property   "cas-clearpass-key"                "$CAS_CLEARPASS_KEY"
+
+    # Add required .jar files to GUACAMOLE_EXT
+    ln -s /opt/guacamole/cas/guacamole-auth-*.jar   "$GUACAMOLE_EXT"
+}
+
+##
 ## Starts Guacamole under Tomcat, replacing the current process with the
 ## Tomcat process. As the current process will be replaced, this MUST be the
 ## last function run within the script.
@@ -797,6 +829,11 @@ fi
 # Use header if specified.
 if [ "$HEADER_ENABLED" = "true" ]; then
     associate_header
+fi
+
+# Use CAS if specified.
+if [ -n "$CAS_AUTHORIZATION_ENDPOINT" ]; then
+    associate_cas
 fi
 
 # Set logback level if specified


### PR DESCRIPTION
This branch provides to Docker image use the guacamole-auth-cas  (version 1.1.0).

Thank you very much.