### PR TITLE
GUACAMOLE-1550: Allow TOTP key to be cleared by setting its generation status.

### DIFF
--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUserContext.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUserContext.java
@@ -68,7 +68,7 @@ public class TOTPUserContext extends DelegatingUserContext {
     @Override
     public Collection<Form> getUserAttributes() {
         Collection<Form> userAttrs = new HashSet<>(super.getUserAttributes());
-        userAttrs.add(TOTPUser.TOTP_CONFIG_FORM);
+        userAttrs.add(TOTPUser.TOTP_ENROLLMENT_STATUS);
         return Collections.unmodifiableCollection(userAttrs);
     }
 

--- a/extensions/guacamole-auth-totp/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-totp/src/main/resources/translations/en.json
@@ -33,10 +33,10 @@
     
     "USER_ATTRIBUTES" : {
         
-        "FIELD_HEADER_GUAC_TOTP_RESET"         : "Clear TOTP secret:",
-        "FIELD_HEADER_GUAC_TOTP_KEY_CONFIRMED" : "TOTP key confirmed:",
+        "FIELD_HEADER_GUAC_TOTP_KEY_GENERATED" : "Secret key generated:",
+        "FIELD_HEADER_GUAC_TOTP_KEY_CONFIRMED" : "Authentication device confirmed:",
         
-        "SECTION_HEADER_TOTP_CONFIG_FORM" : "Configure TOTP"
+        "SECTION_HEADER_TOTP_ENROLLMENT_STATUS" : "TOTP Enrollment Status"
         
     }
 


### PR DESCRIPTION
The previous functionality provided two checkboxes: one for requesting that the TOTP key be cleared, and another for directly managing whether the TOTP key has been confirmed. This is confusing as checkboxes normally represent state, but the "reset" checkbox here is representing an action:

![TOTP status/reset form](https://user-images.githubusercontent.com/4632905/157935058-cfcf67da-6bfa-401e-91bb-40ae08cebad4.png)

Instead, both checkboxes should represent state:

![TOTP enrollment status form](https://user-images.githubusercontent.com/4632905/157935022-8b06dcbb-af29-4c97-9bc5-3d310bef9270.png)
