### PR TITLE
GUACAMOLE-1623: Extract domain field directly from the vault, or split out of username.

### DIFF
--- a/extensions/guacamole-vault/modules/guacamole-vault-base/pom.xml
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/pom.xml
@@ -59,6 +59,13 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
+        <!-- JUnit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Guice -->
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/conf/VaultConfigurationService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/conf/VaultConfigurationService.java
@@ -55,7 +55,7 @@ public abstract class VaultConfigurationService {
 
     @Inject
     private VaultSecretService secretService;
-    
+
     /**
      * ObjectMapper for deserializing YAML.
      */
@@ -127,7 +127,7 @@ public abstract class VaultConfigurationService {
                 return Collections.emptyMap();
 
             return mapping;
-            
+
         }
 
         // Fail if YAML is invalid/unreadable
@@ -169,7 +169,7 @@ public abstract class VaultConfigurationService {
                     String secretName = super.getProperty(name);
                     if (secretName == null)
                         return null;
-                    
+
                     return secretService.getValue(secretName).get();
 
                 }
@@ -177,7 +177,7 @@ public abstract class VaultConfigurationService {
 
                     if (e.getCause() instanceof GuacamoleException)
                         throw (GuacamoleException) e;
-                    
+
                     throw new GuacamoleServerException(String.format("Property "
                             + "\"%s\" could not be retrieved from the vault.", name), e);
                 }
@@ -186,5 +186,24 @@ public abstract class VaultConfigurationService {
         };
 
     }
