### PR TITLE
GUACAMOLE-857:  Add guacamole-auth-header to Docker image

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -159,3 +159,12 @@ if [ -f extensions/guacamole-auth-duo/target/*.tar.gz ]; then
         --strip-components=1                               \
         "*.jar"
 fi
+
+#
+# Copy header auth extension if it was built
+#
+
+if [ -f extensions/guacamole-auth-header/target/guacamole-auth-header*.jar ]; then
+    mkdir -p "$DESTINATION/header"
+    cp extensions/guacamole-auth-header/target/guacamole-auth-header*.jar "$DESTINATION/header"
+fi

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -592,6 +592,18 @@ END
 }
 
 ##
+## Adds properties to guacamole.properties which configure the header
+## authentication provider.
+##
+associate_header() {
+    # Update config file
+    set_optional_property "http-auth-header"         "$HTTP_AUTH_HEADER"
+
+    # Add required .jar files to GUACAMOLE_EXT
+    ln -s /opt/guacamole/header/guacamole-auth-*.jar "$GUACAMOLE_EXT"
+}
+
+##
 ## Starts Guacamole under Tomcat, replacing the current process with the
 ## Tomcat process. As the current process will be replaced, this MUST be the
 ## last function run within the script.
@@ -731,6 +743,11 @@ fi
 # Use Duo if specified.
 if [ -n "$DUO_API_HOSTNAME" ]; then
     associate_duo
+fi
+
+# Use header if specified.
+if [ "$HEADER_ENABLED" = "true" ]; then
+    associate_header
 fi
 
 # Set logback level if specified


### PR DESCRIPTION
Thanks for providing such a useful piece of software!

This pull request adds `guacamole-auth-header` to the `guacamole-client` Docker image.  Please let me know what I need to do to shepherd this pull request through the approval process.

The addition of `guacamole-auth-header` is very useful for folks like me who are running a Dockerized Guacamole instance behind a proxy that authenticates and authorizes with FreeIPA.
