### PR TITLE
GUACAMOLE-1284: add OPENID_MAX_TOKEN_VALIDITY to start.sh

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -584,6 +584,7 @@ END
     set_property          "openid-client-id"                 "$OPENID_CLIENT_ID"
     set_property          "openid-redirect-uri"              "$OPENID_REDIRECT_URI"
     set_optional_property "openid-username-claim-type"       "$OPENID_USERNAME_CLAIM_TYPE"
+    set_optional_property "openid-max-token-validity"        "$OPENID_MAX_TOKEN_VALIDITY"
 
     # Add required .jar files to GUACAMOLE_EXT
     # "1-{}" make it sorted as a first provider (only authentication)


### PR DESCRIPTION
Due to the settings of the OIDC provider, I was forced to set openid-max-token-validity to 24 hours. This was not supported by the start.sh script so I was forced to create a build myself. I think it would be justified for this small patch to go into the script though.