### PR TITLE
GUACAMOLE-773: Exclude node_modules directory from source archive.

### DIFF
--- a/src/main/assembly/dist.xml
+++ b/src/main/assembly/dist.xml
@@ -36,6 +36,7 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
                 <exclude>**/*.log</exclude>
+                <exclude>**/node_modules/**</exclude>
                 <exclude>**/${project.build.directory}/**</exclude>
             </excludes>
         </fileSet>


### PR DESCRIPTION
The sizable, auto-generated `node_modules` directory created by NPM during the build needs to be explicitly excluded from the guacamole-client source archive.