### PR TITLE
GUACAMOLE-1571: Properly wrap stream errors, and check available translations instead of hardcoding.

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/directives/guacFileTransfer.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacFileTransfer.js
@@ -30,7 +30,7 @@ angular.module('client').directive('guacFileTransfer', [function guacFileTransfe
 
             /**
              * The file transfer to display.
-             * 
+             *
              * @type ManagedFileUpload|ManagedFileDownload
              */
             transfer : '='
@@ -40,26 +40,11 @@ angular.module('client').directive('guacFileTransfer', [function guacFileTransfe
         templateUrl: 'app/client/templates/guacFileTransfer.html',
         controller: ['$scope', '$injector', function guacFileTransferController($scope, $injector) {
 
+            // Required services
+            const guacTranslate = $injector.get('guacTranslate');
+
             // Required types
             var ManagedFileTransferState = $injector.get('ManagedFileTransferState');
-
-            /**
-             * All upload error codes handled and passed off for translation.
-             * Any error code not present in this list will be represented by
-             * the "DEFAULT" translation.
-             */
-            var UPLOAD_ERRORS = {
-                0x0100: true,
-                0x0201: true,
-                0x0202: true,
-                0x0203: true,
-                0x0204: true,
-                0x0205: true,
-                0x0301: true,
-                0x0303: true,
-                0x0308: true,
-                0x031D: true
-            };
 
             /**
              * Returns the unit string that is most appropriate for the
@@ -193,7 +178,7 @@ angular.module('client').directive('guacFileTransfer', [function guacFileTransfe
                     return;
 
                 // Save file
-                saveAs($scope.transfer.blob, $scope.transfer.filename); 
+                saveAs($scope.transfer.blob, $scope.transfer.filename);
 
             };
 
@@ -210,23 +195,20 @@ angular.module('client').directive('guacFileTransfer', [function guacFileTransfe
                 return $scope.transfer.transferState.streamState === ManagedFileTransferState.StreamState.ERROR;
             };
 
-            /**
-             * Returns the text of the current error as a translation string.
-             *
-             * @returns {String}
-             *     The name of the translation string containing the text
-             *     associated with the current error.
-             */
-            $scope.getErrorText = function getErrorText() {
+            // The translated error message for the current status code
+            $scope.translatedErrorMessage = '';
+
+            $scope.$watch('transfer.transferState.statusCode', function statusCodeChanged(statusCode) {
 
                 // Determine translation name of error
-                var status = $scope.transfer.transferState.statusCode;
-                var errorName = (status in UPLOAD_ERRORS) ? status.toString(16).toUpperCase() : "DEFAULT";
+                const errorName = 'CLIENT.ERROR_UPLOAD_' + statusCode.toString(16).toUpperCase();
 
-                // Return translation string
-                return 'CLIENT.ERROR_UPLOAD_' + errorName;
+                // Use translation string, or the default if no translation is found for this error code
+                guacTranslate(errorName, 'CLIENT.ERROR_UPLOAD_DEFAULT').then(
+                    translationResult => $scope.translatedErrorMessage = translationResult.message
+                );
 
-            };
+            });
 
         }] // end file transfer controller
 

--- a/guacamole/src/main/frontend/src/app/client/services/guacTranslate.js
+++ b/guacamole/src/main/frontend/src/app/client/services/guacTranslate.js
@@ -47,7 +47,7 @@
      *     A promise which resolves with a TranslationResult containing the results from
      *     the translation attempt.
      */
-    function translateWithFallback(translationId, defaultTranslationId) {
+    var translateWithFallback = function translateWithFallback(translationId, defaultTranslationId) {
         const deferredTranslation = $q.defer();
 
         // Attempt to translate the requested translation ID

--- a/guacamole/src/main/frontend/src/app/client/services/guacTranslate.js
+++ b/guacamole/src/main/frontend/src/app/client/services/guacTranslate.js
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A wrapper around the angular-translate $translate service that offers a
+ * convenient way to fall back to a default translation if the requested
+ * translation is not available.
+ */
+ angular.module('client').factory('guacTranslate', ['$injector', function guacTranslate($injector) {
+
+    // Required services
+    const $q = $injector.get('$q');
+    const $translate = $injector.get('$translate');
+
+    // Required types
+    const TranslationResult = $injector.get('TranslationResult');
+
+    /**
+     * Returns a promise that will be resolved with a TranslationResult containg either the
+     * requested ID and message (if translated), or the default ID and message if translated,
+     * or the literal value of `defaultTranslationId` for both the ID and message if neither
+     * is translated.
+     *
+     * @param {String} translationId
+     *     The requested translation ID, which may or may not be translated.
+     *
+     * @param {Sting} defaultTranslationId
+     *     The translation ID that will be used if no translation is found for `translationId`.
+     *
+     * @returns {Promise.<TranslationResult>}
+     *     A promise which resolves with a TranslationResult containing the results from
+     *     the translation attempt.
+     */
+    function translateWithFallback(translationId, defaultTranslationId) {
+        const deferredTranslation = $q.defer();
+
+        // Attempt to translate the requested translation ID
+        $translate(translationId).then(
+
+            // If the requested translation is available, use that
+            translation => deferredTranslation.resolve(new TranslationResult({
+                id: translationId, message: translation
+            })),
+
+            // Otherwise, try the default translation ID
+            () => $translate(defaultTranslationId).then(
+
+                // Default translation worked, so use that
+                defaultTranslation =>
+                    deferredTranslation.resolve(new TranslationResult({
+                        id: defaultTranslationId, message: defaultTranslation
+                    })),
+
+                // Neither translation is available; as a fallback, return default ID for both
+                () => deferredTranslation.resolve(new TranslationResult({
+                    id: defaultTranslationId, message: defaultTranslationId
+                })),
+            )
+        );
+
+        return deferredTranslation.promise;
+    };
+
+    return translateWithFallback;
+
+}]);

--- a/guacamole/src/main/frontend/src/app/client/templates/guacFileTransfer.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/guacFileTransfer.html
@@ -10,7 +10,7 @@
         </div>
 
         <!-- Error text -->
-        <p class="error-text">{{getErrorText() | translate}}</p>
+        <p class="error-text">{{translatedErrorMessage}}</p>
 
     </div>
 

--- a/guacamole/src/main/frontend/src/app/client/types/TranslationResult.js
+++ b/guacamole/src/main/frontend/src/app/client/types/TranslationResult.js
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides the TranslationResult class used by the guacTranslate service. This class contains
+ * both the translated message and the translation ID that generated the message, in the case
+ * where it's unknown whether a translation is defined or not.
+ */
+ angular.module('client').factory('TranslationResult', [function defineTranslationResult() {
+
+    /**
+     * Object which represents the result of a translation as returned from
+     * the guacTranslate service.
+     *
+     * @constructor
+     * @param {TranslationResult|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     TranslationResult.
+     */
+    const TranslationResult = function TranslationResult(template) {
+
+        // Use empty object by default
+        template = template || {};
+
+        /**
+         * The translation ID.
+         *
+         * @type {String}
+         */
+        this.id = template.id;
+
+        /**
+         * The translated message.
+         *
+         * @type {String}
+         */
+        this.message = template.message;
+
+    };
+
+    return TranslationResult;
+
+}]);

--- a/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
@@ -323,7 +323,7 @@ angular.module('rest').factory('tunnelService', ['$injector',
 
             // Parse and reject with resulting JSON error
             else if (xhr.getResponseHeader('Content-Type') === 'application/json')
-                deferred.reject(angular.fromJson(xhr.responseText));
+                deferred.reject(new Error(angular.fromJson(xhr.responseText)));
 
             // Warn of lack of permission of a proxy rejects the upload
             else if (xhr.status >= 400 && xhr.status < 500)


### PR DESCRIPTION
From https://issues.apache.org/jira/browse/GUACAMOLE-1571:

- JSON-formatted errors received from the server during upload streams are not properly handled, leading to error messages not being displayed to the user
- The list of translatable upload errors is hardcoded in the JS, meaning that translations cannot be supplied for currently untranslated errors by extensions.  (NOTE: the same issue exists for the client notification system)
- In Firefox only, upload streams that are rejected do not contain any response information - the status code is 0 in the XHR, and the response information is blank in the network tab - this is likely related to this issue: https://stackoverflow.com/questions/20210252/status-code-text-and-all-response-headers-are-null-for-an-xhr-that-has-status-c


This PR fixes the first 2 problems. I don't know of any obvious way to fix the 3rd. The fetch API seemed like a possible solution, but it doesn't seem to offer anyway to track the progress of uploads, which would be a dealbreaker.