### PR TITLE
GUACAMOLE-1391: Add support for hashing passwords with SHA-256 in user-mapping.xml

### DIFF
--- a/guacamole/doc/example/user-mapping.xml
+++ b/guacamole/doc/example/user-mapping.xml
@@ -35,7 +35,7 @@
             encoding="md5">
 
         <!-- First authorized connection -->
-		<connection name="localhost">
+    	<connection name="localhost">
             <protocol>vnc</protocol>
             <param name="hostname">localhost</param>
             <param name="port">5901</param>
@@ -43,13 +43,28 @@
         </connection>
 
         <!-- Second authorized connection -->
-   		<connection name="otherhost">
+		<connection name="otherhost">
             <protocol>vnc</protocol>
             <param name="hostname">otherhost</param>
             <param name="port">5900</param>
             <param name="password">VNCPASS</param>
         </connection>
 
- </authorize>
+     </authorize>
+
+     <!-- Another user, but using SHA-256 to hash the password -->
+     <authorize
+            username="USERNAME3"
+            password="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+            encoding="sha256">
+
+        <connection name="localhost">
+            <protocol>vnc</protocol>
+            <param name="hostname">localhost</param>
+            <param name="port">5900</param>
+            <param name="password">VNCPASS</param>
+        </connection>
+
+    </authorize>
 
 </user-mapping>

--- a/guacamole/doc/example/user-mapping.xml
+++ b/guacamole/doc/example/user-mapping.xml
@@ -18,7 +18,7 @@
     under the License.
 -->
 <user-mapping>
-	
+
     <!-- Per-user authentication and config information -->
     <authorize username="USERNAME" password="PASSWORD">
         <protocol>vnc</protocol>
@@ -35,7 +35,7 @@
             encoding="md5">
 
         <!-- First authorized connection -->
-    	<connection name="localhost">
+        <connection name="localhost">
             <protocol>vnc</protocol>
             <param name="hostname">localhost</param>
             <param name="port">5901</param>
@@ -43,7 +43,7 @@
         </connection>
 
         <!-- Second authorized connection -->
-		<connection name="otherhost">
+        <connection name="otherhost">
             <protocol>vnc</protocol>
             <param name="hostname">otherhost</param>
             <param name="port">5900</param>

--- a/guacamole/src/main/java/org/apache/guacamole/auth/file/Authorization.java
+++ b/guacamole/src/main/java/org/apache/guacamole/auth/file/Authorization.java
@@ -46,7 +46,12 @@ public class Authorization {
         /**
          * Password hashed with MD5.
          */
-        MD5
+        MD5,
+        
+        /**
+         * Passwords hashed with SHA256.
+         */
+        SHA_256
 
     }
 
@@ -205,6 +210,19 @@ public class Authorization {
                         throw new UnsupportedOperationException("Unexpected lack of MD5 support.", e);
                     }
 
+                case SHA_256:
+
+                    try {
+                        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                        String hashedPassword = getHexString(digest.digest(password.getBytes("UTF-8")));
+                        return hashedPassword.equals(this.password.toUpperCase());
+                    }
+                    catch (UnsupportedEncodingException e) {
+                        throw new UnsupportedOperationException("Unexpected lack of UTF-8 support.", e);
+                    }
+                    catch (NoSuchAlgorithmException e) {
+                        throw new UnsupportedOperationException("Unexpected lack of SHA-256 support.", e);
+                    }
             }
 
         } // end validation check

--- a/guacamole/src/main/java/org/apache/guacamole/auth/file/AuthorizeTagHandler.java
+++ b/guacamole/src/main/java/org/apache/guacamole/auth/file/AuthorizeTagHandler.java
@@ -73,6 +73,10 @@ public class AuthorizeTagHandler implements TagHandler {
             if (encoding.equals("md5"))
                 authorization.setEncoding(Authorization.Encoding.MD5);
 
+            // If "sha256" use SHA-256 hash
+            else if (encoding.equals("sha256"))
+                authorization.setEncoding(Authorization.Encoding.SHA_S56);
+
             // If "plain", use plain text
             else if (encoding.equals("plain"))
                 authorization.setEncoding(Authorization.Encoding.PLAIN_TEXT);


### PR DESCRIPTION
Currently, the `user-mapping.xml` file only supports plain-text or MD5. While it is typically expected that this authentication mechanism is only used for small proof-of-concept deployments, it may still be widely used for smaller deployments, like in a home-lab or small business with a limited IT team.

 

The changes I'm proposing would add support for the SHA-256 hashing algorithm  to bring the authentication mechanism into the current cryptographic era. MD5 has been broken since near the turn of the century and SHA1 just a few years ago.


https://issues.apache.org/jira/browse/GUACAMOLE-1391