### PR TITLE
GUACAMOLE-1204: Correct Docker image build failure due to PhantomJS.

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -60,6 +60,11 @@ mkdir -p "$DESTINATION"
 
 cd "$BUILD_DIR"
 
+# Required for build leveraging PhantomJS for unit testing (without this, the
+# build fails with "libssl_conf.so: cannot open shared object file: No such
+# file or directory")
+export OPENSSL_CONF=/etc/ssl
+
 if [ -z "$BUILD_PROFILE" ]; then
     mvn package
 else


### PR DESCRIPTION
Without `OPENSSL_CONF` explicitly set, the guacamole-common-js portion of the build fails, as PhantomJS (used for the new unit tests) cannot find `libssl_conf.so`:

    139677016997504:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libssl_conf.so): libssl_conf.so: cannot open shared object file: No such file or directory
    139677016997504:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
    139677016997504:error:0E07506E:configuration file routines:MODULE_LOAD_DSO:error loading dso:conf_mod.c:285:module=ssl_conf, path=ssl_conf
    139677016997504:error:0E076071:configuration file routines:MODULE_RUN:unknown module name:conf_mod.c:222:module=ssl_conf
    Feb 12, 2021 5:09:33 AM org.openqa.selenium.os.UnixProcess checkForError
    SEVERE: org.apache.commons.exec.ExecuteException: Process exited with an error: 1 (Exit value: 1)