### PR TITLE
GUACAMOLE-1152: Correct handling of client vs. server exceptions.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/AuthenticationProviderFacade.java
@@ -21,12 +21,12 @@ package org.apache.guacamole.extension;
 
 import java.util.Set;
 import java.util.UUID;
+import org.apache.guacamole.GuacamoleClientException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
 import org.apache.guacamole.net.auth.UserContext;
-import org.apache.guacamole.net.auth.credentials.GuacamoleCredentialsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -190,41 +190,15 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
             return authProvider.authenticateUser(credentials);
         }
 
-        // Pass through credential exceptions untouched, as these are not
-        // internal failures
-        catch (GuacamoleCredentialsException e) {
+        // Pass through client exceptions untouched, including credential
+        // exceptions, as these are not internal failures
+        catch (GuacamoleClientException e) {
             throw e;
         }
 
         // Pass through all other exceptions (aborting authentication entirely)
         // only if not configured to ignore such failures
-        catch (GuacamoleException e) {
-
-            // Skip using this authentication provider if configured to ignore
-            // internal failures during auth
-            if (isFailureTolerated()) {
-                warnAuthProviderSkipped(e);
-                return null;
-            }
-
-            warnAuthAborted();
-            throw e;
-
-        }
-        catch (RuntimeException e) {
-
-            // Skip using this authentication provider if configured to ignore
-            // internal failures during auth
-            if (isFailureTolerated()) {
-                warnAuthProviderSkipped(e);
-                return null;
-            }
-
-            warnAuthAborted();
-            throw e;
-
-        }
-        catch (Error e) {
+        catch (GuacamoleException | RuntimeException | Error e) {
 
             // Skip using this authentication provider if configured to ignore
             // internal failures during auth
@@ -274,41 +248,15 @@ public class AuthenticationProviderFacade implements AuthenticationProvider {
             return authProvider.getUserContext(authenticatedUser);
         }
 
-        // Pass through credential exceptions untouched, as these are not
-        // internal failures
-        catch (GuacamoleCredentialsException e) {
+        // Pass through client exceptions untouched, including credential
+        // exceptions, as these are not internal failures
+        catch (GuacamoleClientException e) {
             throw e;
         }
 
         // Pass through all other exceptions (aborting authentication entirely)
         // only if not configured to ignore such failures
-        catch (GuacamoleException e) {
-
-            // Skip using this authentication provider if configured to ignore
-            // internal failures during auth
-            if (isFailureTolerated()) {
-                warnAuthProviderSkipped(e);
-                return null;
-            }
-
-            warnAuthAborted();
-            throw e;
-
-        }
-        catch (RuntimeException e) {
-
-            // Skip using this authentication provider if configured to ignore
-            // internal failures during auth
-            if (isFailureTolerated()) {
-                warnAuthProviderSkipped(e);
-                return null;
-            }
-
-            warnAuthAborted();
-            throw e;
-
-        }
-        catch (Error e) {
+        catch (GuacamoleException | RuntimeException | Error e) {
 
             // Skip using this authentication provider if configured to ignore
             // internal failures during auth

--- a/guacamole/src/main/webapp/app/login/directives/login.js
+++ b/guacamole/src/main/webapp/app/login/directives/login.js
@@ -72,6 +72,23 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
         var requestService        = $injector.get('requestService');
 
         /**
+         * The initial value for all login fields. Note that this value must
+         * not be null. If null, empty fields may not be submitted back to the
+         * server at all, causing the request to misrepresent true login state.
+         *
+         * For example, if a user receives an insufficient credentials error
+         * due to their password expiring, failing to provide that new password
+         * should result in the user submitting their username, original
+         * password, and empty new password. If only the username and original
+         * password are sent, the invalid password reset request will be
+         * indistinguishable from a normal login attempt.
+         *
+         * @constant
+         * @type String
+         */
+        var DEFAULT_FIELD_VALUE = '';
+
+        /**
          * A description of the error that occurred during login, if any.
          *
          * @type TranslatableMessage
@@ -148,7 +165,7 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
             // Set default values for all unset fields
             angular.forEach($scope.remainingFields, function setDefault(field) {
                 if (!$scope.enteredValues[field.name])
-                    $scope.enteredValues[field.name] = '';
+                    $scope.enteredValues[field.name] = DEFAULT_FIELD_VALUE;
             });
 
             $scope.relevantField = getRelevantField();
@@ -195,13 +212,11 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
                     else
                         $scope.loginError = error.translatableMessage;
 
-                    // Clear all remaining fields that are not username fields
+                    // Reset all remaining fields to default values, but
+                    // preserve any usernames
                     angular.forEach($scope.remainingFields, function clearEnteredValueIfPassword(field) {
-
-                        // If field is not username field, delete it.
                         if (field.type !== Field.Type.USERNAME && field.name in $scope.enteredValues)
-                            delete $scope.enteredValues[field.name];
-
+                            $scope.enteredValues[field.name] = DEFAULT_FIELD_VALUE;
                     });
                 }
 


### PR DESCRIPTION
[GUACAMOLE-1152](https://issues.apache.org/jira/browse/GUACAMOLE-1152) notes a regression in error handling behavior specific to the new `skip-if-unavailable` property. It turns out there are actually multiple issues at play:

 * The handling of `skip-if-unavailable` does not distinguish between `GuacamoleClientException` subclasses (which are thrown under normal circumstances to reject requests) and any other errors. This results in log noise suggesting the use of `skip-if-unavailable` when inappropriate, and allows request processing to proceed with other authentication providers when normal intent of `GuacamoleClientException` is to reject the request entirely and abort processing.
* The login directive does not correctly reset field values back to the empty string, instead entirely deleting the field from the set of parameters. This results in a state mismatch between client and server that can cause the login form to behave oddly, removing fields that are still relevant and failing to report errors that would normally be reported.
* Failures in these areas can be difficult to locate due to the lack of universal logging surrounding error handling. There _is_ universal error handling which automatically wraps exceptions to comply with the REST API, but these exceptions are not always logged.

These changes correct the above.