### PR TITLE
GUACAMOLE-1465: Allow different bind passwords for multi-LDAP

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/AuthenticationProviderService.java
@@ -228,7 +228,7 @@ public class AuthenticationProviderService {
             }
 
             // Attempt bind (authentication)
-            LdapNetworkConnection ldapConnection = ldapService.bindAs(config, bindDn.getName(), password);
+            LdapNetworkConnection ldapConnection = ldapService.bindAs(config, bindDn.getName(), (password == null || password.isEmpty()) ? config.getSearchBindPassword() : password);
             if (ldapConnection == null) {
                 logger.info("Unable to bind as user \"{}\" against LDAP "
                         + "server \"{}\". Proceeding with next server...",


### PR DESCRIPTION
PR #648 recently added support for querying multiple LDAP servers, but as things stand all servers are required to use the same bind password. This PR enables per-server bind passwords in the new ldap-servers.yml file.