### PR TITLE
GUACAMOLE-1135: Return StoreUrls in URI format

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
@@ -95,7 +95,7 @@ public class MySQLAuthenticationProviderModule implements Module {
         File trustStore = environment.getMySQLSSLTrustStore();
         if (trustStore != null)
             driverProperties.setProperty("trustCertificateKeyStoreUrl",
-                    trustStore.getAbsolutePath());
+                    trustStore.toURI().toString());
         
         String trustPassword = environment.getMySQLSSLTrustPassword();
         if (trustPassword != null)
@@ -105,7 +105,7 @@ public class MySQLAuthenticationProviderModule implements Module {
         File clientStore = environment.getMySQLSSLClientStore();
         if (clientStore != null)
             driverProperties.setProperty("clientCertificateKeyStoreUrl",
-                    clientStore.getAbsolutePath());
+                    clientStore.toURI().toString());
         
         String clientPassword = environment.getMYSQLSSLClientPassword();
         if (clientPassword != null)


### PR DESCRIPTION
The MySQL driver expects locations for TrustStore and ClientStore to be in URI format (file:/path/to/store) - this pushes the URI format into the driverProperties, instead of getAbsolutePath(), which returns without the file:/ schema.