### PR TITLE
GUACAMOLE-1218: Declare availability of JAXB APIs at guacamole-ext level (they are provided by the webapp).

### DIFF
--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -151,6 +151,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- JAXB -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Guacamole Java API -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>


### PR DESCRIPTION
The merge of #576 broke the build due to the addition of the `ByteArrayProperty` class to guacamole-ext. That class depends on JAXB for decoding base64, which is not available out-of-the-box for Java 9 and later.

JAXB is inherently made available within the context of the Guacamole webapp. This change explicitly declares that by listing the JAXB API as a provided dependency of guacamole-ext, thus fixing the build.