### PR TITLE
GUACAMOLE-1130: Only retrieve LDAP attributes that are strictly necessary

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -126,7 +126,7 @@ public class ConnectionService {
             // and possibly any groups the user is a member of that are
             // referred to in the seeAlso attribute of the guacConfigGroup.
             List<Entry> results = queryService.search(ldapConnection,
-                    configurationBaseDN, connectionSearchFilter, 0);
+                    configurationBaseDN, connectionSearchFilter, 0, null);
 
             // Return a map of all readable connections
             return queryService.asMap(results, (entry) -> {

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
@@ -18,8 +18,8 @@
  */
 
 package org.apache.guacamole.auth.ldap.group;
-
 import com.google.inject.Inject;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -186,7 +186,7 @@ public class UserGroupService {
                 ldapConnection,
                 userDN,
                 confService.getUserSearchFilter(),
-                0);
+                0, null);
             // ... there can surely only be one
             if (userEntries.size() != 1)
                 logger.warn("user DN \"{}\" does not return unique value "
@@ -208,13 +208,21 @@ public class UserGroupService {
             }
         }
 
+        // Gather all attributes relevant for a group
+        ArrayList<String> groupAttributes = new ArrayList<String>();
+        groupAttributes.add(confService.getMemberAttribute());
+        confService.getGroupNameAttributes().forEach(
+                       attribute -> groupAttributes.add(attribute)
+                       );
+
         // Get all groups the user is a member of starting at the groupBaseDN,
         // excluding guacConfigGroups
+
         return queryService.search(
             ldapConnection,
             groupBaseDN,
             getGroupSearchFilter(),
-            Collections.singleton(confService.getMemberAttribute()),
+            groupAttributes,
             userIDorDN
         );
 


### PR DESCRIPTION
This aims to reduce the amount of attributes handled in code as described in [Jira](https://issues.apache.org/jira/browse/GUACAMOLE-1130)