### PR TITLE
GUACAMOLE-1418: Add support of SQL Server JDBC plugin in Docker Image

### DIFF
--- a/guacamole-docker/README.md
+++ b/guacamole-docker/README.md
@@ -166,16 +166,6 @@ documented in
 Deploying Guacamole with SQLServer authentication
 --------------------------------------------------
 
-    docker run --name some-guacamole --link some-guacd:guacd \
-        --link some-sqlserver:sqlserver      \
-        -e SQLSERVER_DATABASE=guacamole_db  \
-        -e SQLSERVER_USER=guacamole_user    \
-        -e SQLSERVER_PASSWORD=some_password \
-        -e SQLSERVER_DATABASE_FILE=/run/secrets/<secret_name> \
-        -e SQLSERVER_USER_FILE=/run/secrets/<secret_name> \
-        -e SQLSERVER_PASSWORD_FILE=/run/secrets/<secret_name> \
-        -d -p 8080:8080 guacamole/guacamole
-
 Linking Guacamole to SQLServer requires three environment variables. If any of
 these environment variables are omitted, you will receive an error message, and
 the image will stop:
@@ -185,13 +175,31 @@ the image will stop:
 2. `SQLSERVER_USER` - The user that Guacamole will use to connect to SQLServer.
 3. `SQLSERVER_PASSWORD` - The password that Guacamole will provide when
    connecting to SQLServer as `SQLSERVER_USER`.
-4. `SQLSERVER_DATABASE_FILE` - The path of the docker secret containing the name
+
+    docker run --name some-guacamole --link some-guacd:guacd \
+        --link some-sqlserver:sqlserver      \
+        -e SQLSERVER_DATABASE=guacamole_db  \
+        -e SQLSERVER_USER=guacamole_user    \
+        -e SQLSERVER_PASSWORD=some_password \
+        -d -p 8080:8080 guacamole/guacamole
+
+Alternatively, if you want to store database credentials using Docker secrets,
+the following three variables are required and replace the previous three:
+
+1. `SQLSERVER_DATABASE_FILE` - The path of the docker secret containing the name
    of database to use for Guacamole authentication.
-5. `SQLSERVER_USER_FILE` - The path of the docker secret containing the name of
+2. `SQLSERVER_USER_FILE` - The path of the docker secret containing the name of
    the user that Guacamole will use to connect to SQLServer.
