### PR TITLE
GUACAMOLE-1508: Add support for nesting .jar files within extensions.

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -64,12 +64,11 @@
                         <id>copy-runtime-dependencies</id>
                         <phase>prepare-package</phase>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
                             <includeScope>runtime</includeScope>
                             <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                            <excludes>META-INF/*.SF,META-INF/*.DSA</excludes>
                         </configuration>
                     </execution>
                 </executions>

--- a/guacamole/src/main/java/org/apache/guacamole/extension/Extension.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/Extension.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -355,12 +356,18 @@ public class Extension {
      * @param file
      *     The file to load as an extension.
      *
+     * @param temporaryFiles
+     *     A modifiable List that should be populated with all temporary files
+     *     created for this extension. These files should be deleted on
+     *     application shutdown in reverse order.
+     *
      * @throws GuacamoleException
      *     If the provided file is not a .jar file, does not contain the
      *     guac-manifest.json, or if guac-manifest.json is invalid and cannot
      *     be parsed.
      */
-    public Extension(final ClassLoader parent, final File file) throws GuacamoleException {
+    public Extension(final ClassLoader parent, final File file,
+            final List<File> temporaryFiles) throws GuacamoleException {
 
         // Associate extension abstraction with original file
         this.file = file;
@@ -390,7 +397,7 @@ public class Extension {
             }
 
             // Create isolated classloader for this extension
-            classLoader = ExtensionClassLoader.getInstance(file, parent);
+            classLoader = ExtensionClassLoader.getInstance(file, temporaryFiles, parent);
 
         }
 

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -141,6 +141,13 @@ public class ExtensionModule extends ServletModule {
             new ArrayList<Listener>();
 
     /**
+     * All temporary files that should be deleted upon application shutdown, in
+     * reverse order of desired deletion. This will typically simply be the
+     * order that each file was created.
+     */
+    private final List<File> temporaryFiles = new ArrayList<>();
+
+    /**
      * Service for adding and retrieving language resources.
      */
     private final LanguageResourceService languageResourceService;
@@ -261,6 +268,20 @@ public class ExtensionModule extends ServletModule {
         return Collections.unmodifiableList(boundAuthenticationProviders);
     }
 
+    /**
+     * Returns a list of all temporary files that should be deleted upon
+     * application shutdown, in reverse order of desired deletion. This will
+     * typically simply be the order that each file was created.
+     *
+     * @return
+     *     A List of all temporary files that should be deleted upon
+     *     application shutdown. The List is not modifiable.
+     */
+    @Provides
+    public List<File> getTemporaryFiles() {
+        return Collections.unmodifiableList(temporaryFiles);
+    }
+    
     /**
      * Binds the given provider class such that a listener is bound for each
      * listener interface implemented by the provider and such that all bound
@@ -479,7 +500,7 @@ public class ExtensionModule extends ServletModule {
             try {
 
                 // Load extension from file
-                Extension extension = new Extension(getParentClassLoader(), extensionFile);
+                Extension extension = new Extension(getParentClassLoader(), extensionFile, temporaryFiles);
 
                 // Validate Guacamole version of extension
                 if (!isCompatible(extension.getGuacamoleVersion())) {


### PR DESCRIPTION
This change adds support for nesting .jar files within extensions, automatically extracting those files to a temporary directory for inclusion within the classpath. The files and directory are deleted automatically upon webapp shutdown or, if that somehow fails, upon JVM exit.

This should also remove the need to exclude metadata from signed .jars, as such libraries will now be able to successfully access and verify themselves.