### PR TITLE
GUACAMOLE-1149: Correct regression in TOTP support if user accounts are not automatically created.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -133,7 +133,8 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
             
             // If auto account creation is enabled, add user to DB.
             if (environment.autoCreateAbsentAccounts()) {
-                userService.createObject(new PrivilegedModeledAuthenticatedUser(user.getCurrentUser()), user);
+                ModeledUser createdUser = userService.createObject(new PrivilegedModeledAuthenticatedUser(user.getCurrentUser()), user);
+                user.setModel(createdUser.getModel());
             }
             
         }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -260,7 +260,19 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
             ModeledUser object, UserModel model) throws GuacamoleException {
 
         super.beforeUpdate(user, object, model);
-        
+
+        // Refuse to update if the user is a skeleton and does not actually
+        // exist in the database (this will happen if the user is authenticated
+        // via a non-database authentication provider)
+        if (object.isSkeleton()) {
+            logger.info("Data cannot be stored for user \"{}\" as they do not "
+                    + "have an account within the database. If this is "
+                    + "unexpected, consider allowing automatic creation of "
+                    + "user accounts.", object.getIdentifier());
+            throw new GuacamoleUnsupportedException("User does not exist "
+                    + "within the database and cannot be updated.");
+        }
+
         // Username must not be blank
         if (model.getIdentifier() == null || model.getIdentifier().trim().isEmpty())
             throw new GuacamoleClientException("The username must not be blank.");


### PR DESCRIPTION
Use of TOTP alongside LDAP currently fails unless automatic account creation is enabled. This is because:

* An attempt is made to update the current user within the database even if that user is a skeleton and does not exist. Update attempts should be made only if the user actually exists. Skeleton users should be handled as if they are read-only.
* The IDs related to an automatically-created user are not pulled into the current user's `ModeledUser`, resulting in `isSkeleton()` incorrectly returning `true`. The current user needs to be updated with their new model if they were just created.

These changes correct `beforeUpdate()` within `UserService` such that updates to users are refused if the user does not actually exist, and properly update the model of the current user if they are automatically created.