### PR TITLE
GUACAMOLE-708: Add API for exposing privileged access to extensions.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -139,6 +139,7 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
         
         // Initialize the UserContext with the user account and return it.
         context.init(user.getCurrentUser());
+        context.recordUserLogin();
         return context;
 
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
@@ -82,8 +82,9 @@ public class ActiveConnectionPermissionService
         // Retrieve permissions only if allowed
         if (canReadPermissions(user, targetEntity)) {
 
-            // Administrators may always access active connections
-            boolean isAdmin = targetEntity.isPrivileged();
+            // Privileged accounts (such as administrators or UserContexts
+            // returned by getPrivileged()) may always access active connections
+            boolean isPrivileged = targetEntity.isPrivileged();
 
             // Get all active connections
             Collection<ActiveConnectionRecord> records = tunnelService.getActiveConnections(user);
@@ -96,9 +97,9 @@ public class ActiveConnectionPermissionService
                 String identifier = record.getUUID().toString();
                 permissions.add(new ObjectPermission(ObjectPermission.Type.READ, identifier));
 
-                // If the target use is an admin, or the connection belongs to
-                // the target user, then they can DELETE
-                if (isAdmin || targetEntity.isUser(record.getUsername()))
+                // If the target user is privileged, or the connection belongs
+                // to the target user, then they can DELETE
+                if (isPrivileged || targetEntity.isUser(record.getUsername()))
                     permissions.add(new ObjectPermission(ObjectPermission.Type.DELETE, identifier));
 
             }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionPermissionService.java
