### PR TITLE
GUACAMOLE-1398: Explicitly fit guac-tiled-clients directive to available space.

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/styles/client.css
+++ b/guacamole/src/main/frontend/src/app/client/styles/client.css
@@ -103,7 +103,7 @@ body.client {
     flex: 0 0 auto;
 }
 
-.client-view .client-body .tiled-client-list {
+.client-view .client-body guac-tiled-clients {
 
     position: absolute;
     left: 0;


### PR DESCRIPTION
The CSS rule expanding the guac-tiled-clients directive to fit the viewport was not properly updated when the elements and classes involved were changed via c9900434c443f46429970d1e73c238c3a5382ece. The "tiled-client-list" class was previously used to represent the root element of the set of tiled clients, but that element was replaced with the "guac-tiled-clients" directive.