### PR TITLE
GUACAMOLE-1293: Add client-side support for receiving join and leave notifications.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -1857,7 +1857,7 @@ Guacamole.Client.Message = {
     /**
      * A client message that indicates that a user has joined an existing
      * connection. This message expects a single additional argument - the
-     * username of the user who has joined the connection.
+     * name of the user who has joined the connection.
      * 
      * @type {!number}
      */
@@ -1866,7 +1866,7 @@ Guacamole.Client.Message = {
     /**
      * A client message that indicates that a user has left an existing
      * connection. This message expects a single additional argument - the
-     * username of the user who has left the connection.
+     * name of the user who has left the connection.
      * 
      * @type {!number}
      */

--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -1856,7 +1856,7 @@ Guacamole.Client.Message = {
     
     /**
      * A client message that indicates that a user has joined an existing
-     * connection. This message xpects a single additional argument - the
+     * connection. This message expects a single additional argument - the
      * username of the user who has joined the connection.
      * 
      * @type {!number}

--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -689,13 +689,17 @@ Guacamole.Client = function(tunnel) {
     this.onerror = null;
     
     /**
-     * Fired when a message is received from the remote tunnel and needs to be
-     * displayed to the user.
+     * Fired when an arbitrary message is received from the tunnel that should
+     * be processed by the client.
      * 
      * @event
-     * @param {String} message
-     *     The message sent by the remote end of the tunnel that should be
-     *     displayed for the user.
+     * @param {!number} msgcode
+     *     A status code sent by the remote server that indicates the nature of
+     *     the message that is being sent to the client.
+     *     
+     * @param {string[]} args
+     *     An array of arguments to be processed with the message sent to the
+     *     client.
      */
     this.onmsg = null;
 
@@ -1413,7 +1417,7 @@ Guacamole.Client = function(tunnel) {
         
         "msg" : function(parameters) {
             
-            if (guac_client.onmsg) guac_client.onmsg(parameters[0]);
+            if (guac_client.onmsg) guac_client.onmsg(parseInt(parameters[0]), parameters.slice(1));
             
         },
 
@@ -1840,4 +1844,32 @@ Guacamole.Client.DefaultTransferFunction = {
         dst.blue  =  0xFF & ( src.blue  | ~dst.blue);
     }
 
+};
+
+/**
+ * A list of possible messages that can be sent by the server for processing
+ * by the client.
+ * 
+ * @type {!Object.<string, number>}
+ */
+Guacamole.Client.Message = {
+    
+    /**
+     * A client message that indicates that a user has joined an existing
+     * connection. This message xpects a single additional argument - the
+     * username of the user who has joined the connection.
+     * 
+     * @type {!number}
+     */
+    "USER_JOINED": 0x0001,
+    
+    /**
+     * A client message that indicates that a user has left an existing
+     * connection. This message expects a single additional argument - the
+     * username of the user who has left the connection.
+     * 
+     * @type {!number}
+     */
+    "USER_LEFT": 0x0002
+    
 };

--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -687,6 +687,17 @@ Guacamole.Client = function(tunnel) {
      *     A status object which describes the error.
      */
     this.onerror = null;
+    
+    /**
+     * Fired when a message is received from the remote tunnel and needs to be
+     * displayed to the user.
+     * 
+     * @event
+     * @param {String} message
+     *     The message sent by the remote end of the tunnel that should be
+     *     displayed for the user.
+     */
+    this.onmsg = null;
 
     /**
      * Fired when a audio stream is created. The stream provided to this event
@@ -1398,6 +1409,12 @@ Guacamole.Client = function(tunnel) {
                 display.move(layer, parent, x, y, z);
             }
 
+        },
+        
+        "msg" : function(parameters) {
+            
+            if (guac_client.onmsg) guac_client.onmsg(parameters[0]);
+            
         },
 
         "name": function(parameters) {

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
@@ -297,10 +297,10 @@ public class ConfiguredGuacamoleSocket extends DelegatingGuacamoleSocket {
         }
         
         // Send client name, if supported and available
-        if (GuacamoleProtocolCapability.USERNAME_HANDSHAKE.isSupported(protocolVersion)) {
-            String username = info.getUsername();
-            if (username != null)
-                writer.writeInstruction(new GuacamoleInstruction("username", username));
+        if (GuacamoleProtocolCapability.NAME_HANDSHAKE.isSupported(protocolVersion)) {
+            String name = info.getName();
+            if (name != null)
+                writer.writeInstruction(new GuacamoleInstruction("name", name));
         }
 
         // Send args

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
@@ -297,10 +297,10 @@ public class ConfiguredGuacamoleSocket extends DelegatingGuacamoleSocket {
         }
         
         // Send client name, if supported and available
-        if (GuacamoleProtocolCapability.NAME_HANDSHAKE.isSupported(protocolVersion)) {
-            String name = info.getName();
-            if (name != null)
-                writer.writeInstruction(new GuacamoleInstruction("name", name));
+        if (GuacamoleProtocolCapability.USERNAME_HANDSHAKE.isSupported(protocolVersion)) {
+            String username = info.getUsername();
+            if (username != null)
+                writer.writeInstruction(new GuacamoleInstruction("username", username));
         }
 
         // Send args

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/ConfiguredGuacamoleSocket.java
@@ -293,7 +293,14 @@ public class ConfiguredGuacamoleSocket extends DelegatingGuacamoleSocket {
         if (GuacamoleProtocolCapability.TIMEZONE_HANDSHAKE.isSupported(protocolVersion)) {
             String timezone = info.getTimezone();
             if (timezone != null)
-                writer.writeInstruction(new GuacamoleInstruction("timezone", info.getTimezone()));
+                writer.writeInstruction(new GuacamoleInstruction("timezone", timezone));
+        }
+        
+        // Send client name, if supported and available
+        if (GuacamoleProtocolCapability.NAME_HANDSHAKE.isSupported(protocolVersion)) {
+            String name = info.getName();
+            if (name != null)
+                writer.writeInstruction(new GuacamoleInstruction("name", name));
         }
 
         // Send args

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleClientInformation.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleClientInformation.java
@@ -62,7 +62,7 @@ public class GuacamoleClientInformation {
     /**
      * The name of the user reported by the client.
      */
-    private String name;
+    private String username;
     
     /**
      * The timezone reported by the client.
@@ -162,8 +162,8 @@ public class GuacamoleClientInformation {
      * @return 
      *     A string value of the human-readable name reported by the client.
      */
-    public String getName() {
-        return name;
+    public String getUsername() {
+        return username;
     }
     
     /**
@@ -181,11 +181,11 @@ public class GuacamoleClientInformation {
     /**
      * Set the human-readable name of the user associated with this client.
      * 
-     * @param name 
+     * @param username 
      *     The human-readable name of the user associated with this client.
      */
-    public void setName(String name) {
-        this.name = name;
+    public void setUsername(String username) {
+        this.username = username;
     }
     
     /**

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleClientInformation.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleClientInformation.java
@@ -47,17 +47,22 @@ public class GuacamoleClientInformation {
     /**
      * The list of audio mimetypes reported by the client to be supported.
      */
-    private final List<String> audioMimetypes = new ArrayList<String>();
+    private final List<String> audioMimetypes = new ArrayList<>();
 
     /**
      * The list of video mimetypes reported by the client to be supported.
      */
-    private final List<String> videoMimetypes = new ArrayList<String>();
+    private final List<String> videoMimetypes = new ArrayList<>();
 
     /**
      * The list of image mimetypes reported by the client to be supported.
      */
-    private final List<String> imageMimetypes = new ArrayList<String>();
+    private final List<String> imageMimetypes = new ArrayList<>();
+    
+    /**
+     * The name of the user reported by the client.
+     */
+    private String name;
     
     /**
      * The timezone reported by the client.
@@ -151,6 +156,17 @@ public class GuacamoleClientInformation {
     }
     
     /**
+     * Returns the name of the Guacamole user as reported by the client, or null
+     * if the user name is not set.
+     * 
+     * @return 
+     *     A string value of the human-readable name reported by the client.
+     */
+    public String getName() {
+        return name;
+    }
+    
+    /**
      * Return the timezone as reported by the client, or null if the timezone
      * is not set.  Valid timezones are specified in IANA zone key format,
      * also known as Olson time zone database or TZ Database.
@@ -160,6 +176,16 @@ public class GuacamoleClientInformation {
      */
     public String getTimezone() {
         return timezone;
+    }
+    
+    /**
+     * Set the human-readable name of the user associated with this client.
+     * 
+     * @param name 
+     *     The human-readable name of the user associated with this client.
+     */
+    public void setName(String name) {
+        this.name = name;
     }
     
     /**

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleClientInformation.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleClientInformation.java
@@ -62,7 +62,7 @@ public class GuacamoleClientInformation {
     /**
      * The name of the user reported by the client.
      */
-    private String username;
+    private String name;
     
     /**
      * The timezone reported by the client.
@@ -162,8 +162,8 @@ public class GuacamoleClientInformation {
      * @return 
      *     A string value of the human-readable name reported by the client.
      */
-    public String getUsername() {
-        return username;
+    public String getName() {
+        return name;
     }
     
     /**
@@ -181,11 +181,11 @@ public class GuacamoleClientInformation {
     /**
      * Set the human-readable name of the user associated with this client.
      * 
-     * @param username 
+     * @param name 
      *     The human-readable name of the user associated with this client.
      */
-    public void setUsername(String username) {
-        this.username = username;
+    public void setName(String name) {
+        this.name = name;
     }
     
     /**

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
@@ -41,12 +41,12 @@ public enum GuacamoleProtocolCapability {
     MSG_INSTRUCTION(GuacamoleProtocolVersion.VERSION_1_5_0),
     
     /**
-     * Support for the "name" handshake instruction, allowing clients to send
-     * the name of the Guacamole user to be passed to guacd and associated with
-     * connections. Support for this insruction was introduced in
+     * Support for the "username" handshake instruction, allowing clients to
+     * send the name of the Guacamole user to be passed to guacd and associated
+     * with connections. Support for this instruction was introduced in
      * {@link GuacamoleProtocolVersion#VERSION_1_5_0}.
      */
-    NAME_HANDSHAKE(GuacamoleProtocolVersion.VERSION_1_5_0),
+    USERNAME_HANDSHAKE(GuacamoleProtocolVersion.VERSION_1_5_0),
     
     /**
      * Negotiation of Guacamole protocol version between client and server

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
@@ -41,6 +41,14 @@ public enum GuacamoleProtocolCapability {
     MSG_INSTRUCTION(GuacamoleProtocolVersion.VERSION_1_5_0),
     
     /**
+     * Support for the "name" handshake instruction, allowing clients to send
+     * the name of the Guacamole user to be passed to guacd and associated with
+     * connections. Support for this insruction was introduced in
+     * {@link GuacamoleProtocolVersion#VERSION_1_5_0}.
+     */
+    NAME_HANDSHAKE(GuacamoleProtocolVersion.VERSION_1_5_0),
+    
+    /**
      * Negotiation of Guacamole protocol version between client and server
      * during the protocol handshake. The ability to negotiate protocol
      * versions was introduced in

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
@@ -41,12 +41,12 @@ public enum GuacamoleProtocolCapability {
     MSG_INSTRUCTION(GuacamoleProtocolVersion.VERSION_1_5_0),
     
     /**
-     * Support for the "username" handshake instruction, allowing clients to
-     * send the name of the Guacamole user to be passed to guacd and associated
-     * with connections. Support for this instruction was introduced in
+     * Support for the "name" handshake instruction, allowing clients to send
+     * the name of the Guacamole user to be passed to guacd and associated with
+     * connections. Support for this instruction was introduced in
      * {@link GuacamoleProtocolVersion#VERSION_1_5_0}.
      */
-    USERNAME_HANDSHAKE(GuacamoleProtocolVersion.VERSION_1_5_0),
+    NAME_HANDSHAKE(GuacamoleProtocolVersion.VERSION_1_5_0),
     
     /**
      * Negotiation of Guacamole protocol version between client and server

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolCapability.java
@@ -34,6 +34,13 @@ public enum GuacamoleProtocolCapability {
     ARBITRARY_HANDSHAKE_ORDER(GuacamoleProtocolVersion.VERSION_1_1_0),
     
     /**
+     * Support for the "msg" instruction. The "msg" instruction allows the
+     * server to send messages to the client. Support for this instruction was
+     * introduced in {@link GuacamoleProtocolVersion#VERSION_1_5_0}.
+     */
+    MSG_INSTRUCTION(GuacamoleProtocolVersion.VERSION_1_5_0),
+    
+    /**
      * Negotiation of Guacamole protocol version between client and server
      * during the protocol handshake. The ability to negotiate protocol
      * versions was introduced in

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
@@ -56,7 +56,9 @@ public class GuacamoleProtocolVersion {
     /**
      * Protocol version 1.5.0, which introduces the "msg" instruction, allowing
      * the server to send message notifications that will be displayed on the
-     * client.
+     * client. The version also adds support for the "name" handshake
+     * instruction, allowing guacd to store the name of the user who is
+     * accessing the connection.
      */
     public static final GuacamoleProtocolVersion VERSION_1_5_0 = new GuacamoleProtocolVersion(1, 5, 0);
     

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
@@ -54,10 +54,17 @@ public class GuacamoleProtocolVersion {
     public static final GuacamoleProtocolVersion VERSION_1_3_0 = new GuacamoleProtocolVersion(1, 3, 0);
 
     /**
+     * Protocol version 1.5.0, which introduces the "msg" instruction, allowing
+     * the server to send message notifications that will be displayed on the
+     * client.
+     */
+    public static final GuacamoleProtocolVersion VERSION_1_5_0 = new GuacamoleProtocolVersion(1, 5, 0);
+    
+    /**
      * The most recent version of the Guacamole protocol at the time this
      * version of GuacamoleProtocolVersion was built.
      */
-    public static final GuacamoleProtocolVersion LATEST = VERSION_1_3_0;
+    public static final GuacamoleProtocolVersion LATEST = VERSION_1_5_0;
     
     /**
      * A regular expression that matches the VERSION_X_Y_Z pattern, where

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
@@ -56,8 +56,8 @@ public class GuacamoleProtocolVersion {
     /**
      * Protocol version 1.5.0, which introduces the "msg" instruction, allowing
      * the server to send message notifications that will be displayed on the
-     * client. The version also adds support for the "username" handshake
-     * instruction, allowing guacd to store the username of the user who is
+     * client. The version also adds support for the "name" handshake
+     * instruction, allowing guacd to store the name of the user who is
      * accessing the connection.
      */
     public static final GuacamoleProtocolVersion VERSION_1_5_0 = new GuacamoleProtocolVersion(1, 5, 0);

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleProtocolVersion.java
@@ -56,8 +56,8 @@ public class GuacamoleProtocolVersion {
     /**
      * Protocol version 1.5.0, which introduces the "msg" instruction, allowing
      * the server to send message notifications that will be displayed on the
-     * client. The version also adds support for the "name" handshake
-     * instruction, allowing guacd to store the name of the user who is
+     * client. The version also adds support for the "username" handshake
+     * instruction, allowing guacd to store the username of the user who is
      * accessing the connection.
      */
     public static final GuacamoleProtocolVersion VERSION_1_5_0 = new GuacamoleProtocolVersion(1, 5, 0);

--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -791,6 +791,24 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
             ManagedClient.uploadFile($scope.filesystemMenuContents.client, files[i], $scope.filesystemMenuContents);
 
     };
+    
+    /**
+     * Determines whether the attached client group has any associated client
+     * messages to display.
+     * 
+     * @returns {Boolean}
+     *     true if there are messages to display; otherwise false.
+     */
+    $scope.hasMessages = function hasMessages() {
+        
+        // No client group means no messages
+        if (!$scope.clientGroup)
+            return false;
+        
+        // Otherwise, find messages within the clients in the group.
+        return _.findIndex($scope.clientGroup.clients, ManagedClient.hasMessages) !== -1;
+        
+    };
 
     /**
      * Determines whether the attached client group has any associated file

--- a/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
@@ -28,15 +28,54 @@ angular.module('client').directive('guacClientMessage', [function guacClientMess
         scope: {
 
             /**
-             * The message to display.
+             * The message to display to the client.
              * 
-             * @type String
+             * @type {!ManagedClientMessage}
              */
             message : '='
 
         },
 
-        templateUrl: 'app/client/templates/guacClientMessage.html'
+        templateUrl: 'app/client/templates/guacClientMessage.html',
+        
+        controller: ['$scope', '$injector', '$element',
+                function guacClientMessageController($scope, $injector, $element) {
+            
+            const ManagedClientMessage = $injector.get('ManagedClientMessage');
+            
+            /**
+             * Uses the msgcode to retrieve the correct translation key for
+             * the client message.
+             * 
+             * @returns {string}
+             */
+            $scope.getMessageKey = function getMessageKey() {
+                
+                let msgString = "DEFAULT";
+                if (Object.values(Guacamole.Client.Message).includes($scope.message.msgcode))
+                    msgString = Object.keys(Guacamole.Client.Message).find(key => Guacamole.Client.Message[key] === $scope.message.msgcode);
+                
+                return "CLIENT.CLIENT_MESSAGE_" + msgString.toUpperCase();
+            };
+            
+            /**
+             * Returns a set of key/value object pairs that represent the
+             * arguments provided as part of the message in the form
+             * ARGS[0] = value.
+             * 
+             * @returns {Object}
+             */
+            $scope.getMessageArgs = function getMessageArgs() {
+                return $scope.message.args.reduce(
+                    function(acc, value, index) {
+                        acc[`ARGS[${index}]`] = value;
+                        return acc;
+                    },
+                    {}
+                );
+            };
+                
+        }]
 
     };
 }]);

--- a/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
@@ -41,6 +41,7 @@ angular.module('client').directive('guacClientMessage', [function guacClientMess
         controller: ['$scope', '$injector', '$element',
                 function guacClientMessageController($scope, $injector, $element) {
             
+            // Required types
             const ManagedClientMessage = $injector.get('ManagedClientMessage');
             
             /**
@@ -61,7 +62,9 @@ angular.module('client').directive('guacClientMessage', [function guacClientMess
             /**
              * Returns a set of key/value object pairs that represent the
              * arguments provided as part of the message in the form
-             * ARGS[0] = value.
+             * ARGS[0] = value. Guacamole's translation system relies on
+             * the arguments being available in this format in order to be able
+             * to handle substituting values for an arbitrary list of arguments.
              * 
              * @returns {Object}
              */

--- a/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Directive which displays a message for the client.
+ */
+angular.module('client').directive('guacClientMessage', [function guacClientMessage() {
+
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+
+            /**
+             * The message to display.
+             * 
+             * @type String
+             */
+            message : '='
+
+        },
+
+        templateUrl: 'app/client/templates/guacClientMessage.html'
+
+    };
+}]);

--- a/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
@@ -62,7 +62,7 @@ angular.module('client').directive('guacClientMessage', [function guacClientMess
             /**
              * Returns a set of key/value object pairs that represent the
              * arguments provided as part of the message in the form
-             * ARGS[0] = value. Guacamole's translation system relies on
+             * "ARGS_0 = value". Guacamole's translation system relies on
              * the arguments being available in this format in order to be able
              * to handle substituting values for an arbitrary list of arguments.
              * 
@@ -71,7 +71,7 @@ angular.module('client').directive('guacClientMessage', [function guacClientMess
             $scope.getMessageArgs = function getMessageArgs() {
                 return $scope.message.args.reduce(
                     function(acc, value, index) {
-                        acc[`ARGS[${index}]`] = value;
+                        acc[`ARGS_${index}`] = value;
                         return acc;
                     },
                     {}

--- a/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacClientMessage.js
@@ -44,6 +44,9 @@ angular.module('client').directive('guacClientMessage', [function guacClientMess
             // Required types
             const ManagedClientMessage = $injector.get('ManagedClientMessage');
             
+            // Required services
+            var translationStringService = $injector.get('translationStringService');
+            
             /**
              * Uses the msgcode to retrieve the correct translation key for
              * the client message.
@@ -56,7 +59,7 @@ angular.module('client').directive('guacClientMessage', [function guacClientMess
                 if (Object.values(Guacamole.Client.Message).includes($scope.message.msgcode))
                     msgString = Object.keys(Guacamole.Client.Message).find(key => Guacamole.Client.Message[key] === $scope.message.msgcode);
                 
-                return "CLIENT.CLIENT_MESSAGE_" + msgString.toUpperCase();
+                return "CLIENT.MESSAGE_" + translationStringService.canonicalize(msgString);
             };
             
             /**

--- a/guacamole/src/main/frontend/src/app/client/directives/guacMessageDialog.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacMessageDialog.js
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Directive which displays all client messages.
+ */
+angular.module('client').directive('guacMessageDialog', [function guacMessageDialog() {
+
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+
+            /**
+             * The client group whose messages should be managed by this
+             * directive.
+             * 
+             * @type ManagedClientGroup
+             */
+            clientGroup : '='
+
+        },
+
+        templateUrl: 'app/client/templates/guacMessageDialog.html',
+        controller: ['$scope', '$injector', function guacMessageDialogController($scope, $injector) {
+
+            // Required types
+            const ManagedClient            = $injector.get('ManagedClient');
+            const ManagedClientGroup       = $injector.get('ManagedClientGroup');
+
+            /**
+             * Removes all messages.
+             */
+            $scope.clearAllMessages = function clearAllMessages() {
+                
+                // Nothing to clear if no client group attached
+                if (!$scope.clientGroup)
+                    return;
+
+                // Remove each client's messages
+                $scope.clientGroup.clients.forEach(client =>  {
+                    client.messages = [];
+                });
+
+            };
+
+            /**
+             * @borrows ManagedClientGroup.hasMultipleClients
+             */
+            $scope.hasMultipleClients = ManagedClientGroup.hasMultipleClients;
+
+            /**
+             * @borrows ManagedClient.hasMessages
+             */
+            $scope.hasMessages = ManagedClient.hasMessages;
+
+        }]
+
+    };
+}]);

--- a/guacamole/src/main/frontend/src/app/client/styles/client-message.css
+++ b/guacamole/src/main/frontend/src/app/client/styles/client-message.css
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+p.client-message-text {
+    margin: 5px;
+}
+

--- a/guacamole/src/main/frontend/src/app/client/styles/message-dialog.css
+++ b/guacamole/src/main/frontend/src/app/client/styles/message-dialog.css
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#message-dialog {
+
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    z-index: 20;
+
+    font-size: 0.8em;
+
+    width: 3in;
+    max-width: 100%;
+    max-height: 3in;
+    
+    background: white;
+    opacity: 0.75;
+
+}
+
+#message-dialog .message-dialog-box {
+
+    /* IE10 */
+    display: -ms-flexbox;
+    -ms-flex-align: stretch;
+    -ms-flex-direction: column;
+
+    /* Ancient Mozilla */
+    display: -moz-box;
+    -moz-box-align: stretch;
+    -moz-box-orient: vertical;
+
+    /* Ancient WebKit */
+    display: -webkit-box;
+    -webkit-box-align: stretch;
+    -webkit-box-orient: vertical;
+
+    /* Old WebKit */
+    display: -webkit-flex;
+    -webkit-align-items: stretch;
+    -webkit-flex-direction: column;
+
+    /* W3C */
+    display: flex;
+    align-items: stretch;
+    flex-direction: column;
+
+    max-width: inherit;
+    max-height: inherit;
+
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.25);
+
+}
+
+#message-dialog .message-dialog-box .header {
+    -ms-flex: 0 0 auto;
+    -moz-box-flex: 0;
+    -webkit-box-flex: 0;
+    -webkit-flex: 0 0 auto;
+    flex: 0 0 auto;
+    margin-bottom: 5px;
+}
+
+#message-dialog .message-dialog-box .client-message-body {
+
+    -ms-flex: 1 1 auto;
+    -moz-box-flex: 1;
+    -webkit-box-flex: 1;
+    -webkit-flex: 1 1 auto;
+    flex: 1 1 auto;
+
+    overflow: auto;
+
+}
+
+/*
+ * Shrink maximum height if viewport is too small for default 3in dialog.
+ */
+@media all and (max-height: 3in) {
+
+    #message-dialog {
+        max-height: 1.5in;
+    }
+
+}
+
+/*
+ * If viewport is too small for even the 1.5in dialog, fit all available space.
+ */
+@media all and (max-height: 1.5in) {
+
+    #message-dialog {
+        height: 100%;
+    }
+
+    #message-dialog .message-dialog-box {
+        position: absolute;
+        left:   0.5em;
+        top:    0.5em;
+        right:  0.5em;
+        bottom: 0.5em;
+    }
+
+}

