### PR TITLE
GUACAMOLE-793: validateTicket() returns the CASAuthenticatedUser instance

### DIFF
--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/AuthenticationProviderService.java
@@ -85,13 +85,7 @@ public class AuthenticationProviderService {
             if (ticket != null) {
                 CASAuthenticatedUser authenticatedUser =
                     ticketService.validateTicket(ticket, credentials);
-                String username = credentials.getUsername();
-                if (username != null) {
-                    Map<String, String> tokens = authenticatedUser.getTokens();
-                    Set<String> effectiveGroups = authenticatedUser.getEffectiveUserGroups();
-                    authenticatedUser.init(username, credentials, tokens, effectiveGroups);
-                    return authenticatedUser;
-                }
+                return authenticatedUser;
             }
         }
 

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/CASGuacamoleProperties.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.auth.cas.conf;
 
 import org.apache.guacamole.properties.URIGuacamoleProperty;
+import org.apache.guacamole.properties.StringGuacamoleProperty;
 
 /**
  * Provides properties required for use of the CAS authentication provider.
@@ -68,5 +69,28 @@ public class CASGuacamoleProperties {
         public String getName() { return "cas-clearpass-key"; }
 
     };
+  
+    /**
+     * The attribute used for group membership
+     * example:  memberOf  (case sensitive)
+     */
+    public static final StringGuacamoleProperty CAS_GROUP_ATTRIBUTE =
+            new StringGuacamoleProperty() {
 
+        @Override
+        public String getName() { return "cas-group-attribute"; }
+
+    };
+
+    /**
+     * The name of the attribute used for group membership, such as "memberOf".
+     * This attribute is case sensitive.
+     */
+    public static final StringGuacamoleProperty CAS_GROUP_DN_FORMAT =
+            new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "cas-group-dn-format"; }
+
+    };
 }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/conf/ConfigurationService.java
@@ -85,4 +85,40 @@ public class ConfigurationService {
         return environment.getProperty(CASGuacamoleProperties.CAS_CLEARPASS_KEY);
     }
 
+    /**
+     * Returns the attribute used to determine group memberships
+     * in CAS, or null if not defined.
+     *
+     * @return
+     *     The attribute name used to determine group memberships in CAS,
+     *     null if not defined.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getGroupAttribute() throws GuacamoleException {
+        return environment.getProperty(CASGuacamoleProperties.CAS_GROUP_ATTRIBUTE);
+    }
+
+    /**
+     * Returns the full DN specification used to format group DN's in CAS,
+     * or null if not defined.
+     * If CAS is backed by LDAP, it will return an LDAP DN, such as
+     * CN=foo,OU=bar,DC=example,DC=com.  This DN specification may be set to
+     * CN=%s,OU=bar,DC=example,DC=com and given the example above, would result
+     * in a group called "foo".  CAS backed by something other than LDAP would
+     * likely not need this.
+     *
+     * @return
+     *     The DN format specification.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getGroupDnFormat() throws GuacamoleException {
+        return environment.getProperty(CASGuacamoleProperties.CAS_GROUP_DN_FORMAT);
+    }
+
+
+
 }

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
@@ -157,10 +157,11 @@ public class TicketValidationService {
                         CAS_ATTRIBUTE_TOKEN_PREFIX);
                 Object value = attr.getValue();
                 if (value != null) {
-                    tokens.put(tokenName, value.toString());
+                    String attrValue = value.toString();
+                    tokens.put(tokenName, attrValue);
                     if (attr.getKey().equals(groupAttribute)) {
-                        String valueWithoutBrackets = value.toString().substring(1,value.toString().length()-1);
-                        Matcher matcher = pattern.matcher(valueWithoutBrackets);
+                        Matcher matcher =
+                            pattern.matcher(attrValue.substring(1,attrValue.length()-1));
                         while (matcher.find()) {
                             effectiveGroups.add(matcher.group(1));
                         }
@@ -169,6 +170,7 @@ public class TicketValidationService {
             }
 
             CASAuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
+            authenticatedUser.init(username, credentials, tokens, effectiveGroups);
             return authenticatedUser;
         } 
         catch (TicketValidationException e) {

--- a/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/user/CASAuthenticatedUser.java
+++ b/extensions/guacamole-auth-cas/src/main/java/org/apache/guacamole/auth/cas/user/CASAuthenticatedUser.java
@@ -22,6 +22,7 @@ package org.apache.guacamole.auth.cas.user;
 import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
@@ -51,6 +52,11 @@ public class CASAuthenticatedUser extends AbstractAuthenticatedUser {
     private Map<String, String> tokens;
 
     /**
+     * The unique identifiers of all user groups which this user is a member of.
+     */
+    private Set<String> effectiveGroups;
+
+    /**
      * Initializes this AuthenticatedUser using the given username and
      * credentials, and an empty map of parameter tokens.
      *
@@ -61,7 +67,7 @@ public class CASAuthenticatedUser extends AbstractAuthenticatedUser {
      *     The credentials provided when this user was authenticated.
      */
     public void init(String username, Credentials credentials) {
-        this.init(username, credentials, Collections.emptyMap());
+        this.init(username, credentials, Collections.emptyMap(), Collections.emptySet());
     }
     
     /**
@@ -79,9 +85,10 @@ public class CASAuthenticatedUser extends AbstractAuthenticatedUser {
      *     as tokens when connections are established with this user.
      */
     public void init(String username, Credentials credentials,
-            Map<String, String> tokens) {
+            Map<String, String> tokens, Set<String> effectiveGroups) {
         this.credentials = credentials;
         this.tokens = Collections.unmodifiableMap(tokens);
+        this.effectiveGroups = effectiveGroups;
         setIdentifier(username.toLowerCase());
     }
 
@@ -105,6 +112,11 @@ public class CASAuthenticatedUser extends AbstractAuthenticatedUser {
     @Override
     public Credentials getCredentials() {
         return credentials;
+    }
+
+    @Override
+    public Set<String> getEffectiveUserGroups() {
+        return effectiveGroups;
     }
 
 }


### PR DESCRIPTION
This is a revision of the pull request by @siacali at https://github.com/apache/guacamole-client/pull/454 which provides a functioning solution to this PR. The revised approach is to modify validateTicket() to return the CASAuthenticatedUser instance rather than just a token so CAS Provider can return Group - like LDAP Provider. This alleviates the need for a new class which was the objection to the previous pull request.

This is my first pull request to this project so please feel free to help me comply with your standards. I've tried to incorporate changes that address all of the comments in the previous pull request but may still need to address other issues I may have overlooked. Thanks for any feedback.