### PR TITLE
GUACAMOLE-1397: AUTH-TOTP set autofocus to input field

### DIFF
--- a/extensions/guacamole-auth-totp/src/main/resources/templates/authenticationCodeField.html
+++ b/extensions/guacamole-auth-totp/src/main/resources/templates/authenticationCodeField.html
@@ -41,7 +41,7 @@
     <div class="totp-code">
         <input type="text"
                placeholder="{{'TOTP.FIELD_PLACEHOLDER_CODE' |translate}}"
-               ng-model="model" autocorrect="off" autocapitalize="off">
+               ng-model="model" autocorrect="off" autocapitalize="off" autofocus>
     </div>
 
 </div>


### PR DESCRIPTION
In some cases I start typing the totp code and the input field doesn't have focus. 

So forcing an autofocus is more user friendly.