### PR TITLE
GUACAMOLE-462: Request correct sort order from REST API when searching history.

### DIFF
--- a/guacamole/src/main/frontend/src/app/settings/directives/guacSettingsConnectionHistory.js
+++ b/guacamole/src/main/frontend/src/app/settings/directives/guacSettingsConnectionHistory.js
@@ -89,6 +89,37 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                 'entry.remoteHost'
             ]);
 
+            /**
+             * The names of sortable properties supported by the REST API that
+             * correspond to the properties that may be stored within
+             * $scope.order.
+             *
+             * @type {!Object.<string, string>}
+             */
+            const apiSortProperties = {
+                 'entry.startDate' :  'startDate',
+                '-entry.startDate' : '-startDate'
+            };
+
+            /**
+             * Converts the given sort predicate to a correponding array of
+             * sortable properties supported by the REST API. Any properties
+             * within the predicate that are not supported will be dropped.
+             *
+             * @param {!string[]} predicate
+             *     The sort predicate to convert, as exposed by the predicate
+             *     property of SortOrder.
+             *
+             * @returns {!string[]}
+             *     A corresponding array of sortable properties, omitting any
+             *     properties not supported by the REST API.
+             */
+            var toAPISortPredicate = function toAPISortPredicate(predicate) {
+                return predicate
+                        .map((name) => apiSortProperties[name])
+                        .filter((name) => !!name);
+            };
+
             // Get session date format
             $translate('SETTINGS_CONNECTION_HISTORY.FORMAT_DATE')
             .then(function dateFormatReceived(retrievedDateFormat) {
@@ -166,9 +197,7 @@ angular.module('settings').directive('guacSettingsConnectionHistory', [function 
                 historyService.getConnectionHistory(
                     $scope.dataSource,
                     requiredContents,
-                    $scope.order.predicate.filter(function isSupportedPredicate(predicate) {
-                        return predicate === 'startDate' || predicate === '-startDate';
-                    })
+                    toAPISortPredicate($scope.order.predicate)
                 )
                 .then(function historyRetrieved(historyEntries) {
 


### PR DESCRIPTION
The history screen does not display the correct set of history entries as of recent changes from GUACAMOLE-462. This is because the sort properties of the table in the UI no longer match the sort properties used by the REST API, resulting in only very old records being displayed:

![History search results (wrong)](https://user-images.githubusercontent.com/4632905/161121834-172e12e5-6a40-4cb0-805a-20c8cba6785d.png)

Translating the new properties to the proper REST API properties solves the issue:

![History search results (correct)](https://user-images.githubusercontent.com/4632905/161121903-d58698a6-a8f8-4d2b-9420-37bdf96fafaa.png)

The incorrect behavior is only reproducible on a system with more than 1000 history records. On systems with fewer records, the same records will be present in the returned set regardless of how they are sorted.