### PR TITLE
GUACAMOLE-724: Remove duplicate injection of $rootScope (already injected via parameter).

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -38,7 +38,6 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     // Required services
     const $document               = $injector.get('$document');
     const $q                      = $injector.get('$q');
-    const $rootScope              = $injector.get('$rootScope');
     const $window                 = $injector.get('$window');
     const activeConnectionService = $injector.get('activeConnectionService');
     const authenticationService   = $injector.get('authenticationService');


### PR DESCRIPTION
As of #623, visiting a deployment of the latest `master` fails with the following error in browser devtools:

```
Uncaught Error: Module parse failed: Identifier '$rootScope' has already been declared (41:10)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|     const $document               = $injector.get('$document');
|     const $q                      = $injector.get('$q');
>     const $rootScope              = $injector.get('$rootScope');
|     const $window                 = $injector.get('$window');
|     const activeConnectionService = $injector.get('activeConnectionService');
    <anonymous> http://localhost:8080/guacamole/guacamole.dc07c6323ec1d94a3644.js:306
    g http://localhost:8080/guacamole/guacamole.dc07c6323ec1d94a3644.js:53
    g http://localhost:8080/guacamole/guacamole.dc07c6323ec1d94a3644.js:230
    <anonymous> http://localhost:8080/guacamole/guacamole.dc07c6323ec1d94a3644.js:55
    <anonymous> http://localhost:8080/guacamole/guacamole.dc07c6323ec1d94a3644.js:55
    g http://localhost:8080/guacamole/guacamole.dc07c6323ec1d94a3644.js:53
```

This is because `$rootScope` is being injected both through function parameters and through explicitly invoking `$injector`. Only one declaration and injection of `$rootScope` should be present.