-6. `SQLSERVER_PASSWORD_FILE` - The path of the docker secret containing the
+3. `SQLSERVER_PASSWORD_FILE` - The path of the docker secret containing the
    password that Guacamole will provide when connecting to SQLServer as
    `SQLSERVER_USER.
+
+    docker run --name some-guacamole --link some-guacd:guacd \
+        --link some-sqlserver:sqlserver      \
+        -e SQLSERVER_DATABASE_FILE=/run/secrets/<secret_name> \
+        -e SQLSERVER_USER_FILE=/run/secrets/<secret_name> \
+        -e SQLSERVER_PASSWORD_FILE=/run/secrets/<secret_name> \
+        -d -p 8080:8080 guacamole/guacamole
 
 ### Initializing the SQLServer database
 

--- a/guacamole-docker/README.md
+++ b/guacamole-docker/README.md
@@ -13,7 +13,7 @@ How to use this image
 
 Using this image will require an existing, running Docker container with the
 [guacd image](https://registry.hub.docker.com/u/guacamole/guacd/), and another
-Docker container providing either a PostgreSQL or MySQL database.
+Docker container providing either a PostgreSQL, MySQL or SQLServer database.
 
 The name of the database and all associated credentials are specified with
 environment variables given when the container is created. All other
@@ -31,9 +31,9 @@ Docker, as well.
 Docker Secrets
 ==============
 The string `_FILE` may be appended to some of the environment variables listed
-below if you are using MySQL or PostgreSQL authentication. This will cause the
-startup script to load the values for those variables from files within
-the container.
+below if you are using MySQL, PostgreSQL or SQLServer authentication. This will
+cause the startup script to load the values for those variables from files
+within the container.
 
 This is useful for specifying sensitive info, ie. passwords for
 the database, in secured files instead of plaintext environment variables. This
@@ -162,6 +162,63 @@ Once this script is generated, you must:
 The process for doing this via the `mysql` utility included with MySQL is
 documented in
 [the Guacamole manual](http://guacamole.apache.org/doc/gug/jdbc-auth.html#jdbc-auth-mysql).
+
+Deploying Guacamole with SQLServer authentication
+--------------------------------------------------
+
+    docker run --name some-guacamole --link some-guacd:guacd \
+        --link some-sqlserver:sqlserver      \
+        -e SQLSERVER_DATABASE=guacamole_db  \
+        -e SQLSERVER_USER=guacamole_user    \
+        -e SQLSERVER_PASSWORD=some_password \
+        -e SQLSERVER_DATABASE_FILE=/run/secrets/<secret_name> \
+        -e SQLSERVER_USER_FILE=/run/secrets/<secret_name> \
+        -e SQLSERVER_PASSWORD_FILE=/run/secrets/<secret_name> \
+        -d -p 8080:8080 guacamole/guacamole
+
+Linking Guacamole to SQLServer requires three environment variables. If any of
+these environment variables are omitted, you will receive an error message, and
+the image will stop:
+
+1. `SQLSERVER_DATABASE` - The name of the database to use for Guacamole
+   authentication.
+2. `SQLSERVER_USER` - The user that Guacamole will use to connect to SQLServer.
+3. `SQLSERVER_PASSWORD` - The password that Guacamole will provide when
+   connecting to SQLServer as `SQLSERVER_USER`.
+4. `SQLSERVER_DATABASE_FILE` - The path of the docker secret containing the name
+   of database to use for Guacamole authentication.
+5. `SQLSERVER_USER_FILE` - The path of the docker secret containing the name of
+   the user that Guacamole will use to connect to SQLServer.
+6. `SQLSERVER_PASSWORD_FILE` - The path of the docker secret containing the
+   password that Guacamole will provide when connecting to SQLServer as
+   `SQLSERVER_USER.
+
+### Initializing the SQLServer database
+
+If your database is not already initialized with the Guacamole schema, you will
+need to do so prior to using Guacamole. A convenience script for generating the
+necessary SQL to do this is included in the Guacamole image.
+
+To generate a SQL script which can be used to initialize a fresh SQLServer
+database
+[as documented in the Guacamole manual](http://guacamole.apache.org/doc/gug/jdbc-auth.html#jdbc-auth-sqlserver):
+
+    docker run --rm guacamole/guacamole /opt/guacamole/bin/initdb.sh --sqlserver > initdb.sql
+
+Alternatively, you can use the SQL scripts included with the
+guacamole-auth-jdbc extension from
+[the corresponding release](http://guacamole.apache.org/releases/).
+
+Once this script is generated, you must:
+
+1. Create a database for Guacamole within SQLServer, such as `guacamole_db`.
+2. Run the script on the newly-created database.
+3. Create a user for Guacamole within SQLServer with access to the tables and
+   sequences of this database, such as `guacamole_user`.
+
+The process for doing this via the `sqlcmd` utilities included
+with SQLServer is documented in
+[the Guacamole manual](http://guacamole.apache.org/doc/gug/jdbc-auth.html#jdbc-auth-sqlserver).
 
 Reporting issues
 ================

--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -115,7 +115,7 @@ curl -L "https://jdbc.postgresql.org/download/postgresql-9.4-1201.jdbc41.jar" > 
 #
 
 echo "Downloading SQL Server JDBC driver ..."
-curl -L "https://go.microsoft.com/fwlink/?linkid=2168494&clcid=0x409" | \
+curl -L "https://go.microsoft.com/fwlink/?linkid=2183223&clcid=0x409" | \
 tar -xz                        \
     -C "$DESTINATION/sqlserver/"   \
     --wildcards                \

--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -111,6 +111,20 @@ echo "Downloading PostgreSQL JDBC driver ..."
 curl -L "https://jdbc.postgresql.org/download/postgresql-9.4-1201.jdbc41.jar" > "$DESTINATION/postgresql/postgresql-9.4-1201.jdbc41.jar"
 
 #
+# Download SQL Server JDBC driver
+#
+
+echo "Downloading SQL Server JDBC driver ..."
+curl -L "https://go.microsoft.com/fwlink/?linkid=2168494&clcid=0x409" | \
+tar -xz                        \
+    -C "$DESTINATION/sqlserver/"   \
+    --wildcards                \
+    --no-anchored              \
+    --no-wildcards-match-slash \
+    --strip-components=2       \
+    "mssql-jdbc-*.jre8.jar"
+
+#
 # Copy LDAP auth extension and schema modifications
 #
 

--- a/guacamole-docker/bin/initdb.sh
+++ b/guacamole-docker/bin/initdb.sh
@@ -26,7 +26,7 @@
 ##
 ## @param DATABASE
 ##     The database to generate the SQL script for. This may be either
-##     "--postgres", for PostgreSQL, or "--mysql" for MySQL.
+##     "--postgres", for PostgreSQL, "--mysql" for MySQL, or "--sqlserver" for Microsoft SQL Server.
 ##
 
 DATABASE="$1"
@@ -37,7 +37,7 @@ DATABASE="$1"
 ##
 incorrect_usage() {
     cat <<END
-USAGE: /opt/guacamole/bin/initdb.sh [--postgres | --mysql]
+USAGE: /opt/guacamole/bin/initdb.sh [--postgres | --mysql | --sqlserver]
 END
     exit 1
 }
@@ -60,6 +60,10 @@ case $DATABASE in
 
     --mysql)
         cat /opt/guacamole/mysql/schema/*.sql
+        ;;
+
+    --sqlserver)
+        cat /opt/guacamole/sqlserver/schema/*.sql
         ;;
 
     *)

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -409,9 +409,7 @@ sqlserver_missing_vars() {
 FATAL: Missing required environment variables
 -------------------------------------------------------------------------------
 If using a SQLServer database, you must provide each of the following
-environment variables or their corresponding Docker secrets by appending _FILE
-to the environment variable, and setting the value to the path of the
-corresponding secret:
+environment variables:
 
     SQLSERVER_USER     The user to authenticate as when connecting to
                        SQLServer.
@@ -421,6 +419,20 @@ corresponding secret:
 
     SQLSERVER_DATABASE The name of the SQLServer database to use for Guacamole
                        authentication.
+
+Alternatively, if you want to store database credentials using Docker secrets,
+set the path of the corresponding secrets in the following three variables:
+
+    SQLSERVER_DATABASE_FILE   The path of the docker secret containing the name
+                              of database to use for Guacamole authentication.
+
+    SQLSERVER_USER_FILE       The path of the docker secret containing the name of
+                              the user that Guacamole will use to connect to SQLServer.
+
+    SQLSERVER_PASSWORD_FILE   The path of the docker secret containing the
+                              password that Guacamole will provide when connecting to 
+                              SQLServer as SQLSERVER_USER.
+
 END
     exit 1;
 }

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -23,7 +23,7 @@
 ##
 ## Automatically configures and starts Guacamole under Tomcat. Guacamole's
 ## guacamole.properties file will be automatically generated based on the
-## linked database container (either MySQL,PostgreSQL or SQLServer) and the linked guacd
+## linked database container (either MySQL, PostgreSQL or SQLServer) and the linked guacd
 ## container. The Tomcat process will ultimately replace the process of this
 ## script, running in the foreground until terminated.
 ##


### PR DESCRIPTION
Implement SQL Server support in Docker Image.
According to JIRA issue, need to check if it's legally allowed (saw other ASF software are using it so I guess it could be)
Have a good review :)