### PR TITLE
GUACAMOLE-1150: Fix for correctly checking connection group permissions.

### DIFF
--- a/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
+++ b/guacamole/src/main/webapp/app/manage/controllers/manageConnectionGroupController.js
@@ -242,7 +242,7 @@ angular.module('manage').controller('manageConnectionGroupController', ['$scope'
         $scope.managementPermissions = ManagementPermissions.fromPermissionSet(
                     values.permissions,
                     PermissionSet.SystemPermissionType.CREATE_CONNECTION,
-                    PermissionSet.hasConnectionPermission,
+                    PermissionSet.hasConnectionGroupPermission,
                     identifier);
 
     }, requestService.DIE);


### PR DESCRIPTION
Fix to pass in the right function to check for connection group permissions. Was originally checking against connection permissions.