### PR TITLE
GUACAMOLE-1275: Use effective permissions for determining user home page.

### DIFF
--- a/guacamole/src/main/frontend/src/app/navigation/services/userPageService.js
+++ b/guacamole/src/main/frontend/src/app/navigation/services/userPageService.js
@@ -180,7 +180,7 @@ angular.module('navigation').factory('userPageService', ['$injector',
             ConnectionGroup.ROOT_IDENTIFIER
         );
         var getPermissionSets = dataSourceService.apply(
-            permissionService.getPermissions,
+            permissionService.getEffectivePermissions,
             authenticationService.getAvailableDataSources(),
             authenticationService.getCurrentUsername()
         );


### PR DESCRIPTION
This resolves an issue where permissions inherited through groups were not initially factored in to the home page for a user.