### PR TITLE
GUACAMOLE-820: Match IP address filters against IP addresses anywhere in object properties.

### DIFF
--- a/guacamole/src/main/webapp/app/list/types/FilterPattern.js
+++ b/guacamole/src/main/webapp/app/list/types/FilterPattern.js
@@ -124,10 +124,14 @@ angular.module('list').factory('FilterPattern', ['$injector',
             // For each defined getter
             for (var i=0; i < getters.length; i++) {
 
-                // Test value against IPv4 network
-                var value = IPv4Network.parse(String(getters[i](object)));
-                if (value && network.contains(value))
-                    return true;
+                // Test each possible IPv4 address within the string against
+                // the given IPv4 network
+                var addresses = String(getters[i](object)).split(/[^0-9.]+/);
+                for (var j=0; j < addresses.length; j++) {
+                    var value = IPv4Network.parse(addresses[j]);
+                    if (value && network.contains(value))
+                        return true;
+                }
 
             }
 
@@ -154,10 +158,14 @@ angular.module('list').factory('FilterPattern', ['$injector',
             // For each defined getter
             for (var i=0; i < getters.length; i++) {
 
-                // Test value against IPv6 network
-                var value = IPv6Network.parse(String(getters[i](object)));
-                if (value && network.contains(value))
-                    return true;
+                // Test each possible IPv6 address within the string against
+                // the given IPv6 network
+                var addresses = String(getters[i](object)).split(/[^0-9A-Fa-f:]+/);
+                for (var j=0; j < addresses.length; j++) {
+                    var value = IPv6Network.parse(addresses[j]);
+                    if (value && network.contains(value))
+                        return true;
+                }
 
             }
 


### PR DESCRIPTION
As noted in [GUACAMOLE-820](https://issues.apache.org/jira/browse/GUACAMOLE-820), Guacamole's current search implementation performs strict matching when searching for IP addresses and subnets. This works well when a property contains _only_ an IP address (like `127.0.0.1`), but fails when matching a property that contains additional text (like `TEST - 127.0.0.1`).

This change modifies the IPv4 and IPv6 network matching mechanism such that any address-like substring is considered, rather than only the entire string. A string like `TEST - 127.0.0.1` will thus match a search for `127.0.0.1`, `127.0.0.0/8`, etc.