### PR TITLE
GUACAMOLE-1298: Declare default request size limit constant as static.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/RequestSizeFilter.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/RequestSizeFilter.java
@@ -55,7 +55,7 @@ public class RequestSizeFilter implements ContainerRequestFilter {
      * The default maximum number of bytes to accept within the entity body of
      * any particular REST request.
      */
-    private final long DEFAULT_MAX_REQUEST_SIZE = 2097152;
+    private static final long DEFAULT_MAX_REQUEST_SIZE = 2097152;
 
     /**
      * The maximum number of bytes to accept within the entity body of any


### PR DESCRIPTION
As flagged by Coverity, the private `DEFAULT_MAX_REQUEST_SIZE` constant was erroneously _not_ declared `static`. As a private integer constant, it really should be `static`. It doesn't make sense for a constant to be an instance variable.