--- a/guacamole/src/main/frontend/src/app/client/templates/client.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/client.html
@@ -44,6 +44,11 @@
     <div id="connection-warning" ng-show="isConnectionUnstable()">
         {{'CLIENT.TEXT_CLIENT_STATUS_UNSTABLE' | translate}}
     </div>
+    
+    <!-- Message dialog -->
+    <div id="message-dialog" ng-show="hasMessages()">
+        <guac-message-dialog client-group="clientGroup"></guac-message-dialog>
+    </div>
 
     <!-- Menu -->
     <div class="menu" ng-class="{open: menu.shown}" id="guac-menu">

--- a/guacamole/src/main/frontend/src/app/client/templates/guacClientMessage.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/guacClientMessage.html
@@ -1,6 +1,8 @@
 <div class="client-message" ng-click="clear()">
 
     <!-- Message text -->
-    <p class="client-message-text">{{ message }}</p>
+    <p class="client-message-text"
+       translate="{{ getMessageKey() }}"
+       translate-values="{{ getMessageArgs() }}"></p>
 
 </div>

--- a/guacamole/src/main/frontend/src/app/client/templates/guacClientMessage.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/guacClientMessage.html
@@ -1,0 +1,6 @@
+<div class="client-message" ng-click="clear()">
+
+    <!-- Message text -->
+    <p class="client-message-text">{{ message }}</p>
+
+</div>

