### PR TITLE
GUACAMOLE-890: Security: Allow image to run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,15 @@ WORKDIR /opt/guacamole
 # Copy artifacts from builder image into this image
 COPY --from=builder /opt/guacamole/ .
 
+# Create a new user guacamole
+ARG UID=1001
+ARG GID=1001
+RUN groupadd --gid $GID guacamole
+RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --gid $GID guacamole
+
+# Run with user guacamole
+USER guacamole
+
 # Start Guacamole under Tomcat, listening on 0.0.0.0:8080
 EXPOSE 8080
 CMD ["/opt/guacamole/bin/start.sh" ]

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -659,9 +659,15 @@ associate_header() {
 ##
 start_guacamole() {
 
+    # User-only writable CATALINA_BASE
+    export CATALINA_BASE=$HOME/tomcat
+    for dir in logs temp webapps work; do
+        mkdir -p $CATALINA_BASE/$dir
+    done
+    cp -R /usr/local/tomcat/conf $CATALINA_BASE
+
     # Install webapp
-    rm -Rf /usr/local/tomcat/webapps/${WEBAPP_CONTEXT:-guacamole}
-    ln -sf /opt/guacamole/guacamole.war /usr/local/tomcat/webapps/${WEBAPP_CONTEXT:-guacamole}.war
+    ln -sf /opt/guacamole/guacamole.war $CATALINA_BASE/webapps/${WEBAPP_CONTEXT:-guacamole}.war
 
     # Start tomcat
     cd /usr/local/tomcat


### PR DESCRIPTION
Hi,

This is a rework of #469, and solves https://issues.apache.org/jira/browse/GUACAMOLE-890, allowing Guacamole Docker image to run as non-root user.

Below is why, for now, Guacamole image can't be run as non-root user, and how we solve this.

So first, now, thanks to #553, Docker image is now based on `tomcat:8.5-jdk8`.

Here's below the directory structure from the last `tomcat:8.5-jdk8`  image :

```
# ls -l /usr/local/tomcat/
total 152
-rw-r--r-- 1 root root 19318 Jun 30 21:53 BUILDING.txt
-rw-r--r-- 1 root root  5408 Jun 30 21:53 CONTRIBUTING.md
-rw-r--r-- 1 root root 57011 Jun 30 21:53 LICENSE
-rw-r--r-- 1 root root  1726 Jun 30 21:53 NOTICE
-rw-r--r-- 1 root root  3255 Jun 30 21:53 README.md
-rw-r--r-- 1 root root  7136 Jun 30 21:53 RELEASE-NOTES
-rw-r--r-- 1 root root 16262 Jun 30 21:53 RUNNING.txt
drwxr-xr-x 2 root root  4096 Jul 17 00:48 bin
drwxr-xr-x 1 root root  4096 Jul 20 19:45 conf
drwxr-xr-x 2 root root  4096 Jul 17 00:48 lib
drwxrwxrwx 1 root root  4096 Jul 20 19:45 logs
drwxr-xr-x 2 root root  4096 Jul 17 00:48 native-jni-lib
drwxrwxrwx 2 root root  4096 Jul 17 00:48 temp
drwxr-xr-x 2 root root  4096 Jul 17 00:48 webapps
drwxr-xr-x 7 root root  4096 Jun 30 21:50 webapps.dist
drwxrwxrwx 2 root root  4096 Jun 30 21:49 work
```

As we can see, `logs`, `temp` and `work` directories of the default `CATALINA_BASE` have been made world-writable.
But still, the `webapps` directory is not world-writable, so a non-root user won't be able to link `guacamole.war` into it.
So the Guacamole `start.sh` script will fail here below, and this is why it can't run as non-root user :
https://github.com/apache/guacamole-client/blob/21ec5640a560f95725c081391d9943d5d0beb88d/guacamole-docker/bin/start.sh#L634-L636

We could then ask the Tomcat image maintainers to `chmod 777 webapps`.
But the goal of running as non-root user should not be achieved removing restrictions.
In other words, from a security point of view, the method used by the image maintainers does not seem to be the good one.

To confirm this, here's now the default directory structure from a Debian 10 Tomcat installation :
```
# ls -l /var/lib/tomcat9/
lrwxrwxrwx 1 root   root     12 Jun 13  2019 conf -> /etc/tomcat9
drwxr-xr-x 2 tomcat tomcat 4096 Jun 13  2019 lib
lrwxrwxrwx 1 root   root     17 Jun 13  2019 logs -> ../../log/tomcat9
drwxr-xr-x 2 root   root   4096 Mar 27 22:51 policy
drwxrwxr-x 3 tomcat tomcat 4096 Mar 27 22:51 webapps
lrwxrwxrwx 1 root   root     19 Jun 13  2019 work -> ../../cache/tomcat9
# ls -ld /var/log/tomcat9/ /var/cache/tomcat9/
drwxr-x--- 3 tomcat tomcat 4096 Mar 27 22:51 /var/cache/tomcat9/
drwxr-s--- 2 tomcat adm    4096 Mar 27 22:51 /var/log/tomcat9/
```

As we can see here, `logs`, `work` and `webapps` directories are only writable by the `tomcat` user.
It then does not make sense to make them world-writable so that another user can start its application...
Would be a rather messy configuration...

On the contrary, as explained in the [Tomcat documentation](http://tomcat.apache.org/tomcat-8.5-doc/introduction.html#CATALINA_HOME_and_CATALINA_BASE), we should, in this case, create and use a dedicated proper `CATALINA_BASE` directory structure.
There's indeed no reason why we should absolutely run the Guacamole application from the default runtime directories owned by `root`...

This is then what this PR does.
It creates the 5 runtime directories which are then readable / writable only by the user running the application. Links the application into it, and starts from it...
Thus enforcing directory structure and whole application security.

Thank you 👍