### PR TITLE
GUACAMOLE-957: Correct copypasta in retrieval of LDAP search bind password.

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/JacksonLDAPConfiguration.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/JacksonLDAPConfiguration.java
@@ -357,7 +357,7 @@ public class JacksonLDAPConfiguration implements LDAPConfiguration {
 
     @Override
     public String getSearchBindPassword() throws GuacamoleException {
-        return withDefault(searchBindPassword, defaultConfig::getSearchBindDN);
+        return withDefault(searchBindPassword, defaultConfig::getSearchBindPassword);
     }
 
     @Override


### PR DESCRIPTION
Clearly, the default value for the search bind password should be the search bind password from the underlying default object ... not the search bind DN.