### PR TITLE
GUACAMOLE-957: Correct handling of empty/deleted ldap-servers.yml.

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
@@ -130,6 +130,15 @@ public class ConfigurationService {
 
         }
 
+        // Clear cached YAML if it no longer exists
+        else if (cachedConfigurations != null) {
+            long oldLastModified = lastModified.get();
+            if (lastModified.compareAndSet(oldLastModified, 0)) {
+                logger.debug("Clearing cached LDAP configuration from \"{}\" (file no longer exists).", ldapServers);
+                cachedConfigurations = null;
+            }
+        }
+
         // Use guacamole.properties if not using YAML
         if (cachedConfigurations == null) {
             logger.debug("Reading LDAP configuration from guacamole.properties...");

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
@@ -67,8 +67,11 @@ public class ConfigurationService {
 
     /**
      * The cached copy of the configuration read from {@link #LDAP_SERVERS_YML}.
+     * If the current set of LDAP servers has not yet been read from the YAML
+     * configuration file, or if guacamole.properties is being used instead,
+     * this will be null.
      */
-    private Collection<JacksonLDAPConfiguration> cachedConfigurations = Collections.emptyList();
+    private Collection<JacksonLDAPConfiguration> cachedConfigurations = null;
     
     /**
      * The Guacamole server environment.
@@ -90,7 +93,7 @@ public class ConfigurationService {
      */
     public Collection<? extends LDAPConfiguration> getLDAPConfigurations() throws GuacamoleException {
 
-        // Read configuration from YAML, if available
+        // Read/refresh configuration from YAML, if available
         File ldapServers = new File(environment.getGuacamoleHome(), LDAP_SERVERS_YML);
         if (ldapServers.exists()) {
 
@@ -105,9 +108,15 @@ public class ConfigurationService {
                     logger.debug("Reading updated LDAP configuration from \"{}\"...", ldapServers);
                     Collection<JacksonLDAPConfiguration> configs = mapper.readValue(ldapServers, new TypeReference<Collection<JacksonLDAPConfiguration>>() {});
 
-                    logger.debug("Reading LDAP configuration defaults from guacamole.properties...");
-                    LDAPConfiguration defaultConfig = new EnvironmentLDAPConfiguration(environment);
-                    configs.forEach((config) -> config.setDefaults(defaultConfig));
+                    if (configs != null) {
+                        logger.debug("Reading LDAP configuration defaults from guacamole.properties...");
+                        LDAPConfiguration defaultConfig = new EnvironmentLDAPConfiguration(environment);
+                        configs.forEach((config) -> config.setDefaults(defaultConfig));
+                    }
+                    else
+                        logger.debug("Using only guacamole.properties for "
+                                + "LDAP server definitions as \"{}\" is "
+                                + "empty.", ldapServers);
 
                     cachedConfigurations = configs;
 
@@ -119,13 +128,15 @@ public class ConfigurationService {
             else
                 logger.debug("Using cached LDAP configuration from \"{}\".", ldapServers);
 
-            return cachedConfigurations;
-
         }
 
         // Use guacamole.properties if not using YAML
-        logger.debug("Reading LDAP configuration from guacamole.properties...");
-        return Collections.singletonList(new EnvironmentLDAPConfiguration(environment));
+        if (cachedConfigurations == null) {
+            logger.debug("Reading LDAP configuration from guacamole.properties...");
+            return Collections.singletonList(new EnvironmentLDAPConfiguration(environment));
+        }
+
+        return cachedConfigurations;
 
     }
 


### PR DESCRIPTION
If `ldap-servers.yml` is entirely empty (contains purely placeholder content), the current implementation will fail with a `NullPointerException` as valid but empty YAML is parsed by Jackson as `null`. Further, if `ldap-servers.yml` was used but is later deleted by the admin, the old cached version of `ldap-servers.yml` will continue being used.

Instead, if `ldap-servers.yml` is empty or deleted, the LDAP support should move forward as if no `ldap-servers.yml` was provided.