### PR TITLE
GUACAMOLE-641: Use "KeyPair" typed field for private key only if non-empty.

### DIFF
--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmRecordService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmRecordService.java
@@ -434,8 +434,11 @@ public class KsmRecordService {
 
         // Attempt to find single matching keypair field
         KeyPairs keyPairsField = getField(record, KeyPairs.class, PRIVATE_KEY_LABEL_PATTERN);
-        if (keyPairsField != null)
-            return CompletableFuture.completedFuture(getSingleValue(keyPairsField.getValue(), KeyPair::getPrivateKey));
+        if (keyPairsField != null) {
+            String privateKey = getSingleValue(keyPairsField.getValue(), KeyPair::getPrivateKey);
+            if (privateKey != null && !privateKey.isEmpty())
+                return CompletableFuture.completedFuture(privateKey);
+        }
 
         // Lacking a typed keypair field, prefer a PEM-type attachment
         KeeperFile keyFile = getFile(record, PRIVATE_KEY_FILENAME_PATTERN);


### PR DESCRIPTION
An SSH server record in KSM has an associated "KeyPair" field, but this field need not be set. If unset, the current logic ignores the rest of the record and assumes there is no private key at all. Instead, the standard fallbacks of locating an attached PEM file, locating an alternative password field, etc. should be used.

Without this change, a PEM file attached to an SSH server record is counter-intuitively ignored despite there being no other key associated with the record.