### PR TITLE
GUACAMOLE-1094: Add overridable response_type to auth-openid extension

### DIFF
--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/AuthenticationProviderService.java
@@ -121,6 +121,7 @@ public class AuthenticationProviderService {
                     confService.getScope(),
                     confService.getClientID(),
                     confService.getRedirectURI(),
+                    confService.getResponseType(),
                     nonceService.generate(confService.getMaxNonceValidity() * 60000L)
                 )
 

--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
@@ -63,6 +63,12 @@ public class ConfigurationService {
     private static final int DEFAULT_MAX_NONCE_VALIDITY = 10;
 
     /**
+     * The default maximum value to use for the response_type parameter
+     * in the authorization request.
+     */
+    private static final String DEFAULT_RESPONSE_TYPE = "id_token";
+
+    /**
      * The authorization endpoint (URI) of the OpenID service.
      */
     private static final URIGuacamoleProperty OPENID_AUTHORIZATION_ENDPOINT =
@@ -183,6 +189,18 @@ public class ConfigurationService {
         public String getName() { return "openid-redirect-uri"; }
 
     };
+
+    /**
+     * The value to use for the response_type query parameter when submitting
+     * the authentication request to the authorization server.
+     */
+    private static final StringGuacamoleProperty RESPONSE_TYPE =
+            new StringGuacamoleProperty() {
+
+                @Override
+                public String getName() { return "response-type-override"; }
+
+            };
 
     /**
      * The Guacamole server environment.
@@ -359,6 +377,24 @@ public class ConfigurationService {
      */
     public int getMaxNonceValidity() throws GuacamoleException {
         return environment.getProperty(OPENID_MAX_NONCE_VALIDITY, DEFAULT_MAX_NONCE_VALIDITY);
+    }
+
+    /**
+     * Returns the value of the response_type parameter to use when submitting
+     * an authentication request to the authorization server. Some authorization
+     * servers may require values other than "id_token" for this parameter and
+     * this allows the user to override the default value with an alternate
+     * implementation-specific value that still results in the server following
+     * the "implicit flow." By default, this will be "id_token".
+     *
+     * @return
+     *     The value to use for the response_type parameter
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getResponseType() throws GuacamoleException {
+        return environment.getProperty(RESPONSE_TYPE, DEFAULT_RESPONSE_TYPE);
     }
 
 }

--- a/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/form/TokenField.java
+++ b/extensions/guacamole-auth-openid/src/main/java/org/apache/guacamole/auth/openid/form/TokenField.java
@@ -65,19 +65,23 @@ public class TokenField extends Field {
      *     The URI that the OpenID service should redirect to upon successful
      *     authentication.
      *
+     * @param responseType
+     *     The value that should be used for the response_type parameter of
+     *     the authentication request.
+     *
      * @param nonce
      *     A random string unique to this request. To defend against replay
      *     attacks, this value must cease being valid after its first use.
      */
     public TokenField(URI authorizationEndpoint, String scope,
-            String clientID, URI redirectURI, String nonce) {
+            String clientID, URI redirectURI, String responseType, String nonce) {
 
         // Init base field properties
         super(PARAMETER_NAME, "GUAC_OPENID_TOKEN");
 
         this.authorizationURI = UriBuilder.fromUri(authorizationEndpoint)
                 .queryParam("scope", scope)
-                .queryParam("response_type", "id_token")
+                .queryParam("response_type", responseType)
                 .queryParam("client_id", clientID)
                 .queryParam("redirect_uri", redirectURI)
                 .queryParam("nonce", nonce)


### PR DESCRIPTION
Allows overriding the default value of the response_type parameter in the OpenID auth extension for compatibility with authentication servers that require specific values that are different than the default "id_token", like AWS Cognito. See the [Jira issue](https://issues.apache.org/jira/browse/GUACAMOLE-1094) for further explanation.