### PR TITLE
GUACAMOLE-823: Update item structure of Guacamole menu connection browser to match home screen.

### DIFF
--- a/guacamole/src/main/webapp/app/client/templates/connection.html
+++ b/guacamole/src/main/webapp/app/client/templates/connection.html
@@ -1,4 +1,4 @@
-<a class="connection" ng-href="#/client/{{ item.getClientIdentifier() }}">
+<a class="connection" ng-href="{{ item.getClientURL() }}">
     <div class="icon type" ng-class="item.protocol"></div>
     <span class="name">{{item.name}}</span>
 </a>

--- a/guacamole/src/main/webapp/app/client/templates/connectionGroup.html
+++ b/guacamole/src/main/webapp/app/client/templates/connectionGroup.html
@@ -1,4 +1,4 @@
-<span class="connection-group name">
-    <a ng-show="item.balancing" ng-href="#/client/{{ item.getClientIdentifier() }}">{{item.name}}</a>
-    <span ng-show="!item.balancing">{{item.name}}</span>
-</span>
+<a class="connection-group" ng-href="{{ item.getClientURL() }}">
+    <div ng-show="item.balancing" class="icon type balancer"></div>
+    <span class="name">{{item.name}}</span>
+</a>


### PR DESCRIPTION
This change updates the item structure of the Guacamole menu connection browser to match the home screen, correcting a regression in the rendering of empty connection groups.

See: https://issues.apache.org/jira/browse/GUACAMOLE-823?focusedCommentId=17145793&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17145793