### PR TITLE
GUACAMOLE-1523: Resync ONLY local clipboard to internal clipboard.

### DIFF
--- a/guacamole/src/main/frontend/src/app/clipboard/services/clipboardService.js
+++ b/guacamole/src/main/frontend/src/app/clipboard/services/clipboardService.js
@@ -615,7 +615,7 @@ angular.module('clipboard').factory('clipboardService', ['$injector',
      * components like the "guacClient" directive.
      */
     service.resyncClipboard = function resyncClipboard() {
-        service.getClipboard().then(function clipboardRead(data) {
+        getLocalClipboard().then(function clipboardRead(data) {
             return service.setClipboard(data);
         }, angular.noop);
     };


### PR DESCRIPTION
The clipboard service previously and incorrectly resynced the internal clipboard with itself. This had the effect of forcing a resync of the internal clipboard contents to the external, local clipboard, clearing that clipboard of whatever was copied before.