### PR TITLE
GUACAMOLE-1525: Support for true fullscreen mode and keyboard lock

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -39,6 +39,7 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     const clipboardService       = $injector.get('clipboardService');
     const dataSourceService      = $injector.get('dataSourceService');
     const guacClientManager      = $injector.get('guacClientManager');
+    const guacFullscreen         = $injector.get('guacFullscreen');
     const iconService            = $injector.get('iconService');
     const preferenceService      = $injector.get('preferenceService');
     const requestService         = $injector.get('requestService');
@@ -683,8 +684,22 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         callback  : $scope.disconnect
     };
 
+    /**
+     * Action that toggles fullscreen mode within the
+     * currently-connected client and then closes the menu.
+     */
+    var FULLSCREEN_MENU_ACTION = {
+        name      : 'CLIENT.ACTION_FULLSCREEN',
+        classname : 'fullscreen action',
+        callback  : function fullscreen() {
+            
+            guacFullscreen.toggleFullscreenMode();
+            $scope.menu.shown = false;
+        }
+    };
+
     // Set client-specific menu actions
-    $scope.clientMenuActions = [ DISCONNECT_MENU_ACTION ];
+    $scope.clientMenuActions = [ DISCONNECT_MENU_ACTION,FULLSCREEN_MENU_ACTION ];
 
     /**
      * @borrows Protocol.getNamespace
@@ -833,6 +848,9 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     // Clean up when view destroyed
     $scope.$on('$destroy', function clientViewDestroyed() {
         setAttachedGroup(null);
+
+        // always unset fullscreen mode to not confuse user 
+        guacFullscreen.setFullscreenMode(false);
     });
 
 }]);

--- a/guacamole/src/main/frontend/src/app/client/services/guacFullscreen.js
+++ b/guacamole/src/main/frontend/src/app/client/services/guacFullscreen.js
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A service for providing true fullscreen and keyboard lock support.
+ * Keyboard lock is currently only supported by Chromium based browsers
+ * (Edge >= V79, Chrome >= V68 and Opera >= V55)
+ */
+angular.module('client').factory('guacFullscreen', ['$injector', 
+        function guacFullscreen($injector) {
+
+    var service = {};
+
+    // check is browser in true fullscreen mode
+    service.isInFullscreenMode = function isInFullscreenMode() {
+        return document.fullscreenElement;
+    }
+
+    // set fullscreen mode
+    service.setFullscreenMode = function setFullscreenMode(state) {
+        if (document.fullscreenEnabled) {
+            if (state && !service.isInFullscreenMode())
+                document.documentElement.requestFullscreen().then(navigator.keyboard.lock()); 
+            else if (!state && service.isInFullscreenMode())
+                document.exitFullscreen().then(navigator.keyboard.unlock()); 
+        }
+    }
+
+    // toggles current fullscreen mode (off if on, on if off)
+    service.toggleFullscreenMode = function toggleFullscreenMode() {
+        if (!service.isInFullscreenMode())
+            service.setFullscreenMode(true);
+        else
+            service.setFullscreenMode(false);
+    }
+
+    return service;
+    
+}]);

--- a/guacamole/src/main/frontend/src/translations/de.json
+++ b/guacamole/src/main/frontend/src/translations/de.json
@@ -64,6 +64,7 @@
         "ACTION_CLEAR_COMPLETED_TRANSFERS" : "Entferne abgeschlossene Übertragungen",
         "ACTION_CONTINUE"                  : "@:APP.ACTION_CONTINUE",
         "ACTION_DISCONNECT"                : "Trennen",
+        "ACTION_FULLSCREEN"                : "Vollbild",
         "ACTION_LOGOUT"                    : "@:APP.ACTION_LOGOUT",
         "ACTION_NAVIGATE_BACK"             : "@:APP.ACTION_NAVIGATE_BACK",
         "ACTION_NAVIGATE_HOME"             : "@:APP.ACTION_NAVIGATE_HOME",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -67,6 +67,7 @@
         "ACTION_CLEAR_COMPLETED_TRANSFERS" : "@:APP.ACTION_CLEAR",
         "ACTION_CONTINUE"                  : "@:APP.ACTION_CONTINUE",
         "ACTION_DISCONNECT"                : "Disconnect",
+        "ACTION_FULLSCREEN"                : "Fullscreen",
         "ACTION_LOGOUT"                    : "@:APP.ACTION_LOGOUT",
         "ACTION_NAVIGATE_BACK"             : "@:APP.ACTION_NAVIGATE_BACK",
         "ACTION_NAVIGATE_HOME"             : "@:APP.ACTION_NAVIGATE_HOME",


### PR DESCRIPTION
associated JIRA issue: https://issues.apache.org/jira/browse/GUACAMOLE-1525

see also: GUACAMOLE-989 and GUACAMOLE-124

To start fullscreen mode:
Open gucamole's special menu via Ctrl+Alt+Shift and click fullsceen:
![image](https://user-images.githubusercontent.com/76126743/151699998-f878b01e-8308-46e7-92f6-1e23081fcc68.png)
("Vollbild" is german for Fullscreen)