### PR TITLE
GUACAMOLE-1081: Switch token modifiers to upper-case for consistency.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/token/TokenFilter.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/token/TokenFilter.java
@@ -222,12 +222,12 @@ public class TokenFilter {
                     if (modifier != null && !modifier.isEmpty()) {
                         switch (modifier) {
                             // Switch token to upper-case
-                            case "upper":
+                            case "UPPER":
                                 output.append(tokenValue.toUpperCase());
                                 break;
                                 
                             // Switch token to lower case
-                            case "lower":
+                            case "LOWER":
                                 output.append(tokenValue.toLowerCase());
                                 break;
                                 


### PR DESCRIPTION
Minor tweak to the token modifier functionality such that the modifiers are "UPPER" and "LOWER" for consistency with the case of the tokens themselves.