### PR TITLE
GUACAMOLE-1616: Send updated tokens after adding HISTORY_UUID.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/HistoryTrackingConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/HistoryTrackingConnection.java
@@ -106,7 +106,7 @@ public class HistoryTrackingConnection extends DelegatingConnection {
         updatedTokens.put("HISTORY_UUID", modeledRecord.getUUID().toString());
 
         // Connect, and wrap the tunnel for return
-        GuacamoleTunnel tunnel = super.connect(info, tokens);
+        GuacamoleTunnel tunnel = super.connect(info, updatedTokens);
         return new HistoryTrackingTunnel(
             tunnel, this.connectionRecordMapper, connectionRecordModel);
     }


### PR DESCRIPTION
Oops, missed this in the [original change](GUACAMOLE-1616). Adding the `HISTORY_UUID` field doesn't do much if I never actually send the updated tokens along.