### PR TITLE
GUACAMOLE-1252: Allow RADIUS NAS IP to be manually configured.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/RadiusConnectionService.java
@@ -209,7 +209,7 @@ public class RadiusConnectionService {
             AttributeList radAttrs = new AttributeList();
             radAttrs.add(new Attr_UserName(username));
             radAttrs.add(new Attr_ClientIPAddress(InetAddress.getByName(clientAddress)));
-            radAttrs.add(new Attr_NASIPAddress(InetAddress.getLocalHost()));
+            radAttrs.add(new Attr_NASIPAddress(confService.getRadiusNasIp()));
             radAttrs.add(new Attr_NASPortType(Attr_NASPortType.Virtual));
             if (state != null && state.length > 0)
                 radAttrs.add(new Attr_State(state));

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
@@ -21,6 +21,8 @@ package org.apache.guacamole.auth.radius.conf;
 
 import com.google.inject.Inject;
 import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.environment.Environment;
@@ -326,6 +328,39 @@ public class ConfigurationService {
         
         return authProtocol;
         
+    }
+    
+    /**
+     * Returns the InetAddress containing the NAS IP address that should be
+     * used to identify this RADIUS client when communicating with the RADIUS
+     * server. If no explicit configuration of this property is defined
+     * in guacamole.properties, it falls back to attempting to determine the
+     * IP address using Java's built-in mechanisms for querying local addresses.
+     * 
+     * @return
+     *     The InetAddress corresponding to the NAS IP address specified in
+     *     guacamole.properties, or the IP determined by querying the address
+     *     of the server on which Guacamole is running.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed, or if the InetAddress
+     *     for the NAS IP cannot be read or determined from the system.
+     */
+    public InetAddress getRadiusNasIp() throws GuacamoleException {
+        try {
+            String nasIpStr = environment.getProperty(RadiusGuacamoleProperties.RADIUS_NAS_IP);
+            
+            // If property is specified and non-empty, attempt to return converted address.
+            if (!(nasIpStr == null && nasIpStr.isEmpty()))
+                return InetAddress.getByName(nasIpStr);
+            
+            // By default, return the address of the server.
+            return InetAddress.getLocalHost();
+                
+        }
+        catch (UnknownHostException e) {
+            throw new GuacamoleServerException("Unknown host specified for NAS IP.", e);
+        }
     }
 
 }

--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusGuacamoleProperties.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/RadiusGuacamoleProperties.java
@@ -190,6 +190,20 @@ public class RadiusGuacamoleProperties {
         public String getName() { return "radius-eap-ttls-inner-protocol"; }
 
     };
+    
+    /**
+     * Manually configure the NAS IP address that the RADIUS client will pass
+     * to the server when requesting authentication. Normally this is automatically
+     * determined by gathering the IP address of the system on which Guacamole
+     * is running; however, there are certain scenarios (as in running in a
+     * Docker container) where specifying this manually may be useful.
+     */
+    public static final StringGuacamoleProperty RADIUS_NAS_IP = new StringGuacamoleProperty() {
+        
+        @Override
+        public String getName() { return "radius-nas-ip"; }
+        
+    };
 
 
 }


### PR DESCRIPTION
This change creates the `radius-nas-ip` property, allowing administrators to configure that manually. If the property is not set, it falls back to the functionality present today, which uses `InetAddress.getLocalHost()` to attempt to determine the IP address automatically.