### PR TITLE
GUACAMOLE-1475: Make api-session-timeout settable via env var

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -711,6 +711,13 @@ associate_json() {
 }
 
 ##
+## Adds api-session-timeout to guacamole.properties
+##
+associate_apisessiontimeout() {
+    set_optional_property "api-session-timeout" "$API_SESSION_TIMEOUT"
+}
+
+##
 ## Starts Guacamole under Tomcat, replacing the current process with the
 ## Tomcat process. As the current process will be replaced, this MUST be the
 ## last function run within the script.
@@ -871,6 +878,11 @@ fi
 # Use json-auth if specified.
 if [ -n "$JSON_SECRET_KEY" ]; then
     associate_json
+fi
+
+# Use api-session-timeout if specified.
+if [ -n "$API_SESSION_TIMEOUT" ]; then
+    associate_apisessiontimeout
 fi
 
 # Set logback level if specified


### PR DESCRIPTION
Make api-session-timeout settable in Docker via env var API_SESSION_TIMEOUT