### PR TITLE
Added support for specifying LDAP UPN in properties file

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/ConfigurationService.java
@@ -149,4 +149,20 @@ public class ConfigurationService {
 
     }
 
+     /**
+     * Returns the UPN domain name used to authenticate via LDAP,
+     * or null by default.
+     * 
+     * @return
+     *     The UPN domain name of the LDAP accounts when authenticating per-user.
+     * 
+     * @throws GuacamoleException
+     *     If guacamole.properties connect be parsed.
+     */
+    public String getUPNDomain() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_UPN_DOMAIN,
+            null
+        );
+    }
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
@@ -127,6 +127,17 @@ public class LDAPGuacamoleProperties {
 
     };
 
+     /**
+     * The domain used for a UPN username for LDAP server to connect to when authenticating users.
+     */
+    public static final StringGuacamoleProperty LDAP_UPN_DOMAIN =
+            new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-upn-domain"; }
+
+    };
+
     /**
      * The user that the LDAP extension should bind as when searching for the
      * accounts of users attempting to log in. The format of this parameter
@@ -298,5 +309,5 @@ public class LDAPGuacamoleProperties {
         public String getName() { return "ldap-member-attribute-type"; }
 
     };
-
+    
 }


### PR DESCRIPTION
Added support for specifying LDAP UPN in properties file.  Allows for any user in LDAP (with the corresponding UPN) to authenticate. Removes requirement of users being within same OU for large LDAP deployments.