### PR TITLE
GUACAMOLE-103: Transform username only if present.

### DIFF
--- a/extensions/guacamole-auth-saml/src/main/java/org/apache/guacamole/auth/saml/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-saml/src/main/java/org/apache/guacamole/auth/saml/AuthenticationProviderService.java
@@ -131,9 +131,12 @@ public class AuthenticationProviderService {
                     samlResponse.validateTimestamps();
 
                     // Grab the username, and, if present, finish authentication.
-                    String username = samlResponse.getNameId().toLowerCase();
+                    String username = samlResponse.getNameId();
                     if (username != null) {
-                        
+
+                        // Canonicalize username as lowercase
+                        username = username.toLowerCase();
+
                         // Retrieve any provided attributes
                         Map<String, List<String>> attributes =
                                 samlResponse.getAttributes();


### PR DESCRIPTION
The SAML authentication implementation currently contains an incorrect `null` check:

```java
// Grab the username, and, if present, finish authentication.
String username = samlResponse.getNameId().toLowerCase();
if (username != null) {
   ...
}
```

The intent is clearly to only move forward with using the Name ID as the username if it's present in the response, but that check would need to be performed on the result of `getNameId()` prior to invoking `toLowerCase()`. As-is, the lack of username in the SAML response will produce a `NullPointerException`.