+
+    /**
+     * Return whether Windows domains should be split out from usernames when
+     * fetched from the vault.
+     *
+     * For example: "DOMAIN\\user" or "user@DOMAIN" should both
+     * be split into seperate username and domain tokens if this configuration
+     * is true. If false, no domain token should be created and the above values
+     * should be stored directly in the username token.
+     *
+     * @return
+     *     true if windows domains should be split out from usernames, false
+     *     otherwise.
+     *
+     * @throws GuacamoleException
+     *     If the value specified within guacamole.properties cannot be
+     *     parsed.
+     */
+    public abstract boolean getSplitWindowsUsernames() throws GuacamoleException;
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/secret/WindowsUsername.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/secret/WindowsUsername.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.vault.secret;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A class representing a Windows username, which may optionally also include
+ * a domain. This class can be used to parse the username and domain out of a
+ * username from a vault.
+ */
+public class WindowsUsername {
+
+    /**
+     * A pattern for matching a down-level logon name containing a Windows
+     * domain and username - e.g. domain\\user. For more information, see
+     * https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name
+     */
+    private static final Pattern DOWN_LEVEL_LOGON_NAME_PATTERN = Pattern.compile(
+            "(?<domain>[^@\\\\]+)\\\\(?<username>[^@\\\\]+)");
+
+    /**
+     * A pattern for matching a user principal name containing a Windows
+     * domain and username - e.g. user@domain. For more information, see
+     * https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#user-principal-name
+     */
+    private static final  Pattern USER_PRINCIPAL_NAME_PATTERN = Pattern.compile(
+            "(?<username>[^@\\\\]+)@(?<domain>[^@\\\\]+)");
+
+    /**
+     * The username associated with the potential Windows domain/username
+     * value. If no domain is found, the username field will contain the
+     * entire value as read from the vault.
+     */
+    private final String username;
+
+    /**
+     * The dinaun associated with the potential Windows domain/username
+     * value. If no domain is found, this will be null.
+     */
+    private final String domain;
+
+    /**
+     * Create a WindowsUsername record with no associated domain.
+     *
+     * @param username
+     *     The username, which should be the entire value as extracted
+     *     from the vault.
+     */
+    private WindowsUsername(@Nonnull String username) {
+        this.username = username;
+        this.domain = null;
+    }
+
+    /**
+     * Create a WindowsUsername record with a username and a domain.
+     *
+     * @param username
+     *     The username portion of the field value from the vault.
+     *
+     * @param domain
+     *     The domain portion of the field value from the vault.
+     */
+    private WindowsUsername(
+            @Nonnull String username, @Nonnull String domain) {
+        this.username = username;
+        this.domain = domain;
+    }
+
+    /**
+     * Return the value of the username as extracted from the vault field.
+     * If the domain is null, this will be the entire field value.
+     *
+     * @return
+     *     The username value as extracted from the vault field.
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Return the value of the domain as extracted from the vault field.
+     * If this is null, it means that no domain was found in the vault field.
+     *
+     * @return
+     *     The domain value as extracted from the vault field.
+     */
+    public String getDomain() {
+        return domain;
+    }
+
+    /**
+     * Return true if a domain was found in the vault field, false otherwise.
+     *
+     * @return
+     *     true if a domain was found in the vault field, false otherwise.
+     */
+    public boolean hasDomain() {
+        return this.domain != null;
+    }
+
+    /**
+     * Strip off a Windows domain from the provided username, if one is
+     * present. For example: "DOMAIN\\user" or "user@DOMAIN" will both
+     * be stripped to just "user". Note: neither the '@' or '\\' characters
+     * are valid in Windows usernames.
+     *
+     * @param vaultField
+     *     The raw field value as retrieved from the vault. This might contain
+     *     a Windows domain.
+     *
+     * @return
+     *     The provided username with the Windows domain stripped off, if one
+     *     is present.
+     */
+    public static WindowsUsername splitWindowsUsernameFromDomain(String vaultField) {
+
+        // If it's the down-level logon format, return the extracted username and domain
+        Matcher downLevelLogonMatcher = DOWN_LEVEL_LOGON_NAME_PATTERN.matcher(vaultField);
+        if (downLevelLogonMatcher.matches())
+            return new WindowsUsername(
+                    downLevelLogonMatcher.group("username"),
+                    downLevelLogonMatcher.group("domain"));
+
+        // If it's the user principal format, return the extracted username and domain
+        Matcher userPrincipalMatcher = USER_PRINCIPAL_NAME_PATTERN.matcher(vaultField);
+        if (userPrincipalMatcher.matches())
+            return new WindowsUsername(
+                    userPrincipalMatcher.group("username"),
+                    userPrincipalMatcher.group("domain"));
+
+        // If none of the expected formats matched, return the username with do domain
+        return new WindowsUsername(vaultField);
+
+    }
+
+}

