### PR TITLE
GUACAMOLE-462: Ensure compatibility with 1.x extensions is maintained.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/ConnectionRecord.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/ConnectionRecord.java
@@ -82,6 +82,8 @@ public interface ConnectionRecord extends ActivityRecord {
      * history records, such as log messages and session recordings.
      */
     @Override
-    public UUID getUUID();
+    public default UUID getUUID() {
+        return null;
+    }
 
 }


### PR DESCRIPTION
As of recent changes from GUACAMOLE-462, extensions built for older Guacamole releases may fail with an `AbstractMethodError` due to the new `getUUID()` function added to the `ActivityRecord` interface. While the new function has a default implementation and therefore should be backward compatible, the `ConnectionRecord` interface redeclares `getUUID()` _without a default implementation_, thus causing the method to become abstract: https://docs.oracle.com/javase/tutorial/java/IandI/defaultmethods.html#extending

This change adds a corresponding default implementation to `ConnectionRecord`.