### PR TITLE
GUACAMOLE-1453: Enable SSL connection between Guacamole and DB using MariaDB Connector/J

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
@@ -89,6 +89,7 @@ public class MySQLAuthenticationProviderModule implements Module {
         // For compatibility, set legacy useSSL property when SSL is disabled.
         if (sslMode == MySQLSSLMode.DISABLED)
             driverProperties.setProperty("useSSL", "false");
+        // For compatibility, set legacy useSSL property when SSL is eisabled.(Required for mariadb connector/j)
         else
             driverProperties.setProperty("useSSL", "true");
 


### PR DESCRIPTION
Addressed an issue with SSL communication failure events using mariadb connector/J.
Hope to include it in the next release. Thank you.