--- a/extensions/guacamole-vault/modules/guacamole-vault-base/src/test/java/org/apache/guacamole/vault/secret/WindowsUsernameTest.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/src/test/java/org/apache/guacamole/vault/secret/WindowsUsernameTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.vault.secret;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+/**
+ * Class to test the parsing functionality of the WindowsUsername class.
+ */
+public class WindowsUsernameTest {
+
+    /**
+     * Verify that the splitWindowsUsernameFromDomain() method correctly strips Windows
+     * domains from provided usernames that include them, and does not modify
+     * usernames that do not have Windows domains.
+     */
+    @Test
+    public void testSplitWindowsUsernameFromDomain() {
+
+        WindowsUsername usernameAndDomain;
+
+        // If no Windows domain is present in the provided field, the username should
+        // contain the entire field, and no domain should be returned
+        usernameAndDomain = WindowsUsername.splitWindowsUsernameFromDomain("bob");
+        assertEquals(usernameAndDomain.getUsername(), "bob");
+        assertFalse(usernameAndDomain.hasDomain());
+
+        // It should parse down-level logon name style domains
+        usernameAndDomain = WindowsUsername.splitWindowsUsernameFromDomain("localhost\\bob");
+        assertEquals("bob", usernameAndDomain.getUsername(), "bob");
+        assertTrue(usernameAndDomain.hasDomain());
+        assertEquals("localhost", usernameAndDomain.getDomain());
+
+        // It should parse user principal name style domains
+        usernameAndDomain = WindowsUsername.splitWindowsUsernameFromDomain("bob@localhost");
+        assertEquals("bob", usernameAndDomain.getUsername(), "bob");
+        assertTrue(usernameAndDomain.hasDomain());
+        assertEquals("localhost", usernameAndDomain.getDomain());
+
+        // It should not match if there are an invalid number of separators
+        List<String> invalidSeparators = List.of(
+                "bob@local@host", "local\\host\\bob",
+                "bob\\local@host", "local@host\\bob");
+        invalidSeparators.stream().forEach(
+            invalidSeparator -> {
+
+                // An invalid number of separators means that the parse failed -
+                // there should be no detected domain, and the entire field value
+                // should be returned as the username
+                WindowsUsername parseOutput =
+                        WindowsUsername.splitWindowsUsernameFromDomain(invalidSeparator);
+                assertFalse(parseOutput.hasDomain());
+                assertEquals(invalidSeparator, parseOutput.getUsername());
+
+            });
+
+    }
+
+}

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
@@ -77,6 +77,18 @@ public class KsmConfigurationService extends VaultConfigurationService {
     };
 
     /**
+     * Whether windows domains should be stripped off from usernames that are
+     * read from the KSM vault.
+     */
+    private static final BooleanGuacamoleProperty STRIP_WINDOWS_DOMAINS = new BooleanGuacamoleProperty() {
+
+        @Override
+        public String getName() {
+            return "ksm-strip-windows-domains";
+        }
+    };
+
+    /**
      * Creates a new KsmConfigurationService which reads the configuration
      * from "ksm-token-mapping.yml" and properties from
      * "guacamole.properties.ksm". The token mapping is a YAML file which lists
@@ -103,6 +115,11 @@ public class KsmConfigurationService extends VaultConfigurationService {
      */
     public boolean getAllowUnverifiedCertificate() throws GuacamoleException {
         return environment.getProperty(ALLOW_UNVERIFIED_CERT, false);
+    }
+
+    @Override
+    public boolean getSplitWindowsUsernames() throws GuacamoleException {
+        return environment.getProperty(STRIP_WINDOWS_DOMAINS, false);
     }
 
     /**

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
@@ -22,7 +22,6 @@ package org.apache.guacamole.vault.ksm.secret;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.keepersecurity.secretsManager.core.Hosts;
-import com.keepersecurity.secretsManager.core.KeeperFile;
 import com.keepersecurity.secretsManager.core.KeeperRecord;
 import com.keepersecurity.secretsManager.core.KeeperSecrets;
 import com.keepersecurity.secretsManager.core.Login;
@@ -119,7 +118,7 @@ public class KsmClient {
      * {@link #cacheLock} acquired appropriately.
      */
     private KeeperSecrets cachedSecrets = null;
-    
+
     /**
      * All records retrieved from Keeper Secrets Manager, where each key is the
      * UID of the corresponding record. The contents of this Map are
@@ -216,7 +215,7 @@ public class KsmClient {
 
             // Store all secrets within cache
             cachedSecrets = secrets;
-            
+
             // Clear unambiguous cache of all records by UID
             cachedRecordsByUid.clear();
 
@@ -398,7 +397,7 @@ public class KsmClient {
      *     The record associated with the given username, or null if there is
      *     no such record or multiple such records.
      *
-     * @throws GuacamoleException 
+     * @throws GuacamoleException
      *     If an error occurs that prevents the record from being retrieved.
      */
     public KeeperRecord getRecordByLogin(String username) throws GuacamoleException {


### PR DESCRIPTION
As discussed in https://issues.apache.org/jira/browse/GUACAMOLE-1623, this allows the KSM vault extension to 

* read a domain token out of records in the vault directly, 

* or to split the username field into domain and username tokens if no domain is directly defined, if the username matches the expected formats as seen at https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#user-principal-name, and if the configuration property is enabled.