### PR TITLE
GUACAMOLE-680: Implement a guaranteed logout handler hook

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Event.js
+++ b/guacamole-common-js/src/main/webapp/modules/Event.js
@@ -151,7 +151,7 @@ Guacamole.Event.Target = function Target() {
 
     /**
      * All listeners (callback functions) registered for each event type passed
-     * to {@link Guacamole.Event.Targer#on on()}.
+     * to {@link Guacamole.Event.Target#on on()}.
      *
      * @private
      * @type {Object.<String, Guacamole.Event.Target~listener[]>}

--- a/guacamole/src/main/webapp/app/auth/service/authenticationService.js
+++ b/guacamole/src/main/webapp/app/auth/service/authenticationService.js
@@ -344,7 +344,7 @@ angular.module('auth').factory('authenticationService', ['$injector',
             method: 'DELETE',
             url: 'api/tokens/' + token
         }).then(function() {
-            return logoutEventTarget.dispatch(Guacamole.Event('guacLogout'));
+            return logoutEventTarget.dispatch(new Guacamole.Event('guacLogout'));
         });
 
     };


### PR DESCRIPTION
This is my attempt at a solution for GUACAMOLE-680.  From the discussion in this https://github.com/apache/guacamole-client/pull/346 I wanted to create a utility 'service' that would handle this use case.

I thought about making this generic and adding handlers for other events...but I don't think that is the route that we want to go.  This is a specific use case for the user logout case so it should be handled by the service that handles those actions.  The AngularJS broadcast system should be good enough for other situations.

Example usage in a guacamole extension:
```javascript
angular.module('someModule').run(['authenticationService', 
    function logoutListener(authenticationService) {

    authenticationService.registerLogoutHandler(() => {
       // Do your actions that are needed here.
    })

}]);

// Ensure the someModule module is loaded along with the rest of the app
angular.module('index').requires.push('someModule');
```