### PR TITLE
GUACAMOLE-996: Add support for specifying an LDAP group filter.

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.directory.api.ldap.model.filter.ExprNode;
 import org.apache.directory.api.ldap.model.filter.PresenceNode;
 import org.apache.directory.api.ldap.model.message.AliasDerefMode;
-import org.apache.directory.api.ldap.model.filter.EqualityNode;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
@@ -325,12 +324,12 @@ public class ConfigurationService {
     /**
      * Returns the search filter that should be used when querying the
      * LDAP server for Guacamole groups.  If no filter is specified,
-     * a default of "(objectClass=group)" is returned.
+     * a default of "(objectClass=*)" is used.
      *
      * @return
      *     The search filter that should be used when querying the
      *     LDAP server for groups that are valid in Guacamole, or
-     *     "(objectClass=group)" if not specified.
+     *     "(objectClass=*)" if not specified.
      *
      * @throws GuacamoleException
      *     If guacamole.properties cannot be parsed.
@@ -338,7 +337,7 @@ public class ConfigurationService {
     public ExprNode getGroupSearchFilter() throws GuacamoleException {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_GROUP_SEARCH_FILTER,
-            new EqualityNode("objectClass","group")
+            new PresenceNode("objectClass")
         );
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.directory.api.ldap.model.filter.ExprNode;
 import org.apache.directory.api.ldap.model.filter.PresenceNode;
 import org.apache.directory.api.ldap.model.message.AliasDerefMode;
+import org.apache.directory.api.ldap.model.filter.EqualityNode;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
@@ -318,6 +319,26 @@ public class ConfigurationService {
         return environment.getProperty(
             LDAPGuacamoleProperties.LDAP_USER_SEARCH_FILTER,
             new PresenceNode("objectClass")
+        );
+    }
+
+    /**
+     * Returns the search filter that should be used when querying the
+     * LDAP server for Guacamole groups.  If no filter is specified,
+     * a default of "(objectClass=group)" is returned.
+     *
+     * @return
+     *     The search filter that should be used when querying the
+     *     LDAP server for groups that are valid in Guacamole, or
+     *     "(objectClass=group)" if not specified.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public ExprNode getGroupSearchFilter() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_GROUP_SEARCH_FILTER,
+            new EqualityNode("objectClass","group")
         );
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
@@ -211,6 +211,17 @@ public class LDAPGuacamoleProperties {
     };
 
     /**
+     * A search filter to apply to group LDAP queries.
+     */
+    public static final LdapFilterGuacamoleProperty LDAP_GROUP_SEARCH_FILTER =
+            new LdapFilterGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-group-search-filter"; }
+
+    };
+
+    /**
      * Whether or not we should follow referrals.
      */
     public static final BooleanGuacamoleProperty LDAP_FOLLOW_REFERRALS =

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
@@ -87,9 +87,9 @@ public class UserGroupService {
         if (confService.getConfigurationBaseDN() != null)
             return new NotNode(new EqualityNode("objectClass","guacConfigGroup"));
 
-        // Read any object as a group if LDAP is not being used for connection
-        // storage (guacConfigGroup)
-        return new PresenceNode("objectClass");
+        // Read objects from LDAP with filter defined by "ldap-group-search-filter"
+        // as a group if LDAP is not being used for connection storage (guacConfigGroup)
+        return confService.getGroupSearchFilter();
 
     }
 

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
@@ -28,10 +28,10 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapInvalidAttributeValueException;
+import org.apache.directory.api.ldap.model.filter.AndNode;
 import org.apache.directory.api.ldap.model.filter.EqualityNode;
 import org.apache.directory.api.ldap.model.filter.ExprNode;
 import org.apache.directory.api.ldap.model.filter.NotNode;
-import org.apache.directory.api.ldap.model.filter.PresenceNode;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.apache.guacamole.auth.ldap.conf.ConfigurationService;
@@ -81,16 +81,22 @@ public class UserGroupService {
      */
     private ExprNode getGroupSearchFilter() throws GuacamoleException {
 
+        // Use filter defined by "ldap-group-search-filter" as basis for all
+        // retrieval of user groups
+        ExprNode groupFilter = confService.getGroupSearchFilter();
+
         // Explicitly exclude guacConfigGroup object class only if it should
         // be assumed to be defined (query may fail due to no such object
         // class existing otherwise)
-        if (confService.getConfigurationBaseDN() != null)
-            return new NotNode(new EqualityNode("objectClass","guacConfigGroup"));
+        if (confService.getConfigurationBaseDN() != null) {
+            groupFilter = new AndNode(
+                groupFilter,
+                new NotNode(new EqualityNode<String>("objectClass", "guacConfigGroup"))
+            );
+        }
 
-        // Read objects from LDAP with filter defined by "ldap-group-search-filter"
-        // as a group if LDAP is not being used for connection storage (guacConfigGroup)
-        return confService.getGroupSearchFilter();
-
+        return groupFilter;
+        
     }
 
     /**

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -443,6 +443,7 @@ END
     set_optional_property "ldap-user-search-filter"         "$LDAP_USER_SEARCH_FILTER"
     set_optional_property "ldap-config-base-dn"             "$LDAP_CONFIG_BASE_DN"
     set_optional_property "ldap-group-base-dn"              "$LDAP_GROUP_BASE_DN"
+    set_optional_property "ldap-group-search-filter"        "$LDAP_GROUP_SEARCH_FILTER"
     set_optional_property "ldap-member-attribute-type"      "$LDAP_MEMBER_ATTRIBUTE_TYPE"
     set_optional_property "ldap-group-name-attribute"       "$LDAP_GROUP_NAME_ATTRIBUTE"
     set_optional_property "ldap-dereference-aliases"        "$LDAP_DEREFERENCE_ALIASES"


### PR DESCRIPTION
This change builds off the proposed changes submitted @echu2013 via #497, additionally addressing the feedback on that PR:

* The default value for the new `ldap-group-search-filter` property should produce backward-compatible behavior when not specified (it should default to `(objectClass=*)`).
* The group search filter should always be taken into account when retrieving user groups (it was erroneously ignored if connections were also being stored in LDAP).

I also went ahead and added a corresponding environment variable for the Docker image.