### PR TITLE
GUACAMOLE-1372: Modify usage of SAML library to allow signed requests.

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/acs/AuthenticationSessionManager.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/acs/AuthenticationSessionManager.java
@@ -126,6 +126,8 @@ public class AuthenticationSessionManager {
      * call to resume(). If authentication is never resumed, the session will
      * automatically be cleaned up after it ceases to be valid.
      *
+     * This method will automatically generate a new identifier.
+     *
      * @param session
      *     The {@link AuthenticationSession} representing the in-progress SAML
      *     authentication attempt.
@@ -138,6 +140,27 @@ public class AuthenticationSessionManager {
         String identifier = idGenerator.generateIdentifier();
         sessions.put(identifier, session);
         return identifier;
+    }
+
+    /**
+     * Defers the Guacamole side of authentication for the user having the
+     * given authentication session such that it may be later resumed through a
+     * call to resume(). If authentication is never resumed, the session will
+     * automatically be cleaned up after it ceases to be valid.
+     *
+     * This method accepts an externally generated ID, which should be a UUID
+     * or similar unique identifier.
+     *
+     * @param session
+     *     The {@link AuthenticationSession} representing the in-progress SAML
+     *     authentication attempt.
+     *
+     * @param identifier
+     *     A unique and unpredictable string that may be used to represent the
+     *     given session when calling resume().
+     */
+    public void defer(AuthenticationSession session, String identifier) {
+        sessions.put(identifier, session);
     }
 
     /**

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/conf/ConfigurationService.java
@@ -492,7 +492,15 @@ public class ConfigurationService {
         samlSettings.setDebug(getDebug());
         samlSettings.setCompressRequest(getCompressRequest());
         samlSettings.setCompressResponse(getCompressResponse());
-    
+
+        // Request that the SAML library sign everything that it can, if
+        // both private key and certificate are specified
+        if (privateKeyFile != null && certificateFile != null) {
+            samlSettings.setAuthnRequestsSigned(true);
+            samlSettings.setLogoutRequestSigned(true);
+            samlSettings.setLogoutResponseSigned(true);
+        }
+
         return samlSettings;
     }
 


### PR DESCRIPTION
The previous approach didn't actually allow requests to be signed - this change modifies the way we're calling the SAML library to allow signatures to be appended to the request as query parameters.

Draft since more testing is needed.