### PR TITLE
GUACAMOLE-1387: Update and filter tiled connections only if group is actually changing.

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -284,6 +284,10 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
      */
     const setAttachedGroup = function setAttachedGroup(managedClientGroup) {
 
+        // Do nothing if group is not actually changing
+        if ($scope.clientGroup === managedClientGroup)
+            return;
+
         if ($scope.clientGroup) {
 
             // Remove all disconnected clients from management (the user has


### PR DESCRIPTION
The set of visible connections is normally updated when switching to a different group, with all failed/disconnected connections removed from the view during the switch (as the user has seen the status). The logic within `setAttachedGroup()` erroneously applies this filter even if the group is not changing, resulting in all disconnected connections being removed from the view when only a change has been made to the group.

This change corrects the logic of `setAttachedGroup()` such that it performs the tasks associated with changing the attached group only if the group is actually different.