### PR TITLE
GUACAMOLE-1218: Add auth-json config & extension to docker

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -184,3 +184,11 @@ if [ -f extensions/guacamole-auth-cas/target/*.tar.gz ]; then
     "*.jar"
 fi
 
+#
+# Copy json auth extension if it was built
+#
+
+if [ -f extensions/guacamole-auth-json/target/guacamole-auth-json*.jar ]; then
+    mkdir -p "$DESTINATION/json"
+    cp extensions/guacamole-auth-json/target/guacamole-auth-json*.jar "$DESTINATION/json"
+fi

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -688,6 +688,19 @@ END
 }
 
 ##
+## Adds properties to guacamole.properties which configure the json
+## authentication provider.
+##
+associate_json() {
+    # Update config file
+    set_property          "json-secret-key"        "$JSON_SECRET_KEY"
+    set_optional_property "json-trusted-networks"  "$JSON_TRUSTED_NETWORKS"
+
+    # Add required .jar files to GUACAMOLE_EXT
+    ln -s /opt/guacamole/json/guacamole-auth-*.jar "$GUACAMOLE_EXT"
+}
+
+##
 ## Starts Guacamole under Tomcat, replacing the current process with the
 ## Tomcat process. As the current process will be replaced, this MUST be the
 ## last function run within the script.
@@ -837,6 +850,11 @@ fi
 # Use CAS if specified.
 if [ -n "$CAS_AUTHORIZATION_ENDPOINT" ]; then
     associate_cas
+fi
+
+# Use json-auth if specified.
+if [ -n "$JSON_SECRET_KEY" ]; then
+    associate_json
 fi
 
 # Set logback level if specified


### PR DESCRIPTION
The Docker file is currently missing the auth-json extension & configuration. 

This allows us to enable the extension by defining the $JSON_SECRET_KEY environmental variable 