### PR TITLE
GUACAMOLE-1317: Update all Maven plugins to latest.

### DIFF
--- a/doc/guacamole-example/pom.xml
+++ b/doc/guacamole-example/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.3.1</version>
                 <configuration>
                     <overlays>
                         <overlay>
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.12</version>
+                <version>0.13</version>
 
                 <!-- Bind RAT to validate phase -->
                 <executions>

--- a/doc/guacamole-playback-example/pom.xml
+++ b/doc/guacamole-playback-example/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.3.1</version>
                 <configuration>
                     <overlays>
                         <overlay>
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.12</version>
+                <version>0.13</version>
 
                 <configuration>
                     <excludes>

--- a/extensions/guacamole-auth-duo/pom.xml
+++ b/extensions/guacamole-auth-duo/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>com.keithbranton.mojo</groupId>
                 <artifactId>angular-maven-plugin</artifactId>
-                <version>0.3.2</version>
+                <version>0.3.4</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>
@@ -67,9 +67,8 @@
 
             <!-- JS/CSS Minification Plugin -->
             <plugin>
-                <groupId>com.samaxes.maven</groupId>
+                <groupId>com.github.buckelieg</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
-                <version>1.7.5</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/extensions/guacamole-auth-openid/pom.xml
+++ b/extensions/guacamole-auth-openid/pom.xml
@@ -42,9 +42,8 @@
 
             <!-- JS/CSS Minification Plugin -->
             <plugin>
-                <groupId>com.samaxes.maven</groupId>
+                <groupId>com.github.buckelieg</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
-                <version>1.7.5</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/extensions/guacamole-auth-quickconnect/pom.xml
+++ b/extensions/guacamole-auth-quickconnect/pom.xml
@@ -42,9 +42,8 @@
 
             <!-- JS/CSS Minification Plugin -->
             <plugin>
-                <groupId>com.samaxes.maven</groupId>
+                <groupId>com.github.buckelieg</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
-                <version>1.7.5</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/extensions/guacamole-auth-radius/pom.xml
+++ b/extensions/guacamole-auth-radius/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>com.keithbranton.mojo</groupId>
                 <artifactId>angular-maven-plugin</artifactId>
-                <version>0.3.2</version>
+                <version>0.3.4</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>
@@ -63,9 +63,8 @@
 
             <!-- JS/CSS Minification Plugin -->
             <plugin>
-                <groupId>com.samaxes.maven</groupId>
+                <groupId>com.github.buckelieg</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
-                <version>1.7.5</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/extensions/guacamole-auth-totp/pom.xml
+++ b/extensions/guacamole-auth-totp/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>com.keithbranton.mojo</groupId>
                 <artifactId>angular-maven-plugin</artifactId>
-                <version>0.3.2</version>
+                <version>0.3.4</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>
@@ -63,9 +63,8 @@
 
             <!-- JS/CSS Minification Plugin -->
             <plugin>
-                <groupId>com.samaxes.maven</groupId>
+                <groupId>com.github.buckelieg</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
-                <version>1.7.5</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -65,7 +65,6 @@
             <!-- Assemble JS files into single .zip -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
@@ -77,7 +76,7 @@
                         <id>make-zip</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -85,9 +84,8 @@
 
             <!-- JS/CSS Minification Plugin -->
             <plugin>
-                <groupId>com.samaxes.maven</groupId>
+                <groupId>com.github.buckelieg</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
-                <version>1.6.1</version>
                 <executions>
                     <execution>
                         <id>default-minify</id>

--- a/guacamole-common/pom.xml
+++ b/guacamole-common/pom.xml
@@ -60,37 +60,14 @@
     <build>
         <plugins>
 
-            <!-- Attach source jar -->
+            <!-- Attach source and JavaDoc .jars -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
-
-            <!-- Attach JavaDoc jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
-                <configuration>
-                    <detectOfflineLinks>false</detectOfflineLinks>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -60,37 +60,14 @@
     <build>
         <plugins>
 
-            <!-- Attach source jar -->
+            <!-- Attach source and JavaDoc .jars -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
-
-            <!-- Attach JavaDoc jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
-                <configuration>
-                    <detectOfflineLinks>false</detectOfflineLinks>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.3.1</version>
                 <configuration>
 
                     <webResources>
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>com.keithbranton.mojo</groupId>
                 <artifactId>angular-maven-plugin</artifactId>
-                <version>0.3.2</version>
+                <version>0.3.4</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>
@@ -142,9 +142,8 @@
 
             <!-- JS/CSS Minification Plugin -->
             <plugin>
-                <groupId>com.samaxes.maven</groupId>
+                <groupId>com.github.buckelieg</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
-                <version>1.7.5</version>
                 <executions>
                     <execution>
                         <id>default-cli</id>

--- a/pom.xml
+++ b/pom.xml
@@ -164,13 +164,6 @@
                         <fork>true</fork>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <source>8</source>
-                    </configuration>
-                </plugin>
 
                 <!-- Provide "generate-license-files" execution for automatic
                     generation of LICENSE and NOTICE files -->
@@ -197,12 +190,55 @@
                     </executions>
                 </plugin>
 
-                <!-- Explicitly use latest version of Maven surefire plugin
-                    (https://issues.apache.org/jira/browse/SUREFIRE-1588) -->
+                <!-- Use latest version of JavaScript/CSS minification plugin -->
+                <plugin>
+                    <groupId>com.github.buckelieg</groupId>
+                    <artifactId>minify-maven-plugin</artifactId>
+                    <version>2.0.1</version>
+                </plugin>
+
+                <!-- Explicitly use latest versions of core plugins -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M5</version>
+                </plugin>
+
+                <!-- Provide default configurations for attaching JavaDoc and source -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <detectOfflineLinks>false</detectOfflineLinks>
+                        <source>8</source>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.2.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
 
             </plugins>


### PR DESCRIPTION
This change updates the versions of all Maven plugins to the latest, allowing the build to succeed against newer versions of the JDK. Where reasonable, the version declarations for affected plugins were moved to the main parent `pom.xml`.