### PR TITLE
GUACAMOLE-583: Correct SQLServer instance name property configuration.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/java/org/apache/guacamole/auth/sqlserver/SQLServerAuthenticationProviderModule.java
@@ -70,16 +70,17 @@ public class SQLServerAuthenticationProviderModule implements Module {
         myBatisProperties.setProperty("JDBC.username", environment.getSQLServerUsername());
         myBatisProperties.setProperty("JDBC.password", environment.getSQLServerPassword());
         
-        String instance = environment.getSQLServerInstance();
-        if (instance != null)
-            myBatisProperties.setProperty("JDBC.instanceName", instance);
-        
         myBatisProperties.setProperty("JDBC.autoCommit", "false");
         myBatisProperties.setProperty("mybatis.pooled.pingEnabled", "true");
         myBatisProperties.setProperty("mybatis.pooled.pingQuery", "SELECT 1");
 
         // Use UTF-8 in database
         driverProperties.setProperty("characterEncoding", "UTF-8");
+        
+        // Retrieve instance name and set it
+        String instance = environment.getSQLServerInstance();
+        if (instance != null)
+            driverProperties.setProperty("JDBC.instanceName", instance);
 
         // Capture which driver to use for the connection.
         this.sqlServerDriver = environment.getSQLServerDriver();


### PR DESCRIPTION
Turns out `JDBCHelper` does not use the `instanceName` property directly, so it looks like it needs to be set at the driver level, instead.