### PR TITLE
GUACAMOLE-1322: start.sh SAML Extension load logic incomplete

### DIFF
--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -1046,7 +1046,7 @@ if [ -n "$OPENID_AUTHORIZATION_ENDPOINT" ]; then
 fi
 
 # Use SAML if specified
-if [ -n "$SAML_IDP_METADATA_URL" ]; then
+if [ -n "$SAML_IDP_METADATA_URL" ] || [ -n "$SAML_ENTITY_ID" -a -n "$SAML_CALLBACK_URL" ]; then
     associate_saml
     INSTALLED_AUTH="$INSTALLED_AUTH saml"
 fi


### PR DESCRIPTION
Fix initialization error on SAML auth plugin.
See associated JIRA: https://issues.apache.org/jira/browse/GUACAMOLE-1570