### PR TITLE
GUACAMOLE-1383: Avoid double-encoding client identifiers within URLs.

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -239,7 +239,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             ids.push(id);
 
         // Reconstruct path, updating attached clients via change in route
-        $location.path('/client/' + encodeURIComponent(ManagedClientGroup.getIdentifier(ids)));
+        $location.path('/client/' + ManagedClientGroup.getIdentifier(ids));
 
     };
 


### PR DESCRIPTION
The AngularJS `$location.path()` function unavoidably and automatically URL-encodes all values, so we cannot encode things ahead of time in an attempt to remove special meaning from values. Instead, this change switches over to a URL-safe client identifier format (no `=`, `+`, or `/` characters) while maintaining backward compatibility with the previous format.