### PR TITLE
GUACAMOLE-1218: Allow both lowercase and uppercase for hex values of ByteArrayProperty.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/ByteArrayProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/ByteArrayProperty.java
@@ -39,7 +39,7 @@ public abstract class ByteArrayProperty implements GuacamoleProperty<byte[]> {
 
         // Return value parsed from hex
         try {
-            return BaseEncoding.base16().decode(value);
+            return BaseEncoding.base16().decode(value.toUpperCase());
         }
 
         // Fail parse if hex invalid


### PR DESCRIPTION
The default decoder from `BaseEncoding.base16()` requires uppercase. There is an option to require lowercase instead, but no option to ignore case entirely.