### PR TITLE
GUACAMOLE-221: Add support for parameter prompting via "required".

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -713,6 +713,18 @@ Guacamole.Client = function(tunnel) {
      * @param {String} name The name of the pipe.
      */
     this.onpipe = null;
+    
+    /**
+     * Fired when a "required" instruction is received. A required instruction
+     * indicates that additional parameters are required for the connection to
+     * continue, such as user credentials.
+     * 
+     * @event
+     * @param {String[]} parameters
+     *      The names of the connection parameters that are required to be
+     *      provided for the connection to continue.
+     */
+    this.onrequired = null;
 
     /**
      * Fired whenever a sync instruction is received from the server, indicating
@@ -1336,6 +1348,10 @@ Guacamole.Client = function(tunnel) {
 
             display.rect(layer, x, y, w, h);
 
+        },
+                
+        "required": function required(parameters) {
+            if (guac_client.onrequired) guac_client.onrequired(parameters);
         },
         
         "reset": function(parameters) {

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
@@ -40,7 +40,16 @@ public enum GuacamoleProtocolCapability {
      * {@link GuacamoleProtocolVersion#VERSION_1_1_0}.
      */
     PROTOCOL_VERSION_DETECTION(GuacamoleProtocolVersion.VERSION_1_1_0),
-    
+
+    /**
+     * Support for the "required" instruction. The "required" instruction
+     * allows the server to explicitly request connection parameters from the
+     * client without which the connection cannot continue, such as user
+     * credentials. Support for this instruction was introduced in
+     * {@link GuacamoleProtocolVersion#VERSION_1_3_0}.
+     */
+    REQUIRED_INSTRUCTION(GuacamoleProtocolVersion.VERSION_1_3_0),
+
     /**
      * Support for the "timezone" handshake instruction. The "timezone"
      * instruction allows the client to request that the server forward their

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
@@ -47,10 +47,17 @@ public class GuacamoleProtocolVersion {
     public static final GuacamoleProtocolVersion VERSION_1_1_0 = new GuacamoleProtocolVersion(1, 1, 0);
 
     /**
+     * Protocol version 1.3.0, which introduces the "required" instruction
+     * allowing the server to explicitly request connection parameters from the
+     * client.
+     */
+    public static final GuacamoleProtocolVersion VERSION_1_3_0 = new GuacamoleProtocolVersion(1, 3, 0);
+
+    /**
      * The most recent version of the Guacamole protocol at the time this
      * version of GuacamoleProtocolVersion was built.
      */
-    public static final GuacamoleProtocolVersion LATEST = VERSION_1_1_0;
+    public static final GuacamoleProtocolVersion LATEST = VERSION_1_3_0;
     
     /**
      * A regular expression that matches the VERSION_X_Y_Z pattern, where

--- a/guacamole/src/main/webapp/app/client/styles/notification.css
+++ b/guacamole/src/main/webapp/app/client/styles/notification.css
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.client .notification .parameters h3,
+.client .notification .parameters .password-field .toggle-password {
+    display: none;
+}

--- a/guacamole/src/main/webapp/app/index/controllers/indexController.js
+++ b/guacamole/src/main/webapp/app/index/controllers/indexController.js
@@ -101,8 +101,9 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Broadcast keydown events
     keyboard.onkeydown = function onkeydown(keysym) {
 
-        // Do not handle key events if not logged in
-        if ($scope.expectedCredentials)
+        // Do not handle key events if not logged in or if a notification is
+        // shown
+        if ($scope.expectedCredentials || guacNotification.getStatus())
             return true;
 
         // Warn of pending keydown
@@ -119,8 +120,9 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Broadcast keyup events
     keyboard.onkeyup = function onkeyup(keysym) {
 
-        // Do not handle key events if not logged in
-        if ($scope.expectedCredentials)
+        // Do not handle key events if not logged in or if a notification is
+        // shown
+        if ($scope.expectedCredentials || guacNotification.getStatus())
             return;
 
         // Warn of pending keyup

--- a/guacamole/src/main/webapp/app/notification/styles/notification.css
+++ b/guacamole/src/main/webapp/app/notification/styles/notification.css
@@ -101,3 +101,44 @@
 .notification .progress .text {
     position: relative;
 }
+
+.notification .parameters {
+    width: 100%;
+}
+
+.notification .parameters .fields {
+    display: table;
+    width: 100%;
+}
+
+.notification .parameters .fields .labeled-field {
+    display: table-row;
+}
+
+.notification .parameters .fields .field-header,
+.notification .parameters .fields .form-field {
+    text-align: left;
+    display: table-cell;
+    padding: .125em;
+    vertical-align: top;
+}
+
+.notification .parameters .fields .field-header {
+    padding-right: 1em;
+}
+
+.notification .parameters .fields .field-header {
+    width: 0;
+}
+
+.notification .parameters .fields .form-field {
+    width: 100%;
+}
+
+.notification .parameters input[type=text],
+.notification .parameters input[type=email],
+.notification .parameters input[type=number],
+.notification .parameters input[type=password],
+.notification .parameters textarea {
+    max-width: 100%;
+}

--- a/guacamole/src/main/webapp/app/notification/templates/guacNotification.html
+++ b/guacamole/src/main/webapp/app/notification/templates/guacNotification.html
@@ -1,4 +1,5 @@
-<div class="notification" ng-class="notification.className">
+<form class="notification" ng-class="notification.className"
+      ng-submit="notification.formSubmitCallback()">
 
     <!-- Notification title -->
     <div ng-show="notification.title" class="title-bar">
@@ -11,6 +12,15 @@
         <p ng-show="notification.text" class="text"
            translate="{{notification.text.key}}"
            translate-values="{{notification.text.variables}}"></p>
+
+        <!-- Arbitrary parameters -->
+        <div class="parameters" ng-show="notification.forms">
+            <guac-form
+                namespace="notification.formNamespace"
+                content="notification.forms"
+                model="notification.formModel"
+                model-only="true"></guac-form>
+        </div>
 
         <!-- Current progress -->
         <div class="progress" ng-show="notification.progress"><div class="bar" ng-show="progressPercent" ng-style="{'width': progressPercent + '%'}"></div><div

--- a/guacamole/src/main/webapp/app/notification/types/Notification.js
+++ b/guacamole/src/main/webapp/app/notification/types/Notification.js
@@ -58,6 +58,41 @@ angular.module('notification').factory('Notification', [function defineNotificat
         this.text = template.text;
 
         /**
+         * The translation namespace of the translation strings that will
+         * be generated for all fields within the notification. This namespace
+         * is absolutely required if form fields will be included in the
+         * notification.
+         *
+         * @type String
+         */
+        this.formNamespace = template.formNamespace;
+
+        /**
+         * Optional form content to display. This may be a form, an array of
+         * forms, or a simple array of fields.
+         *
+         * @type Form[]|Form|Field[]|Field
+         */
+        this.forms = template.forms;
+
+        /**
+         * The object which will receive all field values. Each field value
+         * will be assigned to the property of this object having the same
+         * name.
+         *
+         * @type Object.<String, String>
+         */
+        this.formModel = template.model;
+
+        /**
+         * The function to invoke when the form is submitted, if form fields
+         * are present within the notification.
+         *
+         * @type Function
+         */
+        this.formSubmitCallback = template.formSubmitCallback;
+
+        /**
          * An array of all actions available to the user in response to this
          * notification.
          *

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -54,7 +54,9 @@
     "CLIENT" : {
 
         "ACTION_ACKNOWLEDGE"               : "@:APP.ACTION_ACKNOWLEDGE",
+        "ACTION_CANCEL"                    : "@:APP.ACTION_CANCEL",
         "ACTION_CLEAR_COMPLETED_TRANSFERS" : "Clear",
+        "ACTION_CONTINUE"                  : "@:APP.ACTION_CONTINUE",
         "ACTION_DISCONNECT"                : "Disconnect",
         "ACTION_LOGOUT"                    : "@:APP.ACTION_LOGOUT",
         "ACTION_NAVIGATE_BACK"             : "@:APP.ACTION_NAVIGATE_BACK",


### PR DESCRIPTION
This is a re-work of the re-work of the client-side parameter prompting changes proposed with #430. It is the result of building off that absolutely massive effort, re-testing the behavior of those changes, and reworking them with the following changes in approach:

* Prompts are implemented via enhancements to the existing `guacNotification` service, rather than creating a new `guacPrompt` service.
* The UI handling of `required` is separated from the `ManagedClient` handling of `required`, such that interface state is maintained if the user navigates away and back, or switches back and forth between connections.