### PR TITLE
GUACAMOLE-1511: Revert incorrect recursive constructor invocation.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/PropertiesGuacamoleProperties.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/PropertiesGuacamoleProperties.java
@@ -44,7 +44,7 @@ public class PropertiesGuacamoleProperties implements GuacamoleProperties {
      *     values exposed by this instance of PropertiesGuacamoleProperties.
      */
     public PropertiesGuacamoleProperties(Properties properties) {
-        this(properties);
+        this.properties = properties;
     }
 
 


### PR DESCRIPTION
A previous iteration of the whitespace-trimming changes (#688) involved an additional constructor variation. After removing that portion, the original constructor for `PropertiesGuacamoleProperties` was not restored correctly, and now recursively invokes itself.