### PR TITLE
GUACAMOLE-641: Ensure empty strings within KSM record fields are handled as if the field value is absent.

### DIFF
--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmRecordService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmRecordService.java
@@ -113,6 +113,29 @@ public class KsmRecordService {
     }
 
     /**
+     * Returns the single value stored in the given list of strings. If the
+     * list is empty, contains multiple values, or contains only a single empty
+     * string, null is returned.
+     *
+     * @param values
+     *     The list to retrieve a single value from.
+     *
+     * @return
+     *     The single value stored in the given list, or null if the list is
+     *     empty, contains multiple values, or contains only a single empty
+     *     string.
+     */
+    private String getSingleStringValue(List<String> values) {
+
+        String value = getSingleValue(values);
+        if (value != null && !value.isEmpty())
+            return value;
+
+        return null;
+
+    }
+
+    /**
      * Returns the single value stored in the given list, additionally
      * performing a mapping transformation on the single value. If the list is
      * empty or contains multiple values, null is returned.
@@ -142,6 +165,36 @@ public class KsmRecordService {
 
         return mapper.apply(value);
         
+    }
+
+    /**
+     * Returns the single value stored in the given list of strings,
+     * additionally performing a mapping transformation on the single value. If
+     * the list is empty, contains multiple values, or contains only a single
+     * empty string, null is returned.
+     *
+     * @param <T>
+     *     The type of object stored in the list.
+     *
+     * @param values
+     *     The list to retrieve a single value from.
+     *
+     * @param mapper
+     *     The function to use to map the single object of type T to type R.
+     *
+     * @return
+     *     The single value stored in the given list, transformed using the
+     *     provided mapping function, or null if the list is empty, contains
+     *     multiple values, or contains only a single empty string.
+     */
+    private <T> String getSingleStringValue(List<T> values, Function<T, String> mapper) {
+
+        String value = getSingleValue(values, mapper);
+        if (value != null && !value.isEmpty())
+            return value;
+
+        return null;
+
     }
 
     /**
@@ -329,7 +382,7 @@ public class KsmRecordService {
         // Prefer standard login field
         Hosts hostsField = getField(record, Hosts.class, null);
         if (hostsField != null)
-            return getSingleValue(hostsField.getValue(), Host::getHostName);
+            return getSingleStringValue(hostsField.getValue(), Host::getHostName);
 
         KeeperRecordData data = record.getData();
         List<KeeperRecordField> custom = data.getCustom();
@@ -337,12 +390,12 @@ public class KsmRecordService {
         // Use text "hostname" custom field as fallback ...
         Text textField = getField(custom, Text.class, HOSTNAME_LABEL_PATTERN);
         if (textField != null)
-            return getSingleValue(textField.getValue());
+            return getSingleStringValue(textField.getValue());
 
         // ... or hidden "hostname" custom field
         HiddenField hiddenField = getField(custom, HiddenField.class, HOSTNAME_LABEL_PATTERN);
         if (hiddenField != null)
-            return getSingleValue(hiddenField.getValue());
+            return getSingleStringValue(hiddenField.getValue());
 
         return null;
 
@@ -367,7 +420,7 @@ public class KsmRecordService {
         // Prefer standard login field
         Login loginField = getField(record, Login.class, null);
         if (loginField != null)
-            return getSingleValue(loginField.getValue());
+            return getSingleStringValue(loginField.getValue());
 
         KeeperRecordData data = record.getData();
         List<KeeperRecordField> custom = data.getCustom();
@@ -375,12 +428,12 @@ public class KsmRecordService {
         // Use text "username" custom field as fallback ...
         Text textField = getField(custom, Text.class, USERNAME_LABEL_PATTERN);
         if (textField != null)
-            return getSingleValue(textField.getValue());
+            return getSingleStringValue(textField.getValue());
 
         // ... or hidden "username" custom field
         HiddenField hiddenField = getField(custom, HiddenField.class, USERNAME_LABEL_PATTERN);
         if (hiddenField != null)
-            return getSingleValue(hiddenField.getValue());
+            return getSingleStringValue(hiddenField.getValue());
 
         return null;
 
@@ -403,11 +456,11 @@ public class KsmRecordService {
 
         Password passwordField = getField(record, Password.class, PASSWORD_LABEL_PATTERN);
         if (passwordField != null)
-            return getSingleValue(passwordField.getValue());
+            return getSingleStringValue(passwordField.getValue());
 
         HiddenField hiddenField = getField(record, HiddenField.class, PASSWORD_LABEL_PATTERN);
         if (hiddenField != null)
-            return getSingleValue(hiddenField.getValue());
+            return getSingleStringValue(hiddenField.getValue());
 
         return null;
 
@@ -435,7 +488,7 @@ public class KsmRecordService {
         // Attempt to find single matching keypair field
         KeyPairs keyPairsField = getField(record, KeyPairs.class, PRIVATE_KEY_LABEL_PATTERN);
         if (keyPairsField != null) {
-            String privateKey = getSingleValue(keyPairsField.getValue(), KeyPair::getPrivateKey);
+            String privateKey = getSingleStringValue(keyPairsField.getValue(), KeyPair::getPrivateKey);
             if (privateKey != null && !privateKey.isEmpty())
                 return CompletableFuture.completedFuture(privateKey);
         }
@@ -451,12 +504,12 @@ public class KsmRecordService {
         // Use password "private key" custom field as fallback ...
         Password passwordField = getField(custom, Password.class, PRIVATE_KEY_LABEL_PATTERN);
         if (passwordField != null)
-            return CompletableFuture.completedFuture(getSingleValue(passwordField.getValue()));
+            return CompletableFuture.completedFuture(getSingleStringValue(passwordField.getValue()));
 
         // ... or hidden "private key" custom field
         HiddenField hiddenField = getField(custom, HiddenField.class, PRIVATE_KEY_LABEL_PATTERN);
         if (hiddenField != null)
-            return CompletableFuture.completedFuture(getSingleValue(hiddenField.getValue()));
+            return CompletableFuture.completedFuture(getSingleStringValue(hiddenField.getValue()));
 
         return CompletableFuture.completedFuture(null);
 
@@ -488,7 +541,7 @@ public class KsmRecordService {
         if (getField(fields, KeyPairs.class, null) != null) {
             Password passwordField = getField(fields, Password.class, null);
             if (passwordField != null)
-                return getSingleValue(passwordField.getValue());
+                return getSingleStringValue(passwordField.getValue());
         }
 
         // For records WITHOUT a standard keypair field, the passphrase can
@@ -500,12 +553,12 @@ public class KsmRecordService {
         // Use password "private key" custom field as fallback ...
         Password passwordField = getField(custom, Password.class, PASSPHRASE_LABEL_PATTERN);
         if (passwordField != null)
-            return getSingleValue(passwordField.getValue());
+            return getSingleStringValue(passwordField.getValue());
 
         // ... or hidden "private key" custom field
         HiddenField hiddenField = getField(custom, HiddenField.class, PASSPHRASE_LABEL_PATTERN);
         if (hiddenField != null)
-            return getSingleValue(hiddenField.getValue());
+            return getSingleStringValue(hiddenField.getValue());
 
         return null;
         

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmRecordService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmRecordService.java
@@ -91,7 +91,8 @@ public class KsmRecordService {
 
     /**
      * Returns the single value stored in the given list. If the list is empty
-     * or contains multiple values, null is returned.
+     * or contains multiple values, null is returned. Note that null will also
+     * be returned if the single value stored in the list is itself null.
      *
      * @param <T>
      *     The type of object stored in the list.
@@ -115,7 +116,8 @@ public class KsmRecordService {
     /**
      * Returns the single value stored in the given list of strings. If the
      * list is empty, contains multiple values, or contains only a single empty
-     * string, null is returned.
+     * string, null is returned. Note that null will also be returned if the
+     * single value stored in the list is itself null.
      *
      * @param values
      *     The list to retrieve a single value from.
@@ -138,7 +140,9 @@ public class KsmRecordService {
     /**
      * Returns the single value stored in the given list, additionally
      * performing a mapping transformation on the single value. If the list is
-     * empty or contains multiple values, null is returned.
+     * empty or contains multiple values, null is returned. Note that null will
+     * also be returned if the mapping transformation returns null for the
+     * single value stored in the list.
      * 
      * @param <T>
      *     The type of object stored in the list.
@@ -171,7 +175,9 @@ public class KsmRecordService {
      * Returns the single value stored in the given list of strings,
      * additionally performing a mapping transformation on the single value. If
      * the list is empty, contains multiple values, or contains only a single
-     * empty string, null is returned.
+     * empty string, null is returned. Note that null will also be returned if
+     * the mapping transformation returns null for the single value stored in
+     * the list.
      *
      * @param <T>
      *     The type of object stored in the list.


### PR DESCRIPTION
During testing, it was discovered that the fields of a KSM vault record that are initially set to a value and later cleared will be returned as an empty string, not `null`. This change alters the processing of these fields such that both the empty string and `null` are handled equivalently.