### PR TITLE
GUACAMOLE-1125: Fix substituteKeysPressed handler on guacKeyup events

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -678,8 +678,8 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         // Deal with substitute key presses
         if (substituteKeysPressed[keysym]) {
             event.preventDefault();
-            delete substituteKeysPressed[keysym];
             $scope.$broadcast('guacSyntheticKeyup', substituteKeysPressed[keysym]);
+            delete substituteKeysPressed[keysym];
         }
 
         // Mark key as released


### PR DESCRIPTION
Issue which evidenced starting with guacamole-server version 1.2.0. Send guacSyntheticKeyup (DEL key here) BEFORE deleting it for proper behavior.