### PR TITLE
GUACAMOLE-1614: Upgrade to latest jasmine-maven-plugin version to avoid PhantomJS use entirely.

### DIFF
--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>com.github.searls</groupId>
                 <artifactId>jasmine-maven-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.0-beta-02</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Per https://github.com/ariya/phantomjs/issues/15344, PhantomJS is not being actively maintained, and should no longer be used if possible.

The newest version of `jasmine-maven-plugin` does just that - using headless versions of Chrome and Firefox to run tests instead. Unfortunate that it's still a beta version, but it seems to be the best option for fixing this problem.