### PR TITLE
GUACAMOLE-641: Correct regressions in custom pooled datasource behavior.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/DynamicallyAuthenticatedDataSource.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/DynamicallyAuthenticatedDataSource.java
@@ -24,6 +24,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
@@ -71,6 +72,70 @@ public class DynamicallyAuthenticatedDataSource extends PooledDataSource {
 
         });
 
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setPoolPingConnectionsNotUsedFor(
+            @Named("mybatis.pooled.pingConnectionsNotUsedFor") int milliseconds) {
+        super.setPoolPingConnectionsNotUsedFor(milliseconds);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setPoolPingEnabled(@Named("mybatis.pooled.pingEnabled") boolean poolPingEnabled) {
+        super.setPoolPingEnabled(poolPingEnabled);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setPoolPingQuery(@Named("mybatis.pooled.pingQuery") String poolPingQuery) {
+        super.setPoolPingQuery(poolPingQuery);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setPoolTimeToWait(@Named("mybatis.pooled.timeToWait") int poolTimeToWait) {
+        super.setPoolTimeToWait(poolTimeToWait);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setPoolMaximumCheckoutTime(
+            @Named("mybatis.pooled.maximumCheckoutTime") int poolMaximumCheckoutTime) {
+        super.setPoolMaximumCheckoutTime(poolMaximumCheckoutTime);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setPoolMaximumIdleConnections(
+            @Named("mybatis.pooled.maximumIdleConnections") int poolMaximumIdleConnections) {
+        super.setPoolMaximumIdleConnections(poolMaximumIdleConnections);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setPoolMaximumActiveConnections(
+            @Named("mybatis.pooled.maximumActiveConnections") int poolMaximumActiveConnections) {
+        super.setPoolMaximumActiveConnections(poolMaximumActiveConnections);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setDriverProperties(@Named("JDBC.driverProperties") Properties driverProps) {
+        super.setDriverProperties(driverProps);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setDefaultAutoCommit(@Named("JDBC.autoCommit") boolean defaultAutoCommit) {
+        super.setDefaultAutoCommit(defaultAutoCommit);
+    }
+
+    @Override
+    @Inject(optional=true)
+    public void setLoginTimeout(@Named("JDBC.loginTimeout") int loginTimeout) {
+        super.setLoginTimeout(loginTimeout);
     }
 
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/DynamicallyAuthenticatedDataSource.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/DynamicallyAuthenticatedDataSource.java
@@ -28,6 +28,8 @@ import java.util.Properties;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Pooled DataSource implementation which dynamically retrieves the database
@@ -36,6 +38,11 @@ import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
  */
 @Singleton
 public class DynamicallyAuthenticatedDataSource extends PooledDataSource {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(DynamicallyAuthenticatedDataSource.class);
 
     /**
      * Creates a new DynamicallyAuthenticatedDataSource which dynamically
@@ -63,6 +70,7 @@ public class DynamicallyAuthenticatedDataSource extends PooledDataSource {
             @Override
             public Connection getConnection() throws SQLException {
                 try {
+                    logger.debug("Creating new database connection for pool.");
                     return super.getConnection(environment.getUsername(), environment.getPassword());
                 }
                 catch (GuacamoleException e) {

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/DynamicallyAuthenticatedDataSource.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/DynamicallyAuthenticatedDataSource.java
@@ -80,6 +80,13 @@ public class DynamicallyAuthenticatedDataSource extends PooledDataSource {
 
         });
 
+        // Force recalculation of expectedConnectionTypeCode. The
+        // PooledDataSource constructor accepting a single UnpooledDataSource
+        // will otherwise leave this value uninitialized, resulting in all
+        // connections failing to pass sanity checks and never being returned
+        // to the pool.
+        super.forceCloseAll();
+
     }
 
     @Override


### PR DESCRIPTION
The `DynamicallyAuthenticatedDataSource` introduced via [GUACAMOLE-641](https://issues.apache.org/jira/browse/GUACAMOLE-641) does not correctly set driver-specific JDBC properties like `allowMultiQueries`, resulting in failures for queries that depend on those properties. Additionally, the `PooledDataSource` constructor in use does not initialize internal values used by `PooledDataSource` to verify connections being returned to the pool, resulting in an eternally empty pool and new connections being created for each query.

This change corrects the above by:

1. Adding support for the same named injectable values as mybatis-guice's `PooledDataSourceProvider`.
2. Manually invoking `forceCloseAll()` within the constructor, which will initialize the required internals for `PooledDataSource` sanity checks.