### PR TITLE
GUACAMOLE-1364: Correct rendering of SSO provider list during invalid login animation.

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/html/sso-providers.html
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/html/sso-providers.html
@@ -1,7 +1,5 @@
 <meta name="after" content=".login-ui .login-dialog-middle">
 <div class="sso-providers">
-    <div class="sso-providers-content">
-        {{ 'LOGIN.SECTION_HEADER_SSO_OPTIONS' | translate }}
-        <ul class="sso-provider-list"></ul>
-    </div>
+    {{ 'LOGIN.SECTION_HEADER_SSO_OPTIONS' | translate }}
+    <ul class="sso-provider-list"></ul>
 </div>

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/styles/sso-providers.css
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/styles/sso-providers.css
@@ -18,11 +18,18 @@
  */
 
 .login-ui .sso-providers {
+
+    padding: 0.25em 0.5em;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+
     display: none;
+
 }
 
 .login-ui .sso-providers:last-child {
-    display: table-row;
+    display: block;
 }
 
 .sso-providers ul {
@@ -41,10 +48,4 @@
 
 .sso-providers li:first-child::before {
     display: none;
-}
-
-.sso-providers-content {
-    display: table-cell;
-    padding: 0.25em 0.5em;
-    height: 1px;
 }


### PR DESCRIPTION
The SSO provider list unexpectedly shrinks when the invalid login "shake" animation plays due to the use of `display: table-row` vs. the login form's own use of `display: table-cell`. Migrating the SSO provider list to simple absolute positioning corrects this and matches the way the Guacamole version is rendered.