### PR TITLE
GUACAMOLE-773: Restore missing static template/layout files.

### DIFF
--- a/guacamole/src/main/frontend/webpack.config.js
+++ b/guacamole/src/main/frontend/webpack.config.js
@@ -117,8 +117,10 @@ module.exports = {
 
         // Copy static files to dist/
         new CopyPlugin([
+            { from: 'app/**/*' },
             { from: 'fonts/**/*' },
             { from: 'images/**/*' },
+            { from: 'layouts/**/*' },
             { from: 'translations/**/*' }
         ], {
             context: 'src/'


### PR DESCRIPTION
The on-screen keyboard layouts and AngularJS templates were previously part of the Java webapp build, but are now part of the NPM/Webpack build. Those files were incorrectly left out of the Webpack config, causing the on-screen keyboard and automatic display resize to fail.

Display of the on-screen keyboard fails without these files as it relies on loading the on-screen keyboard layouts dynamically via HTTP. Handling of automatic display resize fails because this relies on a hidden  `<object>` element containing a blank HTML document, with that document served statically over HTTP.