### PR TITLE
GUACAMOLE-1545: Ensure tunnel "onload" fires only for true state changes.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -104,7 +104,7 @@ Guacamole.Tunnel = function() {
      * 
      * @type {!number}
      */
-    this.state = Guacamole.Tunnel.State.CONNECTING;
+    this.state = Guacamole.Tunnel.State.CLOSED;
 
     /**
      * The maximum amount of time to wait for data to be received, in


### PR DESCRIPTION
This change corrects the behavior of the `onload` event for session recordings, which should only fire when the recording has finished loading.

Prior to this change, `onload` would fire as soon as the recording started downloading _and_ after the recording finished loading. This is because the tunnel implementation preemptively calls `disconnect()` within `connect()` to ensure any established connection is torn down before initiating a new connection. With the tunnel state (incorrectly) initialized to `CONNECTING`, this resulted in an incorrect `onstatechange` for `CLOSED` at the beginning of all connections.