--- a/guacamole/src/main/frontend/src/app/client/templates/guacMessageDialog.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/guacMessageDialog.html
@@ -1,0 +1,21 @@
+<div class="message-dialog-box">
+    
+    <!-- Message dialog header -->
+    <div class="header">
+        <h2>{{'CLIENT.SECTION_HEADER_CLIENT_MESSAGES' | translate}}</h2>
+        <button ng-click="clearAllMessages()">{{'CLIENT.ACTION_CLEAR_CLIENT_MESSAGES' | translate}}</button>
+    </div>
+
+    <!-- Received messages -->
+    <div class="client-messages-body">
+        <div class="client-messages-body-section" ng-repeat="client in clientGroup.clients" ng-show="hasMessages(client)">
+            <h3 ng-show="hasMultipleClients(clientGroup)">{{ client.name }}</h3>
+            <div class="messages">
+                <guac-client-message
+                    message="message"
+                    ng-repeat="message in client.messages">
+                </guac-client-message>
+            </div>
+        </div>
+    </div>
+</div>

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -173,6 +173,14 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
          * @type ManagedFilesystem[]
          */
         this.filesystems = template.filesystems || [];
+        
+        /**
+         * All messages that have been sent to the client that should be
+         * displayed.
+         * 
+         * @type String[]
+         */
+        this.messages = template.messages || [];
 
         /**
          * All available share links generated for the this ManagedClient via
@@ -485,6 +493,15 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
                     status.code);
 
             });
+        };
+        
+        // Handle messages received from guacd to display to the client.
+        client.onmsg = function clientMessage(message) {
+            
+            $rootScope.$apply(function updateMessages() {
+                managedClient.messages.push(message);
+            });
+            
         };
 
         // Automatically update the client thumbnail
@@ -892,11 +909,27 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         return false;
 
     };
+    
+    /**
+     * Returns whether the given client has any associated messages to display.
+     * 
+     * @param {GuacamoleClient} client
+     *     The client for which messages should be checked.
+     *     
+     * @returns {Boolean}
+     *     true if the given client has any messages, otherwise false.
+     */
+    ManagedClient.hasMessages = function hasMessages(client) {
+        return !!(client && client.messages && client.messages.length);
+    };
 
     /**
      * Returns whether the given client has any associated file transfers,
      * regardless of those file transfers' state.
      *
+     * @param {GuacamoleClient} client
+     *     The client for which file transfers should be checked.
+     * 
      * @returns {boolean}
      *     true if there are any file transfers associated with the
      *     given client, false otherwise.

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -28,6 +28,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     const ClientIdentifier       = $injector.get('ClientIdentifier');
     const ClipboardData          = $injector.get('ClipboardData');
     const ManagedArgument        = $injector.get('ManagedArgument');
+    const ManagedClientMessage   = $injector.get('ManagedClientMessage');
     const ManagedClientState     = $injector.get('ManagedClientState');
     const ManagedClientThumbnail = $injector.get('ManagedClientThumbnail');
     const ManagedDisplay         = $injector.get('ManagedDisplay');
@@ -178,7 +179,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
          * All messages that have been sent to the client that should be
          * displayed.
          * 
-         * @type String[]
+         * @type ManagedClientMessage[]
          */
         this.messages = template.messages || [];
 
