### PR TITLE
GUACAMOLE-1364: Do not rely on Collectors.toUnmodifiableMap().

### DIFF
--- a/extensions/guacamole-auth-saml/src/main/java/org/apache/guacamole/auth/saml/user/SAMLAuthenticatedUser.java
+++ b/extensions/guacamole-auth-saml/src/main/java/org/apache/guacamole/auth/saml/user/SAMLAuthenticatedUser.java
@@ -92,13 +92,13 @@ public class SAMLAuthenticatedUser extends AbstractAuthenticatedUser {
      *     for substitution as parameter tokens.
      */
     private Map<String, String> getTokens(AssertedIdentity identity) {
-        return identity.getAttributes().entrySet()
+        return Collections.unmodifiableMap(identity.getAttributes().entrySet()
                 .stream()
                 .filter((entry) -> !entry.getValue().isEmpty())
-                .collect(Collectors.toUnmodifiableMap(
+                .collect(Collectors.toMap(
                     (entry) -> TokenName.canonicalize(entry.getKey(), SAML_ATTRIBUTE_TOKEN_PREFIX),
                     (entry) -> entry.getValue().get(0)
-                ));
+                )));
     }
 
     /**


### PR DESCRIPTION
`Collectors.toUnmodifiableMap()` is not part of Java 8, thus the build against Java 8 is broken as of #653. This should fix that.