### PR TITLE
GUACAMOLE-1126: Set a maximum of 4 auto-reconnect attempts

### DIFF
--- a/guacamole/src/main/webapp/app/client/controllers/clientController.js
+++ b/guacamole/src/main/webapp/app/client/controllers/clientController.js
@@ -44,6 +44,16 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     var requestService         = $injector.get('requestService');
     var tunnelService          = $injector.get('tunnelService');
     var userPageService        = $injector.get('userPageService');
+	
+	/**
+	 * Counter and limiter for maximum auto-reconnect attempts that we should 
+	 * automatically try to establish a connection when CLIENT_AUTO_RECONNECT or 
+	 * TUNNEL_AUTO_RECONNECT error types occur.
+	 *
+	 * @type Number
+	 */
+	var AUTO_RECONNECT_TRY     = 0;
+	var AUTO_RECONNECT_MAXTRY  = 4;
 
     /**
      * The minimum number of pixels a drag gesture must move to result in the
@@ -770,7 +780,13 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             var errorName = (status in CLIENT_ERRORS) ? status.toString(16).toUpperCase() : "DEFAULT";
 
             // Determine whether the reconnect countdown applies
-            var countdown = (status in CLIENT_AUTO_RECONNECT) ? RECONNECT_COUNTDOWN : null;
+            if (status in CLIENT_AUTO_RECONNECT && AUTO_RECONNECT_TRY < AUTO_RECONNECT_MAXTRY ) {
+                var countdown = RECONNECT_COUNTDOWN;
+                AUTO_RECONNECT_TRY++;
+            } else {
+                var countdown = null;
+                AUTO_RECONNECT_TRY = 0;
+            }
 
             // Show error status
             notifyConnectionClosed({
@@ -792,7 +808,13 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             var errorName = (status in TUNNEL_ERRORS) ? status.toString(16).toUpperCase() : "DEFAULT";
 
             // Determine whether the reconnect countdown applies
-            var countdown = (status in TUNNEL_AUTO_RECONNECT) ? RECONNECT_COUNTDOWN : null;
+            if (status in TUNNEL_AUTO_RECONNECT && AUTO_RECONNECT_TRY < AUTO_RECONNECT_MAXTRY ) {
+                var countdown = RECONNECT_COUNTDOWN;
+                AUTO_RECONNECT_TRY++;
+            } else {
+                var countdown = null;
+                AUTO_RECONNECT_TRY = 0;
+            }
 
             // Show error status
             notifyConnectionClosed({
@@ -828,6 +850,8 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
 
             // Hide status notification
             guacNotification.showStatus(false);
+            // Reset auto-reconnect attempts counter
+            AUTO_RECONNECT_TRY = 0;
 
         }
 


### PR DESCRIPTION
This a base and non-user-configurable change to limit maximum automatic reconnection retries when "reconnectable" client/tunnel error occurs.
Further implementations to do are:
1- set default behaviour as original one
2- add user (per connection?) setting to handle this
3- Show relevant message, in countdown ??