### PR TITLE
GUACAMOLE-823: Render empty balancing group as if they were connections.

### DIFF
--- a/guacamole/src/main/webapp/app/groupList/templates/guacGroupList.html
+++ b/guacamole/src/main/webapp/app/groupList/templates/guacGroupList.html
@@ -3,6 +3,7 @@
     <script type="text/ng-template" id="nestedItem.html">
         <div class="{{item.type}}" ng-if="isVisible(item.type)"
             ng-class="{
+                balancer   : item.balancing,
                 expanded   : item.expanded,
                 expandable : item.expandable,
                 empty      : !item.children.length

--- a/guacamole/src/main/webapp/app/groupList/types/GroupListItem.js
+++ b/guacamole/src/main/webapp/app/groupList/types/GroupListItem.js
@@ -145,7 +145,7 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
                 });
 
             // If the item is a connection group, generate a connection group identifier
-            if (this.type === GroupListItem.Type.CONNECTION_GROUP)
+            if (this.type === GroupListItem.Type.CONNECTION_GROUP && this.balancing)
                 return ClientIdentifier.toString({
                     dataSource : this.dataSource,
                     type       : ClientIdentifier.Types.CONNECTION_GROUP,
@@ -153,6 +153,27 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
                 });
 
             // Otherwise, no such identifier can exist
+            return null;
+
+        };
+
+        /**
+         * Returns the relative URL of the client page that connects to the
+         * connection or connection group represented by this GroupListItem.
+         *
+         * @returns {String}
+         *     The relative URL of the client page that connects to the
+         *     connection or connection group represented by this GroupListItem,
+         *     or null if this GroupListItem cannot be connected to.
+         */
+        this.getClientURL = template.getClientURL || function getClientURL() {
+
+            // There is a client page for this item only if it has an
+            // associated client identifier
+            var identifier = this.getClientIdentifier();
+            if (identifier)
+                return '#/client/' + encodeURIComponent(identifier);
+
             return null;
 
         };

--- a/guacamole/src/main/webapp/app/home/styles/home.css
+++ b/guacamole/src/main/webapp/app/home/styles/home.css
@@ -51,11 +51,11 @@ div.recent-connections div.connection {
     overflow: hidden;
 }
 
-a.home-connection {
+a.home-connection, .empty.balancer a.home-connection-group {
     display: block;
 }
 
-/* Show only expand/collapse icon for connection groups on home screen */
+/* Show only expand/collapse icon for connection groups on home screen ... */
 
 .all-connections .connection-group > .caption .icon {
     display: none;
@@ -63,4 +63,15 @@ a.home-connection {
 
 .all-connections .connection-group > .caption .icon.expand {
     display: inline-block;
+}
+
+/* ... except for empty balancing groups, which should be rendered as if they
+ * are connections. */
+
+.all-connections .connection-group.empty.balancer > .caption .icon {
+    display: inline-block;
+}
+
+.all-connections .connection-group.empty.balancer > .caption .icon.expand {
+    display: none;
 }

--- a/guacamole/src/main/webapp/app/home/styles/home.css
+++ b/guacamole/src/main/webapp/app/home/styles/home.css
@@ -54,3 +54,13 @@ div.recent-connections div.connection {
 a.home-connection {
     display: block;
 }
+
+/* Show only expand/collapse icon for connection groups on home screen */
+
+.all-connections .connection-group > .caption .icon {
+    display: none;
+}
+
+.all-connections .connection-group > .caption .icon.expand {
+    display: inline-block;
+}

--- a/guacamole/src/main/webapp/app/home/templates/connection.html
+++ b/guacamole/src/main/webapp/app/home/templates/connection.html
@@ -1,5 +1,5 @@
 <a class="home-connection"
-   ng-href="#/client/{{ item.getClientIdentifier() }}"
+   ng-href="{{ item.getClientURL() }}"
    ng-class="{active: item.getActiveConnections()}">
 
     <!-- Connection icon -->

--- a/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
+++ b/guacamole/src/main/webapp/app/home/templates/connectionGroup.html
@@ -1,4 +1,10 @@
-<span class="home-connection-group name">
-    <a ng-show="item.balancing" ng-href="#/client/{{ item.getClientIdentifier() }}">{{item.name}}</a>
-    <span ng-show="!item.balancing">{{item.name}}</span>
-</span>
+<a class="home-connection-group"
+   ng-href="{{ item.getClientURL() }}">
+
+    <!-- Connection group icon -->
+    <div ng-show="item.balancing" class="icon type balancer"></div>
+
+    <!-- Connection group name -->
+    <span class="name">{{item.name}}</span>
+
+</a>


### PR DESCRIPTION
Historically, Guacamole has displayed empty balancing groups identically to connections, keeping the balancing nature opaque to users that cannot see the content of the group. This behavior was accidentally removed in 0.9.10-incubating.

This change restores proper rendering of balancing groups by:

* Aligning the HTML structure of connection groups on the home screen with that of connections (see https://github.com/apache/guacamole-client/blob/7db03ba9cb9f4efb6ade04bbaaf913769c4fe219/guacamole/src/main/webapp/app/home/templates/connection.html).
* Adding a connection-style icon for connection groups, which is displayed instead of the expand/collapse icon if a connection group is both balancing and empty.