### PR TITLE
GUACAMOLE-1507: Enable Docker configuration of of the 'extension-priority' property

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -1036,6 +1036,9 @@ if [ -n "$JSON_SECRET_KEY" ]; then
     associate_json
 fi
 
+# Set extension priority if specified
+set_optional_property "extension-priority" "$EXTENSION_PRIORITY"
+
 # Use api-session-timeout if specified.
 if [ -n "$API_SESSION_TIMEOUT" ]; then
     associate_apisessiontimeout


### PR DESCRIPTION
…arameter via environment variable

Enable configuration of of the 'extension-priority' parameter via environment variable.

Details: https://issues.apache.org/jira/browse/GUACAMOLE-1507