@@ -82,21 +82,22 @@ public class ActiveConnectionPermissionService
         // Retrieve permissions only if allowed
         if (canReadPermissions(user, targetEntity)) {
 
-            // Only administrators may access active connections
-            boolean isAdmin = targetEntity.isAdministrator();
+            // Administrators may always access active connections
+            boolean isAdmin = targetEntity.isPrivileged();
 
             // Get all active connections
             Collection<ActiveConnectionRecord> records = tunnelService.getActiveConnections(user);
 
             // We have READ, and possibly DELETE, on all active connections
-            Set<ObjectPermission> permissions = new HashSet<ObjectPermission>();
+            Set<ObjectPermission> permissions = new HashSet<>();
             for (ActiveConnectionRecord record : records) {
 
                 // Add implicit READ
                 String identifier = record.getUUID().toString();
                 permissions.add(new ObjectPermission(ObjectPermission.Type.READ, identifier));
 
-                // If we're an admin, or the connection is ours, then we can DELETE
+                // If the target use is an admin, or the connection belongs to
+                // the target user, then they can DELETE
                 if (isAdmin || targetEntity.isUser(record.getUsername()))
                     permissions.add(new ObjectPermission(ObjectPermission.Type.DELETE, identifier));
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -81,7 +81,7 @@ public class ActiveConnectionService
             Collection<String> identifiers) throws GuacamoleException {
 
         String username = user.getIdentifier();
-        boolean isAdmin = user.isPrivileged();
+        boolean isPrivileged = user.isPrivileged();
         Set<String> identifierSet = new HashSet<String>(identifiers);
 
         // Retrieve all visible connections (permissions enforced by tunnel service)
@@ -95,7 +95,7 @@ public class ActiveConnectionService
             // be able to connect to (join) the active connection if they are
             // the user that started the connection OR the user is an admin
             boolean hasPrivilegedAccess =
-                    isAdmin || username.equals(record.getUsername());
+                    isPrivileged || username.equals(record.getUsername());
 
             // Add connection if within requested identifiers
             if (identifierSet.contains(record.getUUID().toString())) {

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -81,7 +81,7 @@ public class ActiveConnectionService
             Collection<String> identifiers) throws GuacamoleException {
 
         String username = user.getIdentifier();
-        boolean isAdmin = user.getUser().isAdministrator();
+        boolean isAdmin = user.isPrivileged();
         Set<String> identifierSet = new HashSet<String>(identifiers);
 
         // Retrieve all visible connections (permissions enforced by tunnel service)
@@ -211,7 +211,7 @@ public class ActiveConnectionService
         
         ObjectPermissionSet permissionSet = getPermissionSet(user);
         
-        return user.getUser().isAdministrator() 
+        return user.isPrivileged()
                 || permissionSet.hasPermission(type, identifier);
         
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledChildDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledChildDirectoryObjectService.java
@@ -148,7 +148,7 @@ public abstract class ModeledChildDirectoryObjectService<InternalType extends Mo
     protected boolean canUpdateModifiedParents(ModeledAuthenticatedUser user,
             String identifier, ModelType model) throws GuacamoleException {
 
-        // If user is an administrator, no need to check
+        // If user is privileged, no need to check
         if (user.isPrivileged())
             return true;
         

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledChildDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledChildDirectoryObjectService.java
@@ -149,7 +149,7 @@ public abstract class ModeledChildDirectoryObjectService<InternalType extends Mo
             String identifier, ModelType model) throws GuacamoleException {
 
         // If user is an administrator, no need to check
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return true;
         
         // Verify that we have permission to modify any modified parents

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
@@ -395,7 +395,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
 
         Collection<ModelType> objects;
 
-        // Bypass permission checks if the user is a system admin
+        // Bypass permission checks if the user is privileged
         if (user.isPrivileged())
             objects = getObjectMapper().select(identifiers);
 
@@ -507,7 +507,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
     public Set<String> getIdentifiers(ModeledAuthenticatedUser user)
         throws GuacamoleException {
 
-        // Bypass permission checks if the user is a system admin
+        // Bypass permission checks if the user is privileged
         if (user.isPrivileged())
             return getObjectMapper().selectIdentifiers();
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledDirectoryObjectService.java
@@ -171,7 +171,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
         ObjectPermissionSet permissionSet = getEffectivePermissionSet(user);
         
         // Return whether permission is granted
-        return user.getUser().isAdministrator()
+        return user.isPrivileged()
             || permissionSet.hasPermission(type, identifier);
 
     }
@@ -248,7 +248,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
             ExternalType object, ModelType model) throws GuacamoleException {
 
         // Verify permission to create objects
-        if (!user.getUser().isAdministrator() && !hasCreatePermission(user))
+        if (!user.isPrivileged() && !hasCreatePermission(user))
             throw new GuacamoleSecurityException("Permission denied.");
 
     }
@@ -396,7 +396,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
         Collection<ModelType> objects;
 
         // Bypass permission checks if the user is a system admin
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             objects = getObjectMapper().select(identifiers);
 
         // Otherwise only return explicitly readable identifiers
@@ -508,7 +508,7 @@ public abstract class ModeledDirectoryObjectService<InternalType extends Modeled
         throws GuacamoleException {
 
         // Bypass permission checks if the user is a system admin
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return getObjectMapper().selectIdentifiers();
 
         // Otherwise only return explicitly readable identifiers

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledPermissions.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledPermissions.java
@@ -132,18 +132,20 @@ public abstract class ModeledPermissions<ModelType extends EntityModel>
     }
 
     /**
-     * Returns whether this entity is a system administrator, and thus is not
-     * restricted by permissions, taking into account permission inheritance
-     * via user groups.
+     * Returns whether this entity is effectively unrestricted by permissions,
+     * such as a system administrator or an internal user operating via a
+     * privileged UserContext. Permission inheritance via user groups is taken
+     * into account.
      *
      * @return
-     *    true if this entity is a system administrator, false otherwise.
+     *     true if this entity should be unrestricted by permissions, false
+     *     otherwise.
      *
      * @throws GuacamoleException
-     *    If an error occurs while determining the entity's system administrator
-     *    status.
+     *     If an error occurs while determining whether permission restrictions
+     *     apply to the entity.
      */
-    public boolean isAdministrator() throws GuacamoleException {
+    public boolean isPrivileged() throws GuacamoleException {
         SystemPermissionSet systemPermissionSet = getEffective().getSystemPermissions();
         return systemPermissionSet.hasPermission(SystemPermission.Type.ADMINISTER);
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/RelatedObjectSet.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/RelatedObjectSet.java
@@ -141,7 +141,7 @@ public abstract class RelatedObjectSet<ParentObjectType extends ModeledDirectory
             throws GuacamoleException {
 
         // System administrators may alter any relations
-        if (getCurrentUser().getUser().isAdministrator())
+        if (getCurrentUser().isPrivileged())
             return true;
 
         // Non-admin users require UPDATE permission on the parent object ...
@@ -164,7 +164,7 @@ public abstract class RelatedObjectSet<ParentObjectType extends ModeledDirectory
 
         // Bypass permission checks if the user is a system admin
         ModeledAuthenticatedUser user = getCurrentUser();
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return getObjectRelationMapper().selectChildIdentifiers(parent.getModel());
 
         // Otherwise only return explicitly readable identifiers

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/RelatedObjectSet.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/RelatedObjectSet.java
@@ -140,7 +140,8 @@ public abstract class RelatedObjectSet<ParentObjectType extends ModeledDirectory
     private boolean canAlterRelation(Collection<String> identifiers)
             throws GuacamoleException {
 
-        // System administrators may alter any relations
+        // Privileged users (such as system administrators) may alter any
+        // relations
         if (getCurrentUser().isPrivileged())
             return true;
 
@@ -162,7 +163,7 @@ public abstract class RelatedObjectSet<ParentObjectType extends ModeledDirectory
     @Override
     public Set<String> getObjects() throws GuacamoleException {
 
-        // Bypass permission checks if the user is a system admin
+        // Bypass permission checks if the user is a privileged
         ModeledAuthenticatedUser user = getCurrentUser();
         if (user.isPrivileged())
             return getObjectRelationMapper().selectChildIdentifiers(parent.getModel());

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
@@ -297,7 +297,7 @@ public class ConnectionService extends ModeledChildDirectoryObjectService<Modele
             String identifier)
             throws GuacamoleException {
 
-        // Bypass permission checks if the user is a system admin
+        // Bypass permission checks if the user is privileged
         if (user.isPrivileged())
             return connectionMapper.selectIdentifiersWithin(identifier);
 
@@ -470,7 +470,7 @@ public class ConnectionService extends ModeledChildDirectoryObjectService<Modele
 
         List<ConnectionRecordModel> searchResults;
 
-        // Bypass permission checks if the user is a system admin
+        // Bypass permission checks if the user is privileged
         if (user.isPrivileged())
             searchResults = connectionRecordMapper.search(requiredContents,
                     sortPredicates, limit);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ConnectionService.java
@@ -298,7 +298,7 @@ public class ConnectionService extends ModeledChildDirectoryObjectService<Modele
             throws GuacamoleException {
 
         // Bypass permission checks if the user is a system admin
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return connectionMapper.selectIdentifiersWithin(identifier);
 
         // Otherwise only return explicitly readable identifiers
@@ -471,7 +471,7 @@ public class ConnectionService extends ModeledChildDirectoryObjectService<Modele
         List<ConnectionRecordModel> searchResults;
 
         // Bypass permission checks if the user is a system admin
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             searchResults = connectionRecordMapper.search(requiredContents,
                     sortPredicates, limit);
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
@@ -219,7 +219,7 @@ public class ConnectionGroupService extends ModeledChildDirectoryObjectService<M
             throws GuacamoleException {
 
         // Bypass permission checks if the user is a system admin
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return connectionGroupMapper.selectIdentifiersWithin(identifier);
 
         // Otherwise only return explicitly readable identifiers

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connectiongroup/ConnectionGroupService.java
@@ -218,7 +218,7 @@ public class ConnectionGroupService extends ModeledChildDirectoryObjectService<M
             String identifier)
             throws GuacamoleException {
 
-        // Bypass permission checks if the user is a system admin
+        // Bypass permission checks if the user is privileged
         if (user.isPrivileged())
             return connectionGroupMapper.selectIdentifiersWithin(identifier);
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/AbstractPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/AbstractPermissionService.java
@@ -105,7 +105,7 @@ public abstract class AbstractPermissionService<PermissionSetType extends Permis
             return true;
         
         // A system adminstrator can do anything
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return true;
 
         // Can read permissions on target entity if explicit READ is granted

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/AbstractPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/AbstractPermissionService.java
@@ -104,7 +104,7 @@ public abstract class AbstractPermissionService<PermissionSetType extends Permis
         if (targetEntity.isUser(user.getUser().getIdentifier()))
             return true;
         
-        // A system adminstrator can do anything
+        // Privileged users (such as system administrators) may do anything
         if (user.isPrivileged())
             return true;
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledObjectPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledObjectPermissionService.java
@@ -95,7 +95,7 @@ public abstract class ModeledObjectPermissionService
             Collection<ObjectPermission> permissions)
             throws GuacamoleException {
 
-        // A system adminstrator can do anything
+        // Privileged users (such as system administrators) may do anything
         if (user.isPrivileged())
             return true;
         
@@ -187,7 +187,7 @@ public abstract class ModeledObjectPermissionService
         if (identifiers.isEmpty())
             return identifiers;
         
-        // If user is an admin, everything is accessible
+        // Privileged users (such as system administrators) may access everything
         if (user.isPrivileged())
             return identifiers;
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledObjectPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/ModeledObjectPermissionService.java
@@ -96,7 +96,7 @@ public abstract class ModeledObjectPermissionService
             throws GuacamoleException {
 
         // A system adminstrator can do anything
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return true;
         
         // Verify user has update permission on the target entity
@@ -188,7 +188,7 @@ public abstract class ModeledObjectPermissionService
             return identifiers;
         
         // If user is an admin, everything is accessible
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return identifiers;
 
         // Otherwise, return explicitly-retrievable identifiers only if allowed

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionService.java
@@ -94,7 +94,8 @@ public class SystemPermissionService
             ModeledPermissions<? extends EntityModel> targetEntity,
             Collection<SystemPermission> permissions) throws GuacamoleException {
 
-        // Only an admin can create system permissions
+        // Only privileged users (such as system administrators) can create
+        // system permissions
         if (user.isPrivileged()) {
             Collection<SystemPermissionModel> models = getModelInstances(targetEntity, permissions);
             systemPermissionMapper.insert(models);
@@ -111,7 +112,8 @@ public class SystemPermissionService
             ModeledPermissions<? extends EntityModel> targetEntity,
             Collection<SystemPermission> permissions) throws GuacamoleException {
 
-        // Only an admin can delete system permissions
+        // Only privileged users (such as system administrators) can delete
+        // system permissions
         if (user.isPrivileged()) {
 
             // Do not allow users to remove their own admin powers

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/permission/SystemPermissionService.java
@@ -95,7 +95,7 @@ public class SystemPermissionService
             Collection<SystemPermission> permissions) throws GuacamoleException {
 
         // Only an admin can create system permissions
-        if (user.getUser().isAdministrator()) {
+        if (user.isPrivileged()) {
             Collection<SystemPermissionModel> models = getModelInstances(targetEntity, permissions);
             systemPermissionMapper.insert(models);
             return;
@@ -112,7 +112,7 @@ public class SystemPermissionService
             Collection<SystemPermission> permissions) throws GuacamoleException {
 
         // Only an admin can delete system permissions
-        if (user.getUser().isAdministrator()) {
+        if (user.isPrivileged()) {
 
             // Do not allow users to remove their own admin powers
             if (user.getUser().getIdentifier().equals(targetEntity.getIdentifier()))

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -629,7 +629,7 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
             return Collections.<ActiveConnectionRecord>emptyList();
 
         // A system administrator can view all connections; no need to filter
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             return records;
 
         // Build set of all connection identifiers associated with active tunnels

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -628,7 +628,8 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
         if (records.isEmpty())
             return Collections.<ActiveConnectionRecord>emptyList();
 
-        // A system administrator can view all connections; no need to filter
+        // Privileged users (such as system administrators) can view all
+        // connections; no need to filter
         if (user.isPrivileged())
             return records;
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
@@ -174,6 +175,24 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
     public Set<String> getEffectiveUserGroups() {
         return Sets.union(user.getEffectiveUserGroups(),
                 super.getEffectiveUserGroups());
+    }
+
+    /**
+     * Returns whether this user is effectively unrestricted by permissions,
+     * such as a system administrator or an internal user operating via a
+     * privileged UserContext. Permission inheritance via user groups is taken
+     * into account.
+     *
+     * @return
+     *     true if this user should be unrestricted by permissions, false
+     *     otherwise.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while determining whether permission restrictions
+     *     apply to the user.
+     */
+    public boolean isPrivileged() throws GuacamoleException {
+        return getUser().isPrivileged();
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/PrivilegedModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/PrivilegedModeledAuthenticatedUser.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.auth.jdbc.user;
+
+import org.apache.guacamole.GuacamoleException;
+
+/**
+ * A ModeledAuthenticatedUser which is always privileged, returning true for
+ * every call to isPrivileged().
+ */
+public class PrivilegedModeledAuthenticatedUser extends ModeledAuthenticatedUser {
+
+    /**
+     * Creates a new PrivilegedModeledAuthenticatedUser which shares the same
+     * user identity as the given ModeledAuthenticatedUser. Regardless of the
+     * privileges explicitly granted to the given user, the resulting
+     * PrivilegedModeledAuthenticatedUser will always assert that it is
+     * privileged.
+     *
+     * @param authenticatedUser
+     *     The ModeledAuthenticatedUser that declares the identity of the user
+     *     in question.
+     */
+    public PrivilegedModeledAuthenticatedUser(ModeledAuthenticatedUser authenticatedUser){
+        super(authenticatedUser, authenticatedUser.getModelAuthenticationProvider(), authenticatedUser.getUser());
+    }
+
+    @Override
+    public boolean isPrivileged() throws GuacamoleException {
+        return true;
+    }
+
+}

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -278,7 +278,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         // Verify new password does not violate defined policies (if specified)
         if (object.getPassword() != null) {
 
-            // Enforce password age only for non-adminstrators
+            // Enforce password age only for non-privileged users
             if (!user.isPrivileged())
                 passwordPolicyService.verifyPasswordAge(object);
 
@@ -626,7 +626,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
         List<ActivityRecordModel> searchResults;
 
-        // Bypass permission checks if the user is a system admin
+        // Bypass permission checks if the user is privileged
         if (user.isPrivileged())
             searchResults = userRecordMapper.search(requiredContents,
                     sortPredicates, limit);

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -279,7 +279,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         if (object.getPassword() != null) {
 
             // Enforce password age only for non-adminstrators
-            if (!user.getUser().isAdministrator())
+            if (!user.isPrivileged())
                 passwordPolicyService.verifyPasswordAge(object);
 
             // Always verify password complexity
@@ -627,7 +627,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         List<ActivityRecordModel> searchResults;
 
         // Bypass permission checks if the user is a system admin
-        if (user.getUser().isAdministrator())
+        if (user.isPrivileged())
             searchResults = userRecordMapper.search(requiredContents,
                     sortPredicates, limit);
 

--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/UserVerificationService.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/UserVerificationService.java
@@ -181,12 +181,13 @@ public class UserVerificationService {
 
         // Update user object
         try {
-            context.getUserDirectory().update(self);
+            context.getPrivileged().getUserDirectory().update(self);
         }
         catch (GuacamoleSecurityException e) {
             logger.info("User \"{}\" cannot store their TOTP key as they "
-                    + "lack permission to update their own account. TOTP "
-                    + "will be disabled for this user.",
+                    + "lack permission to update their own account and the "
+                    + "TOTP extension was unable to obtain privileged access. "
+                    + "TOTP will be disabled for this user.",
                     self.getIdentifier());
             logger.debug("Permission denied to set TOTP key of user "
                     + "account.", e);

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/AbstractUserContext.java
@@ -254,4 +254,16 @@ public abstract class AbstractUserContext implements UserContext {
     public void invalidate() {
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation simply returns <code>this</code>. Implementations
+     * that wish to provide additional privileges to extensions requesting
+     * privileged access should override this function.
+     */
+    @Override
+    public UserContext getPrivileged() {
+        return this;
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
@@ -152,4 +152,9 @@ public class DelegatingUserContext implements UserContext {
         userContext.invalidate();
     }
 
+    @Override
+    public UserContext getPrivileged() {
+        return userContext.getPrivileged();
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
@@ -262,4 +262,29 @@ public interface UserContext {
      */
     void invalidate();
 
+    /**
+     * Returns a user context which provides privileged access. Unlike the
+     * original user context, which is required to enforce its own permissions
+     * and act only within the rights of the associated user, the user context
+     * returned by this function MAY ignore the restrictions that otherwise
+     * limit the current user's access.
+     *
+     * <p>This function is intended to allow extensions which decorate other
+     * extensions to act independently of the restrictions that affect the
+     * current user. This function will only be invoked by extensions and
+     * WILL NOT be invoked directly by the web application. Implementations of
+     * this function MAY still enforce access restrictions, particularly if
+     * they do not want to grant full, unrestricted access to other extensions.
+     *
+     * <p>A default implementation which simply returns <code>this</code> is
+     * provided for compatibility with Apache Guacamole 1.1.0 and older.
+     *
+     * @return
+     *     A user context instance which MAY ignore some or all restrictions
+     *     which otherwise limit the current user's access.
+     */
+    default UserContext getPrivileged() {
+        return this;
+    }
+
 }


### PR DESCRIPTION
To facilitate collaborative storage of arbitrary attributes between extensions, this change adds a new `getPrivileged()` function to the `UserContext` interface, allowing an internal and privileged `UserContext` to be retrieved. As only an extension may invoke this function (it is not called within the REST API), this allows extensions to expose privileged access to other extensions without requiring that users logging into Guacamole via those extensions have the same privileges.

For example, Guacamole's TOTP support has historically required that each user have `UPDATE` privileges on themselves, since the database authentication would otherwise deny the TOTP extension's attempt to store additional attributes for that user. With these changes, the TOTP support uses a privileged `UserContext` to store its attributes, and users of TOTP need not be granted additional privileges.