### PR TITLE
GUACAMOLE-1174: Add definitions and translations for Kubernetes "exec" command parameter.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
@@ -45,6 +45,10 @@
                 {
                     "name" : "container",
                     "type" : "TEXT"
+                },
+                {
+                    "name" : "exec-command",
+                    "type" : "TEXT"
                 }
             ]
         },

--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -394,6 +394,7 @@
         "FIELD_HEADER_CONTAINER"       : "Container name:",
         "FIELD_HEADER_CREATE_RECORDING_PATH"  : "Automatically create recording path:",
         "FIELD_HEADER_CREATE_TYPESCRIPT_PATH" : "Automatically create typescript path:",
+        "FIELD_HEADER_EXEC_COMMAND"    : "Command (exec):",
         "FIELD_HEADER_FONT_NAME"       : "Font name:",
         "FIELD_HEADER_FONT_SIZE"       : "Font size:",
         "FIELD_HEADER_HOSTNAME"        : "Hostname:",


### PR DESCRIPTION
This change adds the definition and translation for the `exec-command` parameter introduced by apache/guacamole-server#301.