### PR TITLE
GUACAMOLE-1391: Correct typo when referencing SHA_256 enum

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/auth/file/AuthorizeTagHandler.java
+++ b/guacamole/src/main/java/org/apache/guacamole/auth/file/AuthorizeTagHandler.java
@@ -75,7 +75,7 @@ public class AuthorizeTagHandler implements TagHandler {
 
             // If "sha256" use SHA-256 hash
             else if (encoding.equals("sha256"))
-                authorization.setEncoding(Authorization.Encoding.SHA_S56);
+                authorization.setEncoding(Authorization.Encoding.SHA_256);
 
             // If "plain", use plain text
             else if (encoding.equals("plain"))


### PR DESCRIPTION
There was a typo in referencing the Enum value.