### PR TITLE
GUACAMOLE-1386: Correct definitions of "Meta" and "Super" keys.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -439,7 +439,7 @@ Guacamole.Keyboard = function Keyboard(element) {
         46:  [0xFFFF, 0xFFFF, 0xFFFF, 0xFFAE], // delete      / KP decimal
         91:  [0xFFE7], // left windows/command key (meta_l)
         92:  [0xFFE8], // right window/command key (meta_r)
-        93:  null,     // select key
+        93:  [0xFF67], // menu key
         96:  [0xFFB0], // KP 0
         97:  [0xFFB1], // KP 1
         98:  [0xFFB2], // KP 2

--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -437,8 +437,8 @@ Guacamole.Keyboard = function Keyboard(element) {
         40:  [0xFF54, 0xFF54, 0xFF54, 0xFFB2], // down arrow  / KP 2
         45:  [0xFF63, 0xFF63, 0xFF63, 0xFFB0], // insert      / KP 0
         46:  [0xFFFF, 0xFFFF, 0xFFFF, 0xFFAE], // delete      / KP decimal
-        91:  [0xFFEB], // left window key (hyper_l)
-        92:  [0xFF67], // right window key (menu key?)
+        91:  [0xFFE7], // left windows/command key (meta_l)
+        92:  [0xFFE8], // right window/command key (meta_r)
         93:  null,     // select key
         96:  [0xFFB0], // KP 0
         97:  [0xFFB1], // KP 1
@@ -583,7 +583,7 @@ Guacamole.Keyboard = function Keyboard(element) {
         "UIKeyInputUpArrow": [0xFF52],
         "Up": [0xFF52],
         "Undo": [0xFF65],
-        "Win": [0xFFEB],
+        "Win": [0xFFE7, 0xFFE7, 0xFFE8],
         "Zenkaku": [0xFF28],
         "ZenkakuHankaku": [0xFF2A]
     };
@@ -603,8 +603,8 @@ Guacamole.Keyboard = function Keyboard(element) {
         0xFFE8: true, // Right meta 
         0xFFE9: true, // Left alt
         0xFFEA: true, // Right alt
-        0xFFEB: true, // Left hyper
-        0xFFEC: true  // Right hyper
+        0xFFEB: true, // Left super/hyper
+        0xFFEC: true  // Right super/hyper
     };
 
     /**
@@ -1031,8 +1031,8 @@ Guacamole.Keyboard = function Keyboard(element) {
 
         // Resync state of hyper
         updateModifierState(guac_keyboard.modifiers.hyper, state.hyper, [
-            0xFFEB, // Left hyper
-            0xFFEC  // Right hyper
+            0xFFEB, // Left super/hyper
+            0xFFEC  // Right super/hyper
         ], keyEvent);
 
         // Update state

--- a/guacamole/src/main/frontend/src/layouts/de-de-qwertz.json
+++ b/guacamole/src/main/frontend/src/layouts/de-de-qwertz.json
@@ -78,7 +78,6 @@
 
         "Menu" : [{
             "title"    : "Menu",
-            "modifier" : "super",
             "keysym"   : 65383
         }],
         "LShift" : [{
@@ -116,10 +115,10 @@
             "modifier" : "alt-gr",
             "keysym"   : 65027
         }],
-        "Super" : [{
-            "title"    : "Super",
-            "modifier" : "super",
-            "keysym"   : 65515
+        "Meta" : [{
+            "title"    : "Meta",
+            "modifier" : "meta",
+            "keysym"   : 65511
         }],
 
         "^" : [
@@ -404,7 +403,7 @@
                     [ "Tab", "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "+",   1,  0.6 ],
                     [ "Caps",  "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "#", "Enter" ],
                     [ "LShift", "<", "y", "x", "c", "v",  "b", "n",  "m", ",", ".", "-",  "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",         "Space",          "AltGr", "Menu", "RCtrl" ]
+                    [ "LCtrl", "Meta", "LAlt",          "Space",          "AltGr", "Menu", "RCtrl" ]
 
                 ],
 
@@ -431,7 +430,7 @@
         "RShift" : 2.1,
 
         "LCtrl" : 1.6,
-        "Super" : 1.6,
+        "Meta" : 1.6,
         "LAlt"  : 1.6,
         "Space" : 6.1,
         "AltGr" : 1.6,

--- a/guacamole/src/main/frontend/src/layouts/en-us-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/en-us-qwerty.json
@@ -87,10 +87,10 @@
             "modifier" : "alt",
             "keysym"   : 65514
         }],
-        "Super" : [{
-            "title"    : "Super",
-            "modifier" : "super",
-            "keysym"   : 65515
+        "Meta" : [{
+            "title"    : "Meta",
+            "modifier" : "meta",
+            "keysym"   : 65511
         }],
 
         "`" : [
@@ -353,7 +353,7 @@
                     [ "Tab", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\" ],
                     [ "Caps",  "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "Enter" ],
                     [ "LShift", "z", "x", "c", "v",  "b", "n",  "m", ",", ".", "/",  "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",       "Space",        "RAlt", "Menu", "RCtrl" ]
+                    [ "LCtrl", "Meta", "LAlt",        "Space",        "RAlt", "Menu", "RCtrl" ]
 
                 ],
 
@@ -380,7 +380,7 @@
         "RShift" : 3.1,
 
         "LCtrl" : 1.6,
-        "Super" : 1.6,
+        "Meta" : 1.6,
         "LAlt"  : 1.6,
         "Space" : 6.1,
         "RAlt"  : 1.6,

--- a/guacamole/src/main/frontend/src/layouts/es-es-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/es-es-qwerty.json
@@ -78,7 +78,6 @@
 
         "Menu" : [{
             "title"    : "Menu",
-            "modifier" : "super",
             "keysym"   : 65383
         }],
         "LShift" : [{
@@ -116,10 +115,10 @@
             "modifier" : "alt-gr",
             "keysym"   : 65027
         }],
-        "Super" : [{
-            "title"    : "Super",
-            "modifier" : "super",
-            "keysym"   : 65515
+        "Meta" : [{
+            "title"    : "Meta",
+            "modifier" : "meta",
+            "keysym"   : 65511
         }],
 
         "º" : [
@@ -410,7 +409,7 @@
                     [ "Tab", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "`", "+",   1,  0.6 ],
                     [ "Caps",  "a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "´", "ç", "Enter" ],
                     [ "LShift", "<", "z", "x", "c", "v",  "b", "n",  "m", ",", ".", "-",  "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",         "Space",          "AltGr", "Menu", "RCtrl" ]
+                    [ "LCtrl", "Meta", "LAlt",          "Space",          "AltGr", "Menu", "RCtrl" ]
 
                 ],
 
@@ -437,7 +436,7 @@
         "RShift" : 2.2,
 
         "LCtrl" : 1.6,
-        "Super" : 1.6,
+        "Meta" : 1.6,
         "LAlt"  : 1.6,
         "Space" : 6.4,
         "AltGr" : 1.6,

--- a/guacamole/src/main/frontend/src/layouts/fr-fr-azerty.json
+++ b/guacamole/src/main/frontend/src/layouts/fr-fr-azerty.json
@@ -118,10 +118,10 @@
             "modifier" : "alt-gr",
             "keysym"   : 65027
         }],
-        "Super" : [{
-            "title"    : "Super",
-            "modifier" : "super",
-            "keysym"   : 65515
+        "Meta" : [{
+            "title"    : "Meta",
+            "modifier" : "meta",
+            "keysym"   : 65511
         }],
 
         "²" : [
@@ -400,7 +400,7 @@
                     [ "Tab", "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$", 1, 0.8 ],
                     [ "Caps",  "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "*", "Enter" ],
                     [ "LShift", "<", "w", "x", "c", "v",  "b", "n", ",", ";", ":", "!", "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",       "Space",        "AltGr", "Menu", "RCtrl" ]
+                    [ "LCtrl", "Meta", "LAlt",        "Space",        "AltGr", "Menu", "RCtrl" ]
 
                 ],
 
@@ -427,7 +427,7 @@
         "RShift" : 2.1,
 
         "LCtrl" : 1.6,
-        "Super" : 1.6,
+        "Meta" : 1.6,
         "LAlt"  : 1.6,
         "Space" : 6.1,
         "AltGr" : 1.6,

--- a/guacamole/src/main/frontend/src/layouts/it-it-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/it-it-qwerty.json
@@ -78,7 +78,6 @@
 
         "Menu" : [{
             "title"    : "Menu",
-            "modifier" : "super",
             "keysym"   : 65383
         }],
         "LShift" : [{
@@ -116,10 +115,10 @@
             "modifier" : "alt-gr",
             "keysym"   : 65027
         }],
-        "Super" : [{
-            "title"    : "Super",
-            "modifier" : "super",
-            "keysym"   : 65515
+        "Meta" : [{
+            "title"    : "Meta",
+            "modifier" : "meta",
+            "keysym"   : 65511
         }],
 
         "\\" : [
@@ -407,7 +406,7 @@
                     [ "Tab", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "è", "+",   1,  0.6 ],
                     [ "Caps",  "a", "s", "d", "f", "g", "h", "j", "k", "l", "ò", "à", "ù", "Enter" ],
                     [ "LShift", "<", "z", "x", "c", "v",  "b", "n",  "m", ",", ".", "-",  "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",         "Space",          "AltGr", "Menu", "RCtrl" ]
+                    [ "LCtrl", "Meta", "LAlt",          "Space",          "AltGr", "Menu", "RCtrl" ]
 
                 ],
 
@@ -434,7 +433,7 @@
         "RShift" : 2.2,
 
         "LCtrl" : 1.6,
-        "Super" : 1.6,
+        "Meta" : 1.6,
         "LAlt"  : 1.6,
         "Space" : 6.4,
         "AltGr" : 1.6,

--- a/guacamole/src/main/frontend/src/layouts/nl-nl-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/nl-nl-qwerty.json
@@ -78,7 +78,6 @@
 
         "Menu" : [{
             "title"    : "Menu",
-            "modifier" : "super",
             "keysym"   : 65383
         }],
         "LShift" : [{
@@ -116,10 +115,10 @@
             "modifier" : "alt-gr",
             "keysym"   : 65027
         }],
-        "Super" : [{
-            "title"    : "Super",
-            "modifier" : "super",
-            "keysym"   : 65515
+        "Meta" : [{
+            "title"    : "Meta",
+            "modifier" : "meta",
+            "keysym"   : 65511
         }],
 
         "@" : [
@@ -419,7 +418,7 @@
                     [ "Tab", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "¨", "*",   1,  0.6 ],
                     [ "Caps",  "a", "s", "d", "f", "g", "h", "j", "k", "l", "+", "´", "<", "Enter" ],
                     [ "LShift", "]", "z", "x", "c", "v",  "b", "n",  "m", ",", ".", "-",  "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",         "Space",          "AltGr", "Menu", "RCtrl" ]
+                    [ "LCtrl", "Meta", "LAlt",          "Space",          "AltGr", "Menu", "RCtrl" ]
 
                 ],
 
@@ -446,7 +445,7 @@
         "RShift" : 2.2,
 
         "LCtrl" : 1.6,
-        "Super" : 1.6,
+        "Meta" : 1.6,
         "LAlt"  : 1.6,
         "Space" : 6.4,
         "AltGr" : 1.6,

--- a/guacamole/src/main/frontend/src/layouts/ru-ru-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/ru-ru-qwerty.json
@@ -87,10 +87,10 @@
             "modifier" : "alt",
             "keysym"   : 65514
         }],
-        "Super" : [{
-            "title"    : "Super",
-            "modifier" : "super",
-            "keysym"   : 65515
+        "Meta" : [{
+            "title"    : "Meta",
+            "modifier" : "meta",
+            "keysym"   : 65511
         }],
         "Latin" : [{
             "title"    : "Latin",
@@ -499,7 +499,7 @@
                     [ "Tab", "й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "ъ", "\\" ],
                     [ "Caps",  "ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "Enter" ],
                     [ "LShift", "я", "ч", "с", "м",  "и", "т",  "ь", "б", "ю", "/",  "RShift" ],
-                    [ "LCtrl", "Super", "LAlt",       "Space",        "RAlt", "Menu", "RCtrl" ]
+                    [ "LCtrl", "Meta", "LAlt",        "Space",        "RAlt", "Menu", "RCtrl" ]
 
                 ],
 
@@ -526,7 +526,7 @@
         "RShift" : 3.1,
 
         "LCtrl" : 1.6,
-        "Super" : 1.6,
+        "Meta" : 1.6,
         "LAlt"  : 1.6,
         "Space" : 6.1,
         "RAlt"  : 1.6,


### PR DESCRIPTION
Guacamole's on-screen keyboard and part of its general keyboard handling incorrectly define "Super" as the "Windows" or "Command" key. This is incorrect. The correct key for the "Windows" key (or the Mac "Command" key) is "Meta".