### PR TITLE
GUACAMOLE-1378: Correct naming of guacamole-auth-jdbc dist .tar.gz archive.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/pom.xml
@@ -61,4 +61,12 @@
 
     </dependencies>
 
+    <build>
+
+        <!-- Dist .tar.gz for guacamole-auth-jdbc should be named after the
+            parent guacamole-auth-jdbc project, not after guacamole-auth-jdbc-dist -->
+        <finalName>${project.parent.artifactId}-${project.parent.version}</finalName>
+
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,6 @@
                                 <id>make-dist-archive</id>
                                 <phase>package</phase>
                                 <configuration>
-                                    <finalName>${project.artifactId}-${project.version}</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <tarLongFileMode>posix</tarLongFileMode>
                                     <descriptors>


### PR DESCRIPTION
The distribution .tar.gz of the guacamole-auth-jdbc set of extensions should be called `guacamole-auth-jdbc-VERSION.tar.gz`, not `guacamole-auth-jdbc-dist-VERSION.tar.gz`.