### PR TITLE
GUACAMOLE-1146: Take configured "totp-period" into account when generating tokens.

### DIFF
--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/UserVerificationService.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/UserVerificationService.java
@@ -271,7 +271,8 @@ public class UserVerificationService {
 
             // Get generator based on user's key and provided configuration
             TOTPGenerator totp = new TOTPGenerator(key.getSecret(),
-                    confService.getMode(), confService.getDigits());
+                    confService.getMode(), confService.getDigits(),
+                    TOTPGenerator.DEFAULT_START_TIME, confService.getPeriod());
 
             // Verify provided TOTP against value produced by generator
             if ((code.equals(totp.generate()) || code.equals(totp.previous()))


### PR DESCRIPTION
As described in [GUACAMOLE-1146](https://issues.apache.org/jira/browse/GUACAMOLE-1146), the `totp-period` property is not currently used when generating tokens. Tokens are always generated at the default 30-second interval, with `totp-period` only affecting invalidation of tokens. This is a bug - the configured interval should affect *both* generation and invalidation.

This change properly initializes the TOTP token generator with the configured period such that tokens are generated at the desired interval.