### PR TITLE
GUACAMOLE-1252: Fix potential null dereference getting NAS IP.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/conf/ConfigurationService.java
@@ -351,7 +351,7 @@ public class ConfigurationService {
             String nasIpStr = environment.getProperty(RadiusGuacamoleProperties.RADIUS_NAS_IP);
             
             // If property is specified and non-empty, attempt to return converted address.
-            if (!(nasIpStr == null && nasIpStr.isEmpty()))
+            if (nasIpStr != null && !nasIpStr.isEmpty())
                 return InetAddress.getByName(nasIpStr);
             
             // By default, return the address of the server.


### PR DESCRIPTION
Quick fix to a potential null de-reference found by Coverity.