@@ -496,10 +497,14 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         };
         
         // Handle messages received from guacd to display to the client.
-        client.onmsg = function clientMessage(message) {
+        client.onmsg = function clientMessage(msgcode, args) {
+            
+            msg = new ManagedClientMessage();
+            msg.msgcode = msgcode;
+            msg.args = args;
             
             $rootScope.$apply(function updateMessages() {
-                managedClient.messages.push(message);
+                managedClient.messages.push(msg);
             });
             
         };

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClientMessage.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClientMessage.js
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides the ManagedClientMessage class used for messages displayed in
+ * a ManagedClient.
+ */
+angular.module('client').factory('ManagedClientMessage', [function defineManagedClientMessage() {
+
+    /**
+     * Object which represents a message to be displayed to a Guacamole client.
+     *
+     * @constructor
+     * @param {ManagedClientMessage|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     ManagedClientMessage.
+     */
+    var ManagedClientMessage = function ManagedClientMessage(template) {
+
+        // Use empty object by default
+        template = template || {};
+
+        /**
+         * The message code sent by the server that will be used to locate the
+         * message within the Guacamole translation framework.
+         */
+        this.msgcode = template.msgcode;
+        
+        /**
+         * Any arguments that should be passed through the translation system
+         * and displayed as part of the message.
+         */
+        this.args = template.args;
+        
+    };
+
+    return ManagedClientMessage;
+
+}]);

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClientMessage.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClientMessage.js
@@ -39,12 +39,16 @@ angular.module('client').factory('ManagedClientMessage', [function defineManaged
         /**
          * The message code sent by the server that will be used to locate the
          * message within the Guacamole translation framework.
+         * 
+         * @type Number
          */
         this.msgcode = template.msgcode;
         
         /**
          * Any arguments that should be passed through the translation system
          * and displayed as part of the message.
+         * 
+         * @type String[]
          */
         this.args = template.args;
         

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -73,8 +73,8 @@
         "ACTION_UPLOAD_FILES"              : "Upload Files",
 
         "CLIENT_MESSAGE_DEFAULT" : "",
-        "CLIENT_MESSAGE_JOINED"  : "User {ARGS_0} has joined the connection.",
-        "CLIENT_MESSAGE_LEFT"    : "User {ARGS_0} has left the connection.",
+        "CLIENT_MESSAGE_JOINED"  : "User {ARGS_1} has joined the connection.",
+        "CLIENT_MESSAGE_LEFT"    : "User {ARGS_1} has left the connection.",
         
         "DIALOG_HEADER_CONNECTING"       : "Connecting",
         "DIALOG_HEADER_CONNECTION_ERROR" : "Connection Error",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -72,10 +72,6 @@
         "ACTION_SHARE"                     : "@:APP.ACTION_SHARE",
         "ACTION_UPLOAD_FILES"              : "Upload Files",
 
-        "CLIENT_MESSAGE_DEFAULT" : "",
-        "CLIENT_MESSAGE_JOINED"  : "User {ARGS_1} has joined the connection.",
-        "CLIENT_MESSAGE_LEFT"    : "User {ARGS_1} has left the connection.",
-        
         "DIALOG_HEADER_CONNECTING"       : "Connecting",
         "DIALOG_HEADER_CONNECTION_ERROR" : "Connection Error",
         "DIALOG_HEADER_DISCONNECTED"     : "Disconnected",
@@ -132,6 +128,10 @@
 
         "INFO_CONNECTION_SHARED" : "This connection is now shared.",
         "INFO_NO_FILE_TRANSFERS" : "No file transfers.",
+
+        "MESSAGE_DEFAULT"      : "",
+        "MESSAGE_USER_JOINED"  : "User {ARGS_1} has joined the connection.",
+        "MESSAGE_USER_LEFT"    : "User {ARGS_1} has left the connection.",
 
         "NAME_INPUT_METHOD_NONE"   : "None",
         "NAME_INPUT_METHOD_OSK"    : "On-screen keyboard",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -73,8 +73,8 @@
         "ACTION_UPLOAD_FILES"              : "Upload Files",
 
         "CLIENT_MESSAGE_DEFAULT" : "",
-        "CLIENT_MESSAGE_JOINED"  : "User {ARGS[0]} has joined the connection.",
-        "CLIENT_MESSAGE_LEFT"    : "User {ARGS[0]} has left the connection.",
+        "CLIENT_MESSAGE_JOINED"  : "User {ARGS_0} has joined the connection.",
+        "CLIENT_MESSAGE_LEFT"    : "User {ARGS_0} has left the connection.",
         
         "DIALOG_HEADER_CONNECTING"       : "Connecting",
         "DIALOG_HEADER_CONNECTION_ERROR" : "Connection Error",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -60,6 +60,7 @@
 
         "ACTION_ACKNOWLEDGE"               : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CANCEL"                    : "@:APP.ACTION_CANCEL",
+        "ACTION_CLEAR_CLIENT_MESSAGES"     : "Clear",
         "ACTION_CLEAR_COMPLETED_TRANSFERS" : "Clear",
         "ACTION_CONTINUE"                  : "@:APP.ACTION_CONTINUE",
         "ACTION_DISCONNECT"                : "Disconnect",
@@ -138,11 +139,13 @@
         "NAME_MOUSE_MODE_ABSOLUTE" : "Touchscreen",
         "NAME_MOUSE_MODE_RELATIVE" : "Touchpad",
 
-        "SECTION_HEADER_CLIPBOARD"      : "Clipboard",
-        "SECTION_HEADER_DEVICES"        : "Devices",
-        "SECTION_HEADER_DISPLAY"        : "Display",
-        "SECTION_HEADER_FILE_TRANSFERS" : "File Transfers",
-        "SECTION_HEADER_INPUT_METHOD"   : "Input method",
+        "SECTION_HEADER_CLIENT_MESSAGES" : "Messages",
+        "SECTION_HEADER_CLIPBOARD"       : "Clipboard",
+        "SECTION_HEADER_DEVICES"         : "Devices",
+        "SECTION_HEADER_DISPLAY"         : "Display",
+        "SECTION_HEADER_FILE_TRANSFERS"  : "File Transfers",
+        "SECTION_HEADER_INPUT_METHOD"    : "Input method",
+        
         "SECTION_HEADER_MOUSE_MODE"     : "Mouse emulation mode",
 
         "TEXT_ZOOM_AUTO_FIT"              : "Automatically fit to browser window",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -72,6 +72,10 @@
         "ACTION_SHARE"                     : "@:APP.ACTION_SHARE",
         "ACTION_UPLOAD_FILES"              : "Upload Files",
 
+        "CLIENT_MESSAGE_DEFAULT" : "",
+        "CLIENT_MESSAGE_JOINED"  : "User {ARGS[0]} has joined the connection.",
+        "CLIENT_MESSAGE_LEFT"    : "User {ARGS[0]} has left the connection.",
+        
         "DIALOG_HEADER_CONNECTING"       : "Connecting",
         "DIALOG_HEADER_CONNECTION_ERROR" : "Connection Error",
         "DIALOG_HEADER_DISCONNECTED"     : "Disconnected",

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
@@ -340,6 +340,11 @@ public class TunnelRequestService {
         GuacamoleSession session = authenticationService.getGuacamoleSession(authToken);
         AuthenticatedUser authenticatedUser = session.getAuthenticatedUser();
         UserContext userContext = session.getUserContext(authProviderIdentifier);
+        
+        // Attempt to get the username and set it for the tunnel client.
+        String name = authenticatedUser.getCredentials().getUsername();
+        if (name != null)
+            info.setName(name);
 
         try {
 

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
@@ -341,10 +341,10 @@ public class TunnelRequestService {
         AuthenticatedUser authenticatedUser = session.getAuthenticatedUser();
         UserContext userContext = session.getUserContext(authProviderIdentifier);
         
-        // Attempt to get the username and set it for the tunnel client.
-        String username = authenticatedUser.getCredentials().getUsername();
-        if (username != null)
-            info.setUsername(username);
+        // Attempt to get the user's name and set it for the tunnel client.
+        String name = authenticatedUser.getIdentifier();
+        if (name != null)
+            info.setName(name);
 
         try {
 

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequestService.java
@@ -342,9 +342,9 @@ public class TunnelRequestService {
         UserContext userContext = session.getUserContext(authProviderIdentifier);
         
         // Attempt to get the username and set it for the tunnel client.
-        String name = authenticatedUser.getCredentials().getUsername();
-        if (name != null)
-            info.setName(name);
+        String username = authenticatedUser.getCredentials().getUsername();
+        if (username != null)
+            info.setUsername(username);
 
         try {
 


### PR DESCRIPTION
This is the client-side change for apache/guacamole-server#358, which adds support for notifying the connection owner when a user joins the connection.