### PR TITLE
GUACAMOLE-1261: Escape strings used to generate URLs for user, groups, and connections.

### DIFF
--- a/guacamole/src/main/frontend/src/app/index/filters/escapeFilter.js
+++ b/guacamole/src/main/frontend/src/app/index/filters/escapeFilter.js
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A filter for making sure that a string is URI-encoded and
+ * that any characters with special meaning for URIs are escaped.
+ */
+angular.module('index').filter('escape', [function escapeFilter() {
+
+    return function escapeFilter(input) {
+
+        if (input)
+            return window.encodeURIComponent(input);
+        
+        return '';
+
+    };
+
+}]);

--- a/guacamole/src/main/frontend/src/app/settings/templates/settingsConnections.html
+++ b/guacamole/src/main/frontend/src/app/settings/templates/settingsConnections.html
@@ -11,11 +11,11 @@
 
             <a class="add-connection button"
                ng-show="canCreateConnections()"
-               href="#/manage/{{dataSource}}/connections/">{{'SETTINGS_CONNECTIONS.ACTION_NEW_CONNECTION' | translate}}</a>
+               href="#/manage/{{dataSource | escape}}/connections/">{{'SETTINGS_CONNECTIONS.ACTION_NEW_CONNECTION' | translate}}</a>
 
             <a class="add-connection-group button"
                ng-show="canCreateConnectionGroups()"
-               href="#/manage/{{dataSource}}/connectionGroups/">{{'SETTINGS_CONNECTIONS.ACTION_NEW_CONNECTION_GROUP' | translate}}</a>
+               href="#/manage/{{dataSource | escape}}/connectionGroups/">{{'SETTINGS_CONNECTIONS.ACTION_NEW_CONNECTION_GROUP' | translate}}</a>
 
         </div>
 

--- a/guacamole/src/main/frontend/src/app/settings/templates/settingsUserGroups.html
+++ b/guacamole/src/main/frontend/src/app/settings/templates/settingsUserGroups.html
@@ -10,7 +10,7 @@
         <!-- Form action buttons -->
         <div class="action-buttons">
             <a class="add-user-group button" ng-show="canCreateUserGroups()"
-               href="#/manage/{{getDefaultDataSource()}}/userGroups/">{{'SETTINGS_USER_GROUPS.ACTION_NEW_USER_GROUP' | translate}}</a>
+               href="#/manage/{{getDefaultDataSource() | escape}}/userGroups/">{{'SETTINGS_USER_GROUPS.ACTION_NEW_USER_GROUP' | translate}}</a>
         </div>
 
         <!-- User group filter -->
@@ -32,7 +32,7 @@
         <tbody ng-class="{loading: !isLoaded()}">
             <tr ng-repeat="manageableUserGroup in manageableUserGroupPage" class="user-group">
                 <td class="user-group-name">
-                    <a ng-href="#/manage/{{manageableUserGroup.dataSource}}/userGroups/{{manageableUserGroup.userGroup.identifier}}">
+                    <a ng-href="#/manage/{{manageableUserGroup.dataSource | escape}}/userGroups/{{manageableUserGroup.userGroup.identifier | escape}}">
                         <div class="icon user-group"></div>
                         <span class="name">{{manageableUserGroup.userGroup.identifier}}</span>
                     </a>

--- a/guacamole/src/main/frontend/src/app/settings/templates/settingsUsers.html
+++ b/guacamole/src/main/frontend/src/app/settings/templates/settingsUsers.html
@@ -10,7 +10,7 @@
         <!-- Form action buttons -->
         <div class="action-buttons">
             <a class="add-user button" ng-show="canCreateUsers()"
-               href="#/manage/{{getDefaultDataSource()}}/users/">{{'SETTINGS_USERS.ACTION_NEW_USER' | translate}}</a>
+               href="#/manage/{{getDefaultDataSource() | escape}}/users/">{{'SETTINGS_USERS.ACTION_NEW_USER' | translate}}</a>
         </div>
 
         <!-- User filter -->
@@ -41,7 +41,7 @@
         <tbody ng-class="{loading: !isLoaded()}">
             <tr ng-repeat="manageableUser in manageableUserPage" class="user">
                 <td class="username">
-                    <a ng-href="#/manage/{{manageableUser.dataSource}}/users/{{manageableUser.user.username}}">
+                    <a ng-href="#/manage/{{manageableUser.dataSource | escape}}/users/{{manageableUser.user.username | escape}}">
                         <div class="icon user"></div>
                         <span class="name">{{manageableUser.user.username}}</span>
                     </a>


### PR DESCRIPTION
This pull request implements an AngularJS filter - `escape` - for escaping special characters in strings that will end up as part of a URL, and then implements the `escape` on the user, group, and connection links so that users and groups that contain special characters will be correctly interpreted, resolving the bug in the associated Jira issue.