### PR TITLE
GUACAMOLE-1623: Use Java 8 List initializer to fix Java 8 build.

### DIFF
--- a/extensions/guacamole-vault/modules/guacamole-vault-base/src/test/java/org/apache/guacamole/vault/secret/WindowsUsernameTest.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/src/test/java/org/apache/guacamole/vault/secret/WindowsUsernameTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -60,7 +61,7 @@ public class WindowsUsernameTest {
         assertEquals("localhost", usernameAndDomain.getDomain());
 
         // It should not match if there are an invalid number of separators
-        List<String> invalidSeparators = List.of(
+        List<String> invalidSeparators = Arrays.asList(
                 "bob@local@host", "local\\host\\bob",
                 "bob\\local@host", "local@host\\bob");
         invalidSeparators.stream().forEach(


### PR DESCRIPTION
Oops, my [previous PR for GUACAMOLE-1623](https://github.com/apache/guacamole-client/pull/736) had a java 9+ only initializer (`List.of`).

This PR changes it to use the Java 8 compatible `Arrays.listOf` initializer.