### PR TITLE
GUACAMOLE-1511: Automatically trim whitespace from property values.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/FileGuacamoleProperties.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/FileGuacamoleProperties.java
@@ -29,7 +29,8 @@ import org.apache.guacamole.GuacamoleServerException;
 
 /**
  * GuacamoleProperties implementation which reads all properties from a
- * standard Java properties file.
+ * standard Java properties file. Whitespace at the end of property values is
+ * automatically trimmed.
  */
 public class FileGuacamoleProperties extends PropertiesGuacamoleProperties {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/PropertiesGuacamoleProperties.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/PropertiesGuacamoleProperties.java
@@ -24,7 +24,8 @@ import org.apache.guacamole.GuacamoleException;
 
 /**
  * GuacamoleProperties implementation which reads all properties from a
- * {@link Properties} object.
+ * {@link Properties} object. Whitespace at the end of property values is
+ * automatically trimmed.
  */
 public class PropertiesGuacamoleProperties implements GuacamoleProperties {
 
@@ -43,12 +44,19 @@ public class PropertiesGuacamoleProperties implements GuacamoleProperties {
      *     values exposed by this instance of PropertiesGuacamoleProperties.
      */
     public PropertiesGuacamoleProperties(Properties properties) {
-        this.properties = properties;
+        this(properties);
     }
+
 
     @Override
     public String getProperty(String name) throws GuacamoleException {
-        return properties.getProperty(name);
+
+        String value = properties.getProperty(name);
+        if (value == null)
+            return null;
+
+        return value.trim();
+
     }
 
 }


### PR DESCRIPTION
As noted in [GUACAMOLE-1511](https://issues.apache.org/jira/browse/GUACAMOLE-1511), whitespace at the end of property values in `guacamole.properties` is a frequently-encountered "gotcha", with any such whitespace invisibly causing failures. This change alters the behavior of `guacamole.properties` such that whitespace at the end of property values no longer has meaning.