### PR TITLE
GUACAMOLE-896: Always flush instruction buffer upon end of static tunnel.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
+++ b/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
@@ -442,8 +442,8 @@ Guacamole.SessionRecording = function SessionRecording(source) {
         tunnel.onstatechange = function tunnelStateChanged(state) {
             if (state === Guacamole.Tunnel.State.CLOSED) {
 
-                // Append to Blob (creating a new Blob in the process)
-                if (instructionBuffer.length >= BLOCK_SIZE) {
+                // Append any remaining instructions
+                if (instructionBuffer.length) {
                     recordingBlob = new Blob([recordingBlob, instructionBuffer]);
                     instructionBuffer = '';
                 }


### PR DESCRIPTION
This change corrects a logic error that prevented recordings from playing back properly as of the recent addition of large recording support. The instruction buffer was incorrectly compared against the buffer size threshold after the download had completed, resulting in the last block of data being ignored. If the entire recording was approximately `BLOCK_SIZE` or less, then the entire recording would not play.