### PR TITLE
GUACAMOLE-1656: Add per-user KSM vault functionality.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/JDBCAuthenticationProviderService.java
@@ -89,31 +89,9 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
 
     }
 
-    /**
-     * Gets a user context for the given authentication provider and user. If
-     * forceRefresh is set to true, the user record will be re-fetched even if
-     * it has already been loaded from the database. If not, the existing
-     * user will be used.
-     *
-     * @param authenticationProvider
-     *     The authentication provider to use when loading or refreshing the user.
-     *
-     * @param authenticatedUser
-     *     The user for which the user context is being fetched.
-     *
-     * @param forceRefresh
-     *     A flag that, when set to true, will force the authenticated user to
-     *     refreshed from the database. If false, an existing DB user will be
-     *     reused.
-     *
-     * @return
-     *     The fetched user context.
-     *
-     * @throws GuacamoleException
-     *     If an error occurs while fetching or refreshing the user context.
-     */
-    private ModeledUserContext getUserContext(AuthenticationProvider authenticationProvider,
-            AuthenticatedUser authenticatedUser, boolean forceRefresh) throws GuacamoleException {
+    @Override
+    public ModeledUserContext getUserContext(AuthenticationProvider authenticationProvider,
+            AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
         // Always allow but provide no data for users authenticated via our own
         // connection sharing links
@@ -124,9 +102,8 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
         boolean databaseCredentialsUsed = (authenticatedUser instanceof ModeledAuthenticatedUser);
         boolean databaseRestrictionsApplicable = (databaseCredentialsUsed || environment.isUserRequired());
 
-        // Retrieve user account for already-authenticated user, forcing a refresh if requested
-        ModeledUser user = userService.retrieveUser(
-                authenticationProvider, authenticatedUser, forceRefresh);
+        // Retrieve user account for already-authenticated user
+        ModeledUser user = userService.retrieveUser(authenticationProvider, authenticatedUser);
         ModeledUserContext context = userContextProvider.get();
         if (user != null && !user.isDisabled()) {
 
@@ -183,20 +160,12 @@ public class JDBCAuthenticationProviderService implements AuthenticationProvider
     }
 
     @Override
-    public ModeledUserContext getUserContext(AuthenticationProvider authenticationProvider,
-            AuthenticatedUser authenticatedUser) throws GuacamoleException {
-
-        // Do not force refresh unless updateUserContext is explicitly called
-        return getUserContext(authenticationProvider, authenticatedUser, false);
-    }
-
-    @Override
     public UserContext updateUserContext(AuthenticationProvider authenticationProvider,
             UserContext context, AuthenticatedUser authenticatedUser,
             Credentials credentials) throws GuacamoleException {
 
-        // Force-refresh the user context
-        return getUserContext(authenticationProvider, authenticatedUser, true);
+        // Refresh the user context
+        return getUserContext(authenticationProvider, authenticatedUser);
 
     }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -404,6 +404,11 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      * @param authenticatedUser
      *     The AuthenticatedUser to retrieve the corresponding ModeledUser of.
      *
+     * @param forceRefresh
+     *     Whether the user should be force-refreshed: i.e. re-queried from the
+     *     database. If false, and the user has already been queried, it will
+     *     be returned as-is.
+     *
      * @return
      *     The ModeledUser which corresponds to the given AuthenticatedUser, or
      *     null if no such user exists.
@@ -413,10 +418,11 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      *     AuthenticatedUser cannot be created.
      */
     public ModeledUser retrieveUser(AuthenticationProvider authenticationProvider,
-            AuthenticatedUser authenticatedUser) throws GuacamoleException {
+            AuthenticatedUser authenticatedUser, boolean forceRefresh) throws GuacamoleException {
 
-        // If we already queried this user, return that rather than querying again
-        if (authenticatedUser instanceof ModeledAuthenticatedUser)
+        // If refresh is not being forced, and we already queried this user,
+        // return that rather than querying again
+        if (!forceRefresh && (authenticatedUser instanceof ModeledAuthenticatedUser))
             return ((ModeledAuthenticatedUser) authenticatedUser).getUser();
 
         // Retrieve corresponding user model, if such a user exists

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -404,11 +404,6 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      * @param authenticatedUser
      *     The AuthenticatedUser to retrieve the corresponding ModeledUser of.
      *
-     * @param forceRefresh
-     *     Whether the user should be force-refreshed: i.e. re-queried from the
-     *     database. If false, and the user has already been queried, it will
-     *     be returned as-is.
-     *
      * @return
      *     The ModeledUser which corresponds to the given AuthenticatedUser, or
      *     null if no such user exists.
@@ -418,12 +413,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      *     AuthenticatedUser cannot be created.
      */
     public ModeledUser retrieveUser(AuthenticationProvider authenticationProvider,
-            AuthenticatedUser authenticatedUser, boolean forceRefresh) throws GuacamoleException {
-
-        // If refresh is not being forced, and we already queried this user,
-        // return that rather than querying again
-        if (!forceRefresh && (authenticatedUser instanceof ModeledAuthenticatedUser))
-            return ((ModeledAuthenticatedUser) authenticatedUser).getUser();
+            AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
         // Retrieve corresponding user model, if such a user exists
         UserModel userModel = userMapper.selectOne(authenticatedUser.getIdentifier());

--- a/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/conf/VaultAttributeService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/conf/VaultAttributeService.java
@@ -31,6 +31,16 @@ import org.apache.guacamole.form.Form;
 public interface VaultAttributeService {
 
     /**
+     * Return all custom connection attributes to be exposed through the
+     * admin UI for the current vault implementation.
+     *
+     * @return
+     *     All custom connection attributes to be exposed through the
+     *     admin UI for the current vault implementation.
+     */
+    public Collection<Form> getConnectionAttributes();
+
+    /**
      * Return all custom connection group attributes to be exposed through the
      * admin UI for the current vault implementation.
      *
@@ -39,4 +49,24 @@ public interface VaultAttributeService {
      *     admin UI for the current vault implementation.
      */
     public Collection<Form> getConnectionGroupAttributes();
+
+    /**
+     * Return all custom user attributes to be exposed through the admin UI for
+     * the current vault implementation.
+     *
+     * @return
+     *     All custom user attributes to be exposed through the admin UI for
+     *     the current vault implementation.
+     */
+    public Collection<Form> getUserAttributes();
+
+    /**
+     * Return all user preference attributes to be exposed through the user
+     * preferences UI for the current vault implementation.
+     *
+     * @return
+     *     All user preference attributes to be exposed through the user
+     *     preferences UI for the current vault implementation.
+     */
+    public Collection<Form> getUserPreferenceAttributes();
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/user/VaultUserContext.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/user/VaultUserContext.java
@@ -241,7 +241,7 @@ public class VaultUserContext extends TokenInjectingUserContext {
      *
      * @throws GuacamoleException
      *     If the value for any applicable secret cannot be retrieved from the
-     *     vault due to an error.
+     *     vault due to an error.1
      */
     private Map<String, Future<String>> getTokens(
             Connectable connectable, Map<String, String> tokenMapping,
@@ -407,7 +407,6 @@ public class VaultUserContext extends TokenInjectingUserContext {
         TokenFilter filter = createFilter();
         filter.setToken(CONNECTION_NAME_TOKEN, connection.getName());
         filter.setToken(CONNECTION_IDENTIFIER_TOKEN, identifier);
-
         // Add hostname and username tokens if available (implementations are
         // not required to expose connection configuration details)
 
@@ -436,17 +435,6 @@ public class VaultUserContext extends TokenInjectingUserContext {
         // those secrets as parameter tokens
         tokens.putAll(resolve(getTokens(connection, confService.getTokenMapping(),
                 filter, config, new TokenFilter(tokens))));
-
-    }
-
-    @Override
-    public Collection<Form> getConnectionGroupAttributes() {
-
-        // Add any custom attributes to any previously defined attributes
-        return Collections.unmodifiableCollection(Stream.concat(
-                super.getConnectionGroupAttributes().stream(),
-                attributeService.getConnectionGroupAttributes().stream()
-        ).collect(Collectors.toList()));
 
     }
 
@@ -490,6 +478,51 @@ public class VaultUserContext extends TokenInjectingUserContext {
 
         // Defer to the vault-specific directory service
         return directoryService.getSharingProfileDirectory(super.getSharingProfileDirectory());
+
+    }
+
+    @Override
+    public Collection<Form> getUserAttributes() {
+
+        // Add any custom attributes to any previously defined attributes
+        return Collections.unmodifiableCollection(Stream.concat(
+                super.getUserAttributes().stream(),
+                attributeService.getUserAttributes().stream()
+        ).collect(Collectors.toList()));
+
+    }
+
+    @Override
+    public Collection<Form> getUserPreferenceAttributes() {
+
+        // Add any custom preference attributes to any previously defined attributes
+        return Collections.unmodifiableCollection(Stream.concat(
+                super.getUserPreferenceAttributes().stream(),
+                attributeService.getUserPreferenceAttributes().stream()
+        ).collect(Collectors.toList()));
+
+    }
+
+    @Override
+    public Collection<Form> getConnectionAttributes() {
+
+        // Add any custom attributes to any previously defined attributes
+        return Collections.unmodifiableCollection(Stream.concat(
+                super.getConnectionAttributes().stream(),
+                attributeService.getConnectionAttributes().stream()
+        ).collect(Collectors.toList()));
+
+    }
+
+    @Override
+    public Collection<Form> getConnectionGroupAttributes() {
+
+        // Add any custom attributes to any previously defined attributes
+        return Collections.unmodifiableCollection(Stream.concat(
+                super.getConnectionGroupAttributes().stream(),
+                attributeService.getConnectionGroupAttributes().stream()
+        ).collect(Collectors.toList()));
+
     }
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/user/VaultUserContext.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/src/main/java/org/apache/guacamole/vault/user/VaultUserContext.java
@@ -241,7 +241,7 @@ public class VaultUserContext extends TokenInjectingUserContext {
      *
      * @throws GuacamoleException
      *     If the value for any applicable secret cannot be retrieved from the
-     *     vault due to an error.1
+     *     vault due to an error.
      */
     private Map<String, Future<String>> getTokens(
             Connectable connectable, Map<String, String> tokenMapping,

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/GuacamoleExceptionSupplier.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/GuacamoleExceptionSupplier.java
@@ -39,4 +39,5 @@ public abstract class GuacamoleExceptionSupplier<T> {
      *    If an error occurs while attemping to calculate the return value.
      */
     public abstract T get() throws GuacamoleException;
+
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/GuacamoleExceptionSupplier.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/GuacamoleExceptionSupplier.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.vault.ksm;
+
+import org.apache.guacamole.GuacamoleException;
+
+/**
+ * A class that is basically equivalent to the standard Supplier class in
+ * Java, except that the get() function can throw GuacamoleException, which
+ * is impossible with any of the standard Java lambda type classes, since
+ * none of them can handle checked exceptions
+ */
+public abstract class GuacamoleExceptionSupplier<T> {
+
+    /**
+     * Returns a value of the declared type.
+     *
+     * @return
+     *    A value of the declared type.
+     *
+     * @throws GuacamoleException
+     *    If an error occurs while attemping to calculate the return value.
+     */
+    public abstract T get() throws GuacamoleException;
+}

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/GuacamoleExceptionSupplier.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/GuacamoleExceptionSupplier.java
@@ -26,8 +26,12 @@ import org.apache.guacamole.GuacamoleException;
  * Java, except that the get() function can throw GuacamoleException, which
  * is impossible with any of the standard Java lambda type classes, since
  * none of them can handle checked exceptions
+ *
+ * @param <T>
+ *     The type of object which will be returned as a result of calling
+ *     get().
  */
-public abstract class GuacamoleExceptionSupplier<T> {
+public interface GuacamoleExceptionSupplier<T> {
 
     /**
      * Returns a value of the declared type.
@@ -38,6 +42,6 @@ public abstract class GuacamoleExceptionSupplier<T> {
      * @throws GuacamoleException
      *    If an error occurs while attemping to calculate the return value.
      */
-    public abstract T get() throws GuacamoleException;
+    public T get() throws GuacamoleException;
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/KsmAuthenticationProviderModule.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/KsmAuthenticationProviderModule.java
@@ -57,6 +57,7 @@ public class KsmAuthenticationProviderModule
 
         // Bind services specific to Keeper Secrets Manager
         bind(KsmRecordService.class);
+        bind(KsmAttributeService.class);
         bind(VaultAttributeService.class).to(KsmAttributeService.class);
         bind(VaultConfigurationService.class).to(KsmConfigurationService.class);
         bind(VaultSecretService.class).to(KsmSecretService.class);

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/KsmAuthenticationProviderModule.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/KsmAuthenticationProviderModule.java
@@ -24,7 +24,10 @@ import org.apache.guacamole.vault.VaultAuthenticationProviderModule;
 import org.apache.guacamole.vault.ksm.conf.KsmAttributeService;
 import org.apache.guacamole.vault.ksm.conf.KsmConfigurationService;
 import org.apache.guacamole.vault.ksm.secret.KsmSecretService;
+import org.apache.guacamole.vault.ksm.user.KsmConnectionGroup;
 import org.apache.guacamole.vault.ksm.user.KsmDirectoryService;
+import org.apache.guacamole.vault.ksm.user.KsmUserFactory;
+import org.apache.guacamole.vault.ksm.user.KsmUser;
 import org.apache.guacamole.vault.conf.VaultAttributeService;
 import org.apache.guacamole.vault.conf.VaultConfigurationService;
 import org.apache.guacamole.vault.ksm.secret.KsmClient;
@@ -67,6 +70,11 @@ public class KsmAuthenticationProviderModule
         install(new FactoryModuleBuilder()
                 .implement(KsmClient.class, KsmClient.class)
                 .build(KsmClientFactory.class));
+
+        // Bind factory for creating KsmUsers
+        install(new FactoryModuleBuilder()
+                .implement(KsmUser.class, KsmUser.class)
+                .build(KsmUserFactory.class));
     }
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
@@ -23,10 +23,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.form.TextField;
 import org.apache.guacamole.vault.conf.VaultAttributeService;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 /**
@@ -36,28 +39,81 @@ import com.google.inject.Singleton;
 @Singleton
 public class KsmAttributeService implements VaultAttributeService {
 
+
+    @Inject
+    private KsmConfigurationService configurationService;
+
     /**
      * The name of the attribute which can contain a KSM configuration blob
-     * associated with a connection group.
+     * associated with either a connection group or user.
      */
     public static final String KSM_CONFIGURATION_ATTRIBUTE = "ksm-config";
 
     /**
      * All attributes related to configuring the KSM vault on a
-     * per-connection-group basis.
+     * per-connection-group or per-user basis.
      */
     public static final Form KSM_CONFIGURATION_FORM = new Form("ksm-config",
             Arrays.asList(new TextField(KSM_CONFIGURATION_ATTRIBUTE)));
 
     /**
-     * All KSM-specific connection group attributes, organized by form.
+     * All KSM-specific attributes for users or connection groups, organized by form.
      */
-    public static final Collection<Form> KSM_CONNECTION_GROUP_ATTRIBUTES =
+    public static final Collection<Form> KSM_ATTRIBUTES =
             Collections.unmodifiableCollection(Arrays.asList(KSM_CONFIGURATION_FORM));
+
+    /**
+     * The name of the attribute which can controls whether a KSM user configuration
+     * is enabled on a connection-by-connection basis.
+     */
+    public static final String KSM_USER_CONFIG_ENABLED_ATTRIBUTE = "ksm-user-config-enabled";
+
+    /**
+     * The string value used by KSM attributes to represent the boolean value "true".
+     */
+    public static final String TRUTH_VALUE = "true";
+
+    /**
+     * All attributes related to configuring the KSM vault on a per-connection basis.
+     */
+    public static final Form KSM_CONNECTION_FORM = new Form("ksm-config",
+            Arrays.asList(new BooleanField(KSM_USER_CONFIG_ENABLED_ATTRIBUTE, TRUTH_VALUE)));
+
+    /**
+     * All KSM-specific attributes for connections, organized by form.
+     */
+    public static final Collection<Form> KSM_CONNECTION_ATTRIBUTES =
+            Collections.unmodifiableCollection(Arrays.asList(KSM_CONNECTION_FORM));
+
+    @Override
+    public Collection<Form> getConnectionAttributes() {
+        return KSM_CONNECTION_ATTRIBUTES;
+    }
 
     @Override
     public Collection<Form> getConnectionGroupAttributes() {
-        return KSM_CONNECTION_GROUP_ATTRIBUTES;
+        return KSM_ATTRIBUTES;
     }
+
+    @Override
+    public Collection<Form> getUserAttributes() {
+        return KSM_ATTRIBUTES;
+    }
+
+    @Override
+    public Collection<Form> getUserPreferenceAttributes() {
+
+        try {
+
+            // Expose the user attributes IFF user-level KSM configuration is enabled
+            return configurationService.getAllowUserConfig() ? KSM_ATTRIBUTES : Collections.emptyList();
+
+        } catch (GuacamoleException e) {
+
+            // If the configuration can't be parsed, default to not exposing the attribute
+            return Collections.emptyList();
+        }
+    }
+
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
@@ -28,6 +28,8 @@ import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.form.TextField;
 import org.apache.guacamole.vault.conf.VaultAttributeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -39,7 +41,14 @@ import com.google.inject.Singleton;
 @Singleton
 public class KsmAttributeService implements VaultAttributeService {
 
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(KsmAttributeService.class);
 
+    /**
+     * Service for retrieving KSM configuration details.
+     */
     @Inject
     private KsmConfigurationService configurationService;
 
@@ -57,7 +66,7 @@ public class KsmAttributeService implements VaultAttributeService {
             Arrays.asList(new TextField(KSM_CONFIGURATION_ATTRIBUTE)));
 
     /**
-     * All KSM-specific attributes for users or connection groups, organized by form.
+     * All KSM-specific attributes for users, connections, or connection groups, organized by form.
      */
     public static final Collection<Form> KSM_ATTRIBUTES =
             Collections.unmodifiableCollection(Arrays.asList(KSM_CONFIGURATION_FORM));
@@ -108,7 +117,16 @@ public class KsmAttributeService implements VaultAttributeService {
             // Expose the user attributes IFF user-level KSM configuration is enabled
             return configurationService.getAllowUserConfig() ? KSM_ATTRIBUTES : Collections.emptyList();
 
-        } catch (GuacamoleException e) {
+        }
+
+        catch (GuacamoleException e) {
+
+            logger.warn(
+                    "Unable to determine if user preference attributes "
+                    + "should be exposed due to config parsing error: {}.", e.getMessage());
+            logger.debug(
+                    "Config parsing error prevented checking user preference configuration",
+                    e);
 
             // If the configuration can't be parsed, default to not exposing the attribute
             return Collections.emptyList();

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
@@ -19,20 +19,30 @@
 
 package org.apache.guacamole.vault.ksm.conf;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.form.BooleanField;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.form.TextField;
+import org.apache.guacamole.language.TranslatableGuacamoleClientException;
 import org.apache.guacamole.vault.conf.VaultAttributeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.keepersecurity.secretsManager.core.InMemoryStorage;
+import com.keepersecurity.secretsManager.core.SecretsManager;
+import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
 
 /**
  * A service that exposes KSM-specific attributes, allowing setting KSM
@@ -53,10 +63,39 @@ public class KsmAttributeService implements VaultAttributeService {
     private KsmConfigurationService configurationService;
 
     /**
+     * A singleton ObjectMapper for converting a Map to a JSON string when
+     * generating a base64-encoded JSON KSM config blob.
+     */
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * All expected fields in the KSM configuration JSON blob.
+     */
+    private static final List<String> EXPECTED_KSM_FIELDS = (
+            Collections.unmodifiableList(Arrays.asList(
+                    SecretsManager.KEY_HOSTNAME,
+                    SecretsManager.KEY_CLIENT_ID,
+                    SecretsManager.KEY_PRIVATE_KEY,
+                    SecretsManager.KEY_CLIENT_KEY,
+                    SecretsManager.KEY_APP_KEY,
+                    SecretsManager.KEY_OWNER_PUBLIC_KEY,
+                    SecretsManager.KEY_SERVER_PUBIC_KEY_ID
+    )));
+
+    /**
      * The name of the attribute which can contain a KSM configuration blob
      * associated with either a connection group or user.
      */
     public static final String KSM_CONFIGURATION_ATTRIBUTE = "ksm-config";
+
+    /**
+     * The KSM configuration attribute contains sensitive information, so it
+     * should not be exposed through the directory. Instead, if a value is
+     * set on the attributes of an object, the following value will be exposed
+     * in its place, and correspondingly the underlying value will not be
+     * changed if this value is provided to an update call.
+     */
+    public static final String KSM_ATTRIBUTE_PLACEHOLDER_VALUE = "**********";
 
     /**
      * All attributes related to configuring the KSM vault on a
@@ -131,6 +170,182 @@ public class KsmAttributeService implements VaultAttributeService {
             // If the configuration can't be parsed, default to not exposing the attribute
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Sanitize the value of the provided KSM config attribute. If the provided
+     * config value is non-empty, it will be replaced with the placeholder
+     * value to avoid leaking sensitive information. If the value is empty, it
+     * will be replaced by `null`.
+     *
+     * @param ksmAttributeValue
+     *    The KSM configuration attribute value to sanitize.
+     *
+     * @return
+     *    The sanitized KSM configuration attribute value, stripped of any
+     *    sensitive information.
+     */
+    public static String sanitizeKsmAttributeValue(String ksmAttributeValue) {
+
+        // Any non-empty values may contain sensitive information, and should
+        // be replaced by the safe placeholder value
+        if (ksmAttributeValue != null && !ksmAttributeValue.trim().isEmpty())
+            return KSM_ATTRIBUTE_PLACEHOLDER_VALUE;
+
+        // If the configuration value is empty, expose a null value
+        else
+            return null;
+
+    }
+
+    /**
+     * Return true if the provided input is a valid base64-encoded string,
+     * false otherwise.
+     *
+     * @param input
+     *     The string to check if base-64 encoded.
+     *
+     * @return
+     *     true if the provided input is a valid base64-encoded string,
+     *     false otherwise.
+     */
+    private static boolean isBase64(String input) {
+
+        try {
+            Base64.getDecoder().decode(input);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Given a map of attribute values, check for the presence of the
+     * KSM_CONFIGURATION_ATTRIBUTE attribute. If it's set, check if it's a valid
+     * KSM one-time token. If so, attempt to translate it to a base-64-encoded
+     * json KSM config blob. If it's already a KSM config blob, validate it as
+     * config blob. If either validation fails, a GuacamoleException will be thrown.
+     * The processed attribute values will be returned.
+     *
+     * @param attributes
+     *     The attributes for which the KSM configuration attribute
+     *     parsing/validation should be performed.
+     *
+     * @throws GuacamoleException
+     *     If the KSM_CONFIGURATION_ATTRIBUTE is set, but fails to validate as
+     *     either a KSM one-time-token, or a KSM base64-encoded JSON config blob.
+     */
+    public Map<String, String> processAttributes(
+            Map<String, String> attributes) throws GuacamoleException {
+
+        // Get the value of the KSM config attribute in the provided map
+        String ksmConfigValue = attributes.get(
+                KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE);
+
+        // If the placeholder value was provided, do not update the attribute
+        if (KsmAttributeService.KSM_ATTRIBUTE_PLACEHOLDER_VALUE.equals(ksmConfigValue)) {
+
+            // Remove the attribute from the map so it won't be updated
+            attributes = new HashMap<>(attributes);
+            attributes.remove(KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE);
+
+        }
+
+        // Check if the attribute is set to a non-empty value
+        else if (ksmConfigValue != null && !ksmConfigValue.trim().isEmpty()) {
+
+            // If it's already base64-encoded, it's a KSM configuration blob,
+            // so validate it immediately
+            if (isBase64(ksmConfigValue)) {
+
+                // Attempt to validate the config as a base64-econded KSM config blob
+                try {
+                    KsmConfig.parseKsmConfig(ksmConfigValue);
+
+                    // If it validates, the entity can be left alone - it's already valid
+                    return attributes;
+                }
+
+                catch (GuacamoleException exception) {
+
+                    // If the parsing attempt fails, throw a translatable error for display
+                    // on the frontend
+                    throw new TranslatableGuacamoleClientException(
+                            "Invalid base64-encoded JSON KSM config provided for "
+                            + KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE + " attribute",
+                            "CONNECTION_GROUP_ATTRIBUTES.ERROR_INVALID_KSM_CONFIG_BLOB",
+                            exception);
+                }
+            }
+
+            // It wasn't a valid base64-encoded string, it should be a one-time token, so
+            // attempt to validat it as such, and if valid, update the attribute to the
+            // base64 config blob generated by the token
+            try {
+
+                // Create an initially empty storage to be populated using the one-time token
+                InMemoryStorage storage = new InMemoryStorage();
+
+                // Populate the in-memory storage using the one-time-token
+                SecretsManager.initializeStorage(storage, ksmConfigValue, null);
+
+                // Create an options object using the values we extracted from the one-time token
+                SecretsManagerOptions options = new SecretsManagerOptions(
+                    storage, null,
+                    configurationService.getAllowUnverifiedCertificate());
+
+                // Attempt to fetch secrets using the options we created. This will both validate
+                // that the configuration works, and potentially populate missing fields that the
+                // initializeStorage() call did not set.
+                SecretsManager.getSecrets(options);
+
+                // Create a map to store the extracted values from the KSM storage
+                Map<String, String> configMap = new HashMap<>();
+
+                // Go through all the expected fields, extract from the KSM storage,
+                // and write to the newly created map
+                EXPECTED_KSM_FIELDS.forEach(configKey -> {
+
+                    // Only write the value into the new map if non-null
+                    String value = storage.getString(configKey);
+                    if (value != null)
+                        configMap.put(configKey, value);
+
+                });
+
+                // JSON-encode the value, and then base64 encode that to get the format
+                // that KSM would expect
+                String jsonString = objectMapper.writeValueAsString(configMap);
+                String base64EncodedJson = Base64.getEncoder().encodeToString(
+                        jsonString.getBytes(StandardCharsets.UTF_8));
+
+                // Finally, try to parse the newly generated token as a KSM config. If this
+                // works, the config should be fully functional
+                KsmConfig.parseKsmConfig(base64EncodedJson);
+
+                // Make a copy of the existing attributes, modifying just the value for
+                // KSM_CONFIGURATION_ATTRIBUTE
+                attributes = new HashMap<>(attributes);
+                attributes.put(
+                        KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE, base64EncodedJson);
+
+            }
+
+            // The KSM SDK only throws raw Exceptions, so we can't be more specific
+            catch (Exception exception) {
+
+                // If the parsing attempt fails, throw a translatable error for display
+                // on the frontend
+                throw new TranslatableGuacamoleClientException(
+                        "Invalid one-time KSM token provided for "
+                        + KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE + " attribute",
+                        "CONNECTION_GROUP_ATTRIBUTES.ERROR_INVALID_KSM_ONE_TIME_TOKEN",
+                        exception);
+            }
+        }
+
+        return attributes;
+
     }
 
 

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
@@ -85,6 +85,17 @@ public class KsmConfigurationService extends VaultConfigurationService {
     };
 
     /**
+     * Whether users should be able to supply their own KSM configurations.
+     */
+    private static final BooleanGuacamoleProperty ALLOW_USER_CONFIG = new BooleanGuacamoleProperty() {
+
+        @Override
+        public String getName() {
+            return "ksm-allow-user-config";
+        }
+    };
+
+    /**
      * Whether windows domains should be stripped off from usernames that are
      * read from the KSM vault.
      */
@@ -136,6 +147,21 @@ public class KsmConfigurationService extends VaultConfigurationService {
      */
     public boolean getAllowUnverifiedCertificate() throws GuacamoleException {
         return environment.getProperty(ALLOW_UNVERIFIED_CERT, false);
+    }
+
+    /**
+     * Return whether users should be able to provide their own KSM configs.
+     *
+     * @return
+     *     true if users should be able to provide their own KSM configs,
+     *     false otherwise.
+     *
+     * @throws GuacamoleException
+     *     If the value specified within guacamole.properties cannot be
+     *     parsed.
+     */
+    public boolean getAllowUserConfig() throws GuacamoleException {
+        return environment.getProperty(ALLOW_USER_CONFIG, false);
     }
 
     @Override

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
@@ -605,7 +605,7 @@ public class KsmClient {
      * value of a specific field, custom field, or file associated with a
      * specific record. See: https://docs.keeper.io/secrets-manager/secrets-manager/about/keeper-notation
      * If a fallbackFunction is provided, it will be invoked to generate
-     * a return value in the case where no secrest is found with the given
+     * a return value in the case where no secret is found with the given
      * keeper notation.
      *
      * @param notation

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,10 +44,12 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.vault.ksm.conf.KsmConfigurationService;
 import org.apache.guacamole.vault.secret.WindowsUsername;
+import org.apache.guacamole.vault.ksm.GuacamoleExceptionSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -595,6 +596,38 @@ public class KsmClient {
      *     is invalid.
      */
     public Future<String> getSecret(String notation) throws GuacamoleException {
+        return getSecret(notation, null);
+    }
+
+    /**
+     * Returns the value of the secret stored within Keeper Secrets Manager and
+     * represented by the given Keeper notation. Keeper notation locates the
+     * value of a specific field, custom field, or file associated with a
+     * specific record. See: https://docs.keeper.io/secrets-manager/secrets-manager/about/keeper-notation
+     * If a fallbackFunction is provided, it will be invoked to generate
+     * a return value in the case where no secrest is found with the given
+     * keeper notation.
+     *
+     * @param notation
+     *     The Keeper notation of the secret to retrieve.
+     *
+     * @param fallbackFunction
+     *     A function to invoke in order to produce a Future for return,
+     *     if the requested secret is not found. If the provided Function
+     *     is null, it will not be run.
+     *
+     * @return
+     *     A Future which completes with the value of the secret represented by
+     *     the given Keeper notation, or null if there is no such secret.
+     *
+     * @throws GuacamoleException
+     *     If the requested secret cannot be retrieved or the Keeper notation
+     *     is invalid.
+     */
+    public Future<String> getSecret(
+            String notation,
+            @Nullable GuacamoleExceptionSupplier<Future<String>> fallbackFunction)
+            throws GuacamoleException {
         validateCache();
         cacheLock.readLock().lock();
         try {
@@ -614,6 +647,11 @@ public class KsmClient {
         catch (Error e) {
             logger.warn("Record \"{}\" does not exist.", notation);
             logger.debug("Retrieval of record by Keeper notation failed.", e);
+
+            // If the secret is not found, invoke the fallback function
+            if (fallbackFunction != null)
+                return fallbackFunction.get();
+
             return CompletableFuture.completedFuture(null);
         }
 

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnection.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnection.java
@@ -19,24 +19,20 @@
 
 package org.apache.guacamole.vault.ksm.user;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.guacamole.net.auth.DelegatingConnection;
+import org.apache.guacamole.vault.ksm.conf.KsmAttributeService;
 import org.apache.guacamole.net.auth.Connection;
 
 import com.google.common.collect.Maps;
 
 /**
- * A Connection that explicitly adds a blank entry for any defined
- * KSM connection attributes.
+ * A Connection that explicitly adds a blank entry for any defined KSM
+ * connection attributes. This ensures that any such field will always
+ * be displayed to the user when editing a connection through the UI.
  */
 public class KsmConnection extends DelegatingConnection {
-
-    /**
-     * The names of all connection attributes defined for the vault.
-     */
-    private List<String> connectionAttributeNames;
 
     /**
      * Create a new Vault connection wrapping the provided Connection record. Any
@@ -45,15 +41,9 @@ public class KsmConnection extends DelegatingConnection {
      *
      * @param connection
      *     The connection record to wrap.
-     *
-     * @param connectionAttributeNames
-     *     The names of all connection attributes to automatically expose.
      */
-    KsmConnection(Connection connection, List<String> connectionAttributeNames) {
-
+    KsmConnection(Connection connection) {
         super(connection);
-        this.connectionAttributeNames = connectionAttributeNames;
-
     }
 
     /**
@@ -70,13 +60,12 @@ public class KsmConnection extends DelegatingConnection {
     public Map<String, String> getAttributes() {
 
         // Make a copy of the existing map
-        Map<String, String> attributeMap = Maps.newHashMap(super.getAttributes());
+        Map<String, String> attributes = Maps.newHashMap(super.getAttributes());
 
-        // Add every defined attribute
-        connectionAttributeNames.forEach(
-                attributeName -> attributeMap.putIfAbsent(attributeName, null));
+        // Add the configuration attribute
+        attributes.putIfAbsent(KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE, null);
+        return attributes;
 
-        return attributeMap;
     }
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnection.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnection.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.vault.ksm.user;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.guacamole.net.auth.DelegatingConnection;
+import org.apache.guacamole.net.auth.Connection;
+
+import com.google.common.collect.Maps;
+
+/**
+ * A Connection that explicitly adds a blank entry for any defined
+ * KSM connection attributes.
+ */
+public class KsmConnection extends DelegatingConnection {
+
+    /**
+     * The names of all connection attributes defined for the vault.
+     */
+    private List<String> connectionAttributeNames;
+
+    /**
+     * Create a new Vault connection wrapping the provided Connection record. Any
+     * attributes defined in the provided connection attribute forms will have empty
+     * values automatically populated when getAttributes() is called.
+     *
+     * @param connection
+     *     The connection record to wrap.
+     *
+     * @param connectionAttributeNames
+     *     The names of all connection attributes to automatically expose.
+     */
+    KsmConnection(Connection connection, List<String> connectionAttributeNames) {
+
+        super(connection);
+        this.connectionAttributeNames = connectionAttributeNames;
+
+    }
+
+    /**
+     * Return the underlying wrapped connection record.
+     *
+     * @return
+     *     The wrapped connection record.
+     */
+    Connection getUnderlyingConnection() {
+        return getDelegateConnection();
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+
+        // Make a copy of the existing map
+        Map<String, String> attributeMap = Maps.newHashMap(super.getAttributes());
+
+        // Add every defined attribute
+        connectionAttributeNames.forEach(
+                attributeName -> attributeMap.putIfAbsent(attributeName, null));
+
+        return attributeMap;
+    }
+
+}

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnection.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnection.java
@@ -62,10 +62,9 @@ public class KsmConnection extends DelegatingConnection {
         // Make a copy of the existing map
         Map<String, String> attributes = Maps.newHashMap(super.getAttributes());
 
-        // Add the configuration attribute
-        attributes.putIfAbsent(KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE, null);
+        // Add the user-config-enabled configuration attribute
+        attributes.putIfAbsent(KsmAttributeService.KSM_USER_CONFIG_ENABLED_ATTRIBUTE, null);
         return attributes;
-
     }
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnectionGroup.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmConnectionGroup.java
@@ -19,12 +19,13 @@
 
 package org.apache.guacamole.vault.ksm.user;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.DelegatingConnectionGroup;
 import org.apache.guacamole.vault.ksm.conf.KsmAttributeService;
+
+import com.google.common.collect.Maps;
 
  /**
   * A KSM-specific connection group implementation that always exposes
@@ -50,17 +51,11 @@ import org.apache.guacamole.vault.ksm.conf.KsmAttributeService;
     @Override
     public Map<String, String> getAttributes() {
 
-        // All attributes defined on the underlying connection group
-        Map<String, String> attributes = super.getAttributes();
+        // Make a copy of the existing map
+        Map<String, String> attributes = Maps.newHashMap(super.getAttributes());
 
-        // If the attribute is already present, there's no need to add it - return
-        // the existing attributes as they are
-        if (attributes.containsKey(KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE))
-            return attributes;
-
-        // Make a copy of the existing attributes and add KSM_CONFIGURATION_ATTRIBUTE
-        attributes = new HashMap<>(attributes);
-        attributes.put(KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE, null);
+        // Add the configuration attribute
+        attributes.putIfAbsent(KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE, null);
         return attributes;
 
     }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmDirectory.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmDirectory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.vault.ksm.user;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.DelegatingDirectory;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Identifiable;
+
+/**
+ * A KSM-specific version of DecoratingDirectory that exposes the underlying
+ * directory for when it's needed.
+ */
+public abstract class KsmDirectory<ObjectType extends Identifiable>
+        extends DelegatingDirectory<ObjectType> {
+
+    /**
+     * Create a new KsmDirectory, delegating to the provided directory.
+     *
+     * @param directory
+     *    The directory to delegate to.
+     */
+    public KsmDirectory(Directory<ObjectType> directory) {
+        super(directory);
+    }
+
+    /**
+     * Returns the underlying directory that this DecoratingDirectory is
+     * delegating to.
+     *
+     * @return
+     *    The underlying directory.
+     */
+    public Directory<ObjectType> getUnderlyingDirectory() {
+        return getDelegateDirectory();
+    }
+
+    /**
+     * Process and return a potentially-modified version of the object
+     * with the same identifier in the wrapped directory.
+     *
+     * @param object
+     *     The object from the underlying directory.
+     *
+     * @return
+     *     A potentially-modified version of the object with the same
+     *     identifier in the wrapped directory.
+     */
+    protected abstract ObjectType wrap(ObjectType object);
+
+    @Override
+    public ObjectType get(String identifier) throws GuacamoleException {
+
+        // Process and return the object from the wrapped directory
+        return wrap(super.get(identifier));
+
+    }
+
+    @Override
+    public Collection<ObjectType> getAll(Collection<String> identifiers)
+            throws GuacamoleException {
+
+        // Process and return each object from the wrapped directory
+        return super.getAll(identifiers).stream().map(
+                superObject -> wrap(superObject)
+                ).collect(Collectors.toList());
+
+    }
+
+}

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmDirectoryService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmDirectoryService.java
@@ -19,32 +19,17 @@
 
 package org.apache.guacamole.vault.ksm.user;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.guacamole.GuacamoleException;
-import org.apache.guacamole.language.TranslatableGuacamoleClientException;
-import org.apache.guacamole.net.auth.Attributes;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.DecoratingDirectory;
+import org.apache.guacamole.net.auth.DelegatingDirectory;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.vault.ksm.conf.KsmAttributeService;
-import org.apache.guacamole.vault.ksm.conf.KsmConfig;
-import org.apache.guacamole.vault.ksm.conf.KsmConfigurationService;
 import org.apache.guacamole.vault.user.VaultDirectoryService;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
-import com.keepersecurity.secretsManager.core.InMemoryStorage;
-import com.keepersecurity.secretsManager.core.SecretsManager;
-import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
 
 /**
  * A KSM-specific vault directory service that wraps the connection group directory
@@ -54,175 +39,17 @@ import com.keepersecurity.secretsManager.core.SecretsManagerOptions;
 public class KsmDirectoryService extends VaultDirectoryService {
 
     /**
-     * Service for retrieving KSM configuration details.
+     * A factory for constructing new KsmUser instances.
      */
     @Inject
-    private KsmConfigurationService configurationService;
+    private KsmUserFactory ksmUserFactory;
 
     /**
-     * A singleton ObjectMapper for converting a Map to a JSON string when
-     * generating a base64-encoded JSON KSM config blob.
+     * Service for retrieving any custom attributes defined for the
+     * current vault implementation and processing of said attributes.
      */
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    /**
-     * All expected fields in the KSM configuration JSON blob.
-     */
-    private static final List<String> EXPECTED_KSM_FIELDS = (
-            Collections.unmodifiableList(Arrays.asList(
-                    SecretsManager.KEY_HOSTNAME,
-                    SecretsManager.KEY_CLIENT_ID,
-                    SecretsManager.KEY_PRIVATE_KEY,
-                    SecretsManager.KEY_CLIENT_KEY,
-                    SecretsManager.KEY_APP_KEY,
-                    SecretsManager.KEY_OWNER_PUBLIC_KEY,
-                    SecretsManager.KEY_SERVER_PUBIC_KEY_ID
-    )));
-
-    /**
-     * Return true if the provided input is a valid base64-encoded string,
-     * false otherwise.
-     *
-     * @param input
-     *     The string to check if base-64 encoded.
-     *
-     * @return
-     *     true if the provided input is a valid base64-encoded string,
-     *     false otherwise.
-     */
-    private static boolean isBase64(String input) {
-
-        try {
-            Base64.getDecoder().decode(input);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
-    }
-
-    /**
-     * Given an attributes-enabled entity, check for the presence of the
-     * KSM_CONFIGURATION_ATTRIBUTE attribute. If it's set, check if it's a valid
-     * KSM one-time token. If so, attempt to translate it to a base-64-encoded
-     * json KSM config blob, and set it back to the provided entity.
-     * If it's already a KSM config blob, validate it as config blob. If either
-     * validation fails, a GuacamoleException will be thrown.
-     *
-     * @param entity
-     *     The attributes-enabled entity for which the KSM configuration
-     *     attribute parsing/validation should be performed.
-     *
-     * @throws GuacamoleException
-     *     If the KSM_CONFIGURATION_ATTRIBUTE is set, but fails to validate as
-     *     either a KSM one-time-token, or a KSM base64-encoded JSON config blob.
-     */
-    public void processAttributes(Attributes entity) throws GuacamoleException {
-
-        // By default, if the KSM config attribute isn't being set, pass the
-        // provided attributes through without any changes
-        Map<String, String> attributes = entity.getAttributes();
-
-        // Get the value of the KSM config attribute in the provided map
-        String ksmConfigValue = attributes.get(
-                KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE);
-
-        // Check if the attribute is set to a non-empty value
-        if (ksmConfigValue != null && !ksmConfigValue.trim().isEmpty()) {
-
-            // If it's already base64-encoded, it's a KSM configuration blob,
-            // so validate it immediately
-            if (isBase64(ksmConfigValue)) {
-
-                // Attempt to validate the config as a base64-econded KSM config blob
-                try {
-                    KsmConfig.parseKsmConfig(ksmConfigValue);
-
-                    // If it validates, the entity can be left alone - it's already valid
-                    return;
-                }
-
-                catch (GuacamoleException exception) {
-
-                    // If the parsing attempt fails, throw a translatable error for display
-                    // on the frontend
-                    throw new TranslatableGuacamoleClientException(
-                            "Invalid base64-encoded JSON KSM config provided for "
-                            + KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE + " attribute",
-                            "CONNECTION_GROUP_ATTRIBUTES.ERROR_INVALID_KSM_CONFIG_BLOB",
-                            exception);
-                }
-            }
-
-            // It wasn't a valid base64-encoded string, it should be a one-time token, so
-            // attempt to validat it as such, and if valid, update the attribute to the
-            // base64 config blob generated by the token
-            try {
-
-                // Create an initially empty storage to be populated using the one-time token
-                InMemoryStorage storage = new InMemoryStorage();
-
-                // Populate the in-memory storage using the one-time-token
-                SecretsManager.initializeStorage(storage, ksmConfigValue, null);
-
-                // Create an options object using the values we extracted from the one-time token
-                SecretsManagerOptions options = new SecretsManagerOptions(
-                    storage, null,
-                    configurationService.getAllowUnverifiedCertificate());
-
-                // Attempt to fetch secrets using the options we created. This will both validate
-                // that the configuration works, and potentially populate missing fields that the
-                // initializeStorage() call did not set.
-                SecretsManager.getSecrets(options);
-
-                // Create a map to store the extracted values from the KSM storage
-                Map<String, String> configMap = new HashMap<>();
-
-                // Go through all the expected fields, extract from the KSM storage,
-                // and write to the newly created map
-                EXPECTED_KSM_FIELDS.forEach(configKey -> {
-
-                    // Only write the value into the new map if non-null
-                    String value = storage.getString(configKey);
-                    if (value != null)
-                        configMap.put(configKey, value);
-
-                });
-
-                // JSON-encode the value, and then base64 encode that to get the format
-                // that KSM would expect
-                String jsonString = objectMapper.writeValueAsString(configMap);
-                String base64EncodedJson = Base64.getEncoder().encodeToString(
-                        jsonString.getBytes(StandardCharsets.UTF_8));
-
-                // Finally, try to parse the newly generated token as a KSM config. If this
-                // works, the config should be fully functional
-                KsmConfig.parseKsmConfig(base64EncodedJson);
-
-                // Make a copy of the existing attributes, modifying just the value for
-                // KSM_CONFIGURATION_ATTRIBUTE
-                attributes = new HashMap<>(attributes);
-                attributes.put(
-                        KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE, base64EncodedJson);
-
-                // Set the newly updated attributes back to the original object
-                entity.setAttributes(attributes);
-
-            }
-
-            // The KSM SDK only throws raw Exceptions, so we can't be more specific
-            catch (Exception exception) {
-
-                // If the parsing attempt fails, throw a translatable error for display
-                // on the frontend
-                throw new TranslatableGuacamoleClientException(
-                        "Invalid one-time KSM token provided for "
-                        + KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE + " attribute",
-                        "CONNECTION_GROUP_ATTRIBUTES.ERROR_INVALID_KSM_ONE_TIME_TOKEN",
-                        exception);
-            }
-        }
-
-    }
+    @Inject
+    private KsmAttributeService attributeService;
 
     @Override
     public Directory<Connection> getConnectionDirectory(
@@ -259,40 +86,45 @@ public class KsmDirectoryService extends VaultDirectoryService {
         // validate KSM configurations, and translate one-time-tokens, if possible,
         // as well as ensuring that all ConnectionGroups returned include the
         // KSM_CONFIGURATION_ATTRIBUTE attribute, so it will be available in the UI.
-        return new DecoratingDirectory<ConnectionGroup>(underlyingDirectory) {
+        // The value of the KSM_CONFIGURATION_ATTRIBUTE will be sanitized if set.
+        return new KsmDirectory<ConnectionGroup>(underlyingDirectory) {
 
             @Override
             public void add(ConnectionGroup connectionGroup) throws GuacamoleException {
 
-                // Check for the KSM config attribute and translate the one-time token
-                // if possible before adding
-                processAttributes(connectionGroup);
+                // Process attribute values before saving
+                connectionGroup.setAttributes(
+                    attributeService.processAttributes(
+                        connectionGroup.getAttributes()));
+
                 super.add(connectionGroup);
             }
 
             @Override
             public void update(ConnectionGroup connectionGroup) throws GuacamoleException {
 
-                // Check for the KSM config attribute and translate the one-time token
-                // if possible before updating
-                processAttributes(connectionGroup);
+                // Unwrap the existing ConnectionGroup
+                if (connectionGroup instanceof KsmConnectionGroup)
+                    connectionGroup = ((KsmConnectionGroup) connectionGroup).getUnderlyingConnectionGroup();
+
+                // Process attribute values before saving
+                connectionGroup.setAttributes(
+                    attributeService.processAttributes(
+                        connectionGroup.getAttributes()));
+
                 super.update(connectionGroup);
-            }
-
-            @Override
-            protected ConnectionGroup decorate(ConnectionGroup connectionGroup) throws GuacamoleException {
-
-                // Wrap the existing connection group in a KsmConnection to ensure the presence of the
-                // KSM_CONFIGURATION_ATTRIBUTE attribute
-                return new KsmConnectionGroup(connectionGroup);
 
             }
 
             @Override
-            protected ConnectionGroup undecorate(ConnectionGroup connectionGroup) throws GuacamoleException {
+            protected ConnectionGroup wrap(ConnectionGroup object) {
 
-                // Return the underlying connection group that the KsmConnectionGroup wraps
-                return ((KsmConnectionGroup) connectionGroup).getUnderlyConnectionGroup();
+                // Do not process the ConnectionGroup further if it does not exist
+                if (object == null)
+                    return null;
+
+                // Sanitize values when a ConnectionGroup is fetched from the directory
+                return new KsmConnectionGroup(object);
 
             }
 
@@ -307,40 +139,47 @@ public class KsmDirectoryService extends VaultDirectoryService {
         // validate KSM configurations, and translate one-time-tokens, if possible
         // Additionally, this directory will will decorate all users with a
         // KsmUser wrapper to ensure that all defined KSM fields will be exposed
-        // in the user attributes.
-        return new DecoratingDirectory<User>(underlyingDirectory) {
+        // in the user attributes.  The value of the KSM_CONFIGURATION_ATTRIBUTE
+        // will be sanitized if set.
+        return new KsmDirectory<User>(underlyingDirectory) {
 
             @Override
             public void add(User user) throws GuacamoleException {
 
-                // Check for the KSM config attribute and translate the one-time token
-                // if possible before adding
-                processAttributes(user);
+                // Process attribute values before saving
+                user.setAttributes(
+                    attributeService.processAttributes(
+                        user.getAttributes()));
+
                 super.add(user);
             }
 
             @Override
             public void update(User user) throws GuacamoleException {
 
-                // Check for the KSM config attribute and translate the one-time token
-                // if possible before updating
-                processAttributes(user);
+                // Unwrap the existing user
+                if (user instanceof KsmUser)
+                    user = ((KsmUser) user).getUnderlyingUser();
+
+                // Process attribute values before saving
+                user.setAttributes(
+                    attributeService.processAttributes(
+                        user.getAttributes()));
+
                 super.update(user);
+
             }
 
             @Override
-            protected User decorate(User user) throws GuacamoleException {
+            protected User wrap(User object) {
 
-                // Wrap in a KsmUser class to ensure that all defined KSM fields will be
-                // present
-                return new KsmUser(user);
-            }
+                // Do not process the user further if it does not exist
+                if (object == null)
+                    return null;
 
-            @Override
-            protected User undecorate(User user) throws GuacamoleException {
+                // Sanitize values when a user is fetched from the directory
+                return ksmUserFactory.create(object);
 
-                // Unwrap the KsmUser
-                return ((KsmUser) user).getUnderlyingUser();
             }
 
         };

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmUser.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmUser.java
@@ -19,11 +19,11 @@
 
 package org.apache.guacamole.vault.ksm.user;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.guacamole.net.auth.DelegatingUser;
 import org.apache.guacamole.net.auth.User;
+import org.apache.guacamole.vault.ksm.conf.KsmAttributeService;
 
 import com.google.common.collect.Maps;
 
@@ -34,26 +34,15 @@ import com.google.common.collect.Maps;
 public class KsmUser extends DelegatingUser {
 
     /**
-     * The names of all user attributes defined for the vault.
-     */
-    private List<String> userAttributeNames;
-
-    /**
      * Create a new Vault user wrapping the provided User record. Any
-     * attributes defined in the provided user attribute forms will have empty
-     * values automatically populated when getAttributes() is called.
+     * KSM-specific attribute forms will have empty values automatically
+     * populated when getAttributes() is called.
      *
      * @param user
      *     The user record to wrap.
-     *
-     * @param userAttributeNames
-     *     The names of all user attributes to automatically expose.
      */
-    KsmUser(User user, List<String> userAttributeNames) {
-
+    KsmUser(User user) {
         super(user);
-        this.userAttributeNames = userAttributeNames;
-
     }
 
     /**
@@ -70,13 +59,11 @@ public class KsmUser extends DelegatingUser {
     public Map<String, String> getAttributes() {
 
         // Make a copy of the existing map
-        Map<String, String> attributeMap = Maps.newHashMap(super.getAttributes());
+        Map<String, String> attributes = Maps.newHashMap(super.getAttributes());
 
-        // Add every defined attribute
-        userAttributeNames.forEach(
-                attributeName -> attributeMap.putIfAbsent(attributeName, null));
-
-        return attributeMap;
+        // Add the configuration attribute
+        attributes.putIfAbsent(KsmAttributeService.KSM_CONFIGURATION_ATTRIBUTE, null);
+        return attributes;
     }
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmUser.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmUser.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.vault.ksm.user;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.guacamole.net.auth.DelegatingUser;
+import org.apache.guacamole.net.auth.User;
+
+import com.google.common.collect.Maps;
+
+/**
+ * A User that explicitly adds a blank entry for any defined
+ * KSM user attributes.
+ */
+public class KsmUser extends DelegatingUser {
+
+    /**
+     * The names of all user attributes defined for the vault.
+     */
+    private List<String> userAttributeNames;
+
+    /**
+     * Create a new Vault user wrapping the provided User record. Any
+     * attributes defined in the provided user attribute forms will have empty
+     * values automatically populated when getAttributes() is called.
+     *
+     * @param user
+     *     The user record to wrap.
+     *
+     * @param userAttributeNames
+     *     The names of all user attributes to automatically expose.
+     */
+    KsmUser(User user, List<String> userAttributeNames) {
+
+        super(user);
+        this.userAttributeNames = userAttributeNames;
+
+    }
+
+    /**
+     * Return the underlying wrapped user record.
+     *
+     * @return
+     *     The wrapped user record.
+     */
+    User getUnderlyingUser() {
+        return getDelegateUser();
+    }
+
+    @Override
+    public Map<String, String> getAttributes() {
+
+        // Make a copy of the existing map
+        Map<String, String> attributeMap = Maps.newHashMap(super.getAttributes());
+
+        // Add every defined attribute
+        userAttributeNames.forEach(
+                attributeName -> attributeMap.putIfAbsent(attributeName, null));
+
+        return attributeMap;
+    }
+
+}

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmUserFactory.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmUserFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.vault.ksm.user;
+
+import org.apache.guacamole.net.auth.User;
+
+/**
+ * Factory for creating KSM-specific users, which wrap an underlying User.
+ */
+public interface KsmUserFactory {
+
+    /**
+     * Returns a new instance of a KsmUser, wrapping the provided underlying User.
+     *
+     * @param user
+     *     The underlying User that should be wrapped.
+     *
+     * @return
+     *     A new instance of a KsmUser, wrapping the provided underlying User.
+     */
+    KsmUser create(User user);
+
+}

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/resources/translations/en.json
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/resources/translations/en.json
@@ -4,12 +4,22 @@
         "NAME" : "Keeper Secrets Manager"
     },
 
+    "CONNECTION_ATTRIBUTES" : {
+        "SECTION_HEADER_KSM_CONFIG"            : "Keeper Secrets Manager",
+        "FIELD_HEADER_KSM_USER_CONFIG_ENABLED" : "Allow user-provided KSM configuration"
+    },
+
     "CONNECTION_GROUP_ATTRIBUTES" : {
         "SECTION_HEADER_KSM_CONFIG" : "Keeper Secrets Manager",
         "FIELD_HEADER_KSM_CONFIG"   : "KSM Service Configuration ",
 
         "ERROR_INVALID_KSM_CONFIG_BLOB"    : "The provided base64-encoded KSM configuration blob is not valid. Please ensure that you have copied the entire blob.",
         "ERROR_INVALID_KSM_ONE_TIME_TOKEN" : "The provided configuration is not a valid KSM one-time token or base64-encoded configuration blob. Please ensure that you have copied the entire token value."
+    },
+
+    "USER_ATTRIBUTES" : {
+        "SECTION_HEADER_KSM_CONFIG" : "Keeper Secrets Manager",
+        "FIELD_HEADER_KSM_CONFIG"   : "KSM Service Configuration "
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/DelegatingUserContext.java
@@ -128,6 +128,11 @@ public class DelegatingUserContext implements UserContext {
     }
 
     @Override
+    public Collection<Form> getUserPreferenceAttributes() {
+        return userContext.getUserPreferenceAttributes();
+    }
+
+    @Override
     public Collection<Form> getUserGroupAttributes() {
         return userContext.getUserGroupAttributes();
     }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/UserContext.java
@@ -20,6 +20,8 @@
 package org.apache.guacamole.net.auth;
 
 import java.util.Collection;
+import java.util.Collections;
+
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.form.Form;
 
@@ -210,6 +212,21 @@ public interface UserContext {
      *     A collection of all attributes applicable to users.
      */
     Collection<Form> getUserAttributes();
+
+    /**
+     * Retrieves a collection of user attributes, specific to the user preferences
+     * page in the UI. Unlike standard user attributes, these should be self-editable.
+     *
+     * @return
+     *     A collection of form of user attributes, specific to the user preferences
+     *     page in the UI.
+     */
+    default Collection<Form> getUserPreferenceAttributes() {
+
+        // By default, a user context does not expose any preference user attributes
+        return Collections.emptyList();
+
+    }
 
     /**
      * Retrieves a collection of all attributes applicable to user groups. This

--- a/guacamole/src/main/frontend/src/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/frontend/src/app/manage/controllers/manageUserController.js
@@ -501,6 +501,4 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         return userService.deleteUser($scope.dataSource, $scope.user);
     };
 
-    console.log($scope);
-
 }]);

--- a/guacamole/src/main/frontend/src/app/manage/controllers/manageUserController.js
+++ b/guacamole/src/main/frontend/src/app/manage/controllers/manageUserController.js
@@ -501,4 +501,6 @@ angular.module('manage').controller('manageUserController', ['$scope', '$injecto
         return userService.deleteUser($scope.dataSource, $scope.user);
     };
 
+    console.log($scope);
+
 }]);

--- a/guacamole/src/main/frontend/src/app/rest/services/schemaService.js
+++ b/guacamole/src/main/frontend/src/app/rest/services/schemaService.js
@@ -59,6 +59,34 @@ angular.module('rest').factory('schemaService', ['$injector',
     };
 
     /**
+     * Makes a request to the REST API to get the list of available user preference
+     * attributes, returning a promise that provides an array of @link{Form} objects
+     * if successful. Each element of the array describes a logical grouping of
+     * possible user preference attributes.
+     *
+     * @param {String} dataSource
+     *     The unique identifier of the data source containing the users whose
+     *     available user preference attributes are to be retrieved. This
+     *     identifier corresponds to an AuthenticationProvider within the
+     *     Guacamole web application.
+     *
+     * @returns {Promise.<Form[]>}
+     *     A promise which will resolve with an array of @link{Form}
+     *     objects, where each @link{Form} describes a logical grouping of
+     *     possible attributes.
+     */
+    service.getUserPreferenceAttributes = function getUserPreferenceAttributes(dataSource) {
+
+        // Retrieve available user attributes
+        return authenticationService.request({
+            cache   : cacheService.schema,
+            method  : 'GET',
+            url     : 'api/session/data/' + encodeURIComponent(dataSource) + '/schema/userPreferenceAttributes'
+        });
+
+    };
+
+    /**
      * Makes a request to the REST API to get the list of available attributes
      * for user group objects, returning a promise that provides an array of
      * @link{Form} objects if successful. Each element of the array describes

--- a/guacamole/src/main/frontend/src/app/settings/directives/guacSettingsPreferences.js
+++ b/guacamole/src/main/frontend/src/app/settings/directives/guacSettingsPreferences.js
@@ -59,6 +59,20 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
             };
 
             /**
+             * An action which closes the current dialog, and refreshes
+             * the user data on dialog close.
+             */
+            const ACKNOWLEDGE_ACTION_RELOAD = {
+                name        : 'SETTINGS_PREFERENCES.ACTION_ACKNOWLEDGE',
+                // Handle action
+                callback    : function acknowledgeCallback() {
+                    userService.getUser(dataSource, username)
+                        .then(user => $scope.user = user)
+                        .then(guacNotification.showStatus(false))
+                }
+            };
+
+            /**
              * The user being modified.
              *
              * @type User
@@ -237,7 +251,9 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
                         text    : {
                             key : 'SETTINGS_PREFERENCES.INFO_PREFERENCE_ATTRIBUTES_CHANGED'
                         },
-                        actions : [ ACKNOWLEDGE_ACTION ]
+
+                        // Reload the user on successful save in case any attributes changed
+                        actions : [ ACKNOWLEDGE_ACTION_RELOAD ]
                     }),
                     guacNotification.SHOW_REQUEST_ERROR);
             };

--- a/guacamole/src/main/frontend/src/app/settings/templates/settingsPreferences.html
+++ b/guacamole/src/main/frontend/src/app/settings/templates/settingsPreferences.html
@@ -90,7 +90,6 @@
     </div>
 
     <!-- User attributes section -->
-    <h2 class="header" ng-show="attributes.length">{{'SETTINGS_PREFERENCES.SECTION_HEADER_UPDATE_ATTRIBUTES' | translate}}</h2>
     <div class="attributes" ng-show="attributes.length">
         <guac-form namespace="'USER_ATTRIBUTES'" content="attributes"
                    model="user.attributes"></guac-form>

--- a/guacamole/src/main/frontend/src/app/settings/templates/settingsPreferences.html
+++ b/guacamole/src/main/frontend/src/app/settings/templates/settingsPreferences.html
@@ -89,4 +89,14 @@
         </div>
     </div>
 
+    <!-- User attributes section -->
+    <h2 class="header" ng-show="attributes.length">{{'SETTINGS_PREFERENCES.SECTION_HEADER_UPDATE_ATTRIBUTES' | translate}}</h2>
+    <div class="attributes" ng-show="attributes.length">
+        <guac-form namespace="'USER_ATTRIBUTES'" content="attributes"
+                   model="user.attributes"></guac-form>
+
+        <!-- User attributes save button -->
+        <button ng-show="attributes.length" ng-click="saveUser()" class="save">{{'SETTINGS_PREFERENCES.ACTION_SAVE' | translate}}</button>
+    </div>
+
 </div>

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -916,6 +916,7 @@
 
         "ACTION_ACKNOWLEDGE"        : "@:APP.ACTION_ACKNOWLEDGE",
         "ACTION_CANCEL"             : "@:APP.ACTION_CANCEL",
+        "ACTION_SAVE"               : "@:APP.ACTION_SAVE",
         "ACTION_UPDATE_PASSWORD"    : "@:APP.ACTION_UPDATE_PASSWORD",
 
         "DIALOG_HEADER_ERROR"    : "@:APP.DIALOG_HEADER_ERROR",
@@ -942,6 +943,7 @@
         "HELP_UPDATE_PASSWORD"      : "If you wish to change your password, enter your current password and the desired new password below, and click \"Update Password\". The change will take effect immediately.",
 
         "INFO_PASSWORD_CHANGED" : "Password changed.",
+        "INFO_PREFERENCE_ATTRIBUTES_CHANGED" : "User attributes saved.",
 
         "NAME_INPUT_METHOD_NONE" : "@:CLIENT.NAME_INPUT_METHOD_NONE",
         "NAME_INPUT_METHOD_OSK"  : "@:CLIENT.NAME_INPUT_METHOD_OSK",
@@ -949,6 +951,7 @@
 
         "SECTION_HEADER_DEFAULT_INPUT_METHOD" : "Default Input Method",
         "SECTION_HEADER_DEFAULT_MOUSE_MODE"   : "Default Mouse Emulation Mode",
+        "SECTION_HEADER_UPDATE_ATTRIBUTES"    : "User Attributes",
         "SECTION_HEADER_UPDATE_PASSWORD"      : "Change Password"
 
     },

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -951,7 +951,6 @@
 
         "SECTION_HEADER_DEFAULT_INPUT_METHOD" : "Default Input Method",
         "SECTION_HEADER_DEFAULT_MOUSE_MODE"   : "Default Mouse Emulation Mode",
-        "SECTION_HEADER_UPDATE_ATTRIBUTES"    : "User Attributes",
         "SECTION_HEADER_UPDATE_PASSWORD"      : "Change Password"
 
     },

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -943,7 +943,7 @@
         "HELP_UPDATE_PASSWORD"      : "If you wish to change your password, enter your current password and the desired new password below, and click \"Update Password\". The change will take effect immediately.",
 
         "INFO_PASSWORD_CHANGED" : "Password changed.",
-        "INFO_PREFERENCE_ATTRIBUTES_CHANGED" : "User attributes saved.",
+        "INFO_PREFERENCE_ATTRIBUTES_CHANGED" : "User settings saved.",
 
         "NAME_INPUT_METHOD_NONE" : "@:CLIENT.NAME_INPUT_METHOD_NONE",
         "NAME_INPUT_METHOD_OSK"  : "@:CLIENT.NAME_INPUT_METHOD_OSK",

--- a/guacamole/src/main/frontend/webpack.config.js
+++ b/guacamole/src/main/frontend/webpack.config.js
@@ -77,6 +77,18 @@ module.exports = {
         ]
     },
     optimization: {
+        minimizer: [
+
+            // Minify using Google Closure Compiler
+            new ClosureWebpackPlugin({ mode: 'STANDARD' }, {
+                languageIn: 'ECMASCRIPT_2020',
+                languageOut: 'ECMASCRIPT5',
+                compilationLevel: 'SIMPLE'
+            }),
+
+            new CssMinimizerPlugin()
+
+        ],
         splitChunks: {
             cacheGroups: {
 

--- a/guacamole/src/main/frontend/webpack.config.js
+++ b/guacamole/src/main/frontend/webpack.config.js
@@ -77,18 +77,6 @@ module.exports = {
         ]
     },
     optimization: {
-        minimizer: [
-
-            // Minify using Google Closure Compiler
-            new ClosureWebpackPlugin({ mode: 'STANDARD' }, {
-                languageIn: 'ECMASCRIPT_2020',
-                languageOut: 'ECMASCRIPT5',
-                compilationLevel: 'SIMPLE'
-            }),
-
-            new CssMinimizerPlugin()
-
-        ],
         splitChunks: {
             cacheGroups: {
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/schema/SchemaResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/schema/SchemaResource.java
@@ -89,7 +89,7 @@ public class SchemaResource {
      */
     @GET
     @Path("userPreferenceAttributes")
-    public Collection<Form> getUserAttrigetUserPreferenceAttributesbutes()
+    public Collection<Form> getUserPreferenceAttributes()
             throws GuacamoleException {
 
         // Retrieve all possible user preference attributes

--- a/guacamole/src/main/java/org/apache/guacamole/rest/schema/SchemaResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/schema/SchemaResource.java
@@ -78,6 +78,26 @@ public class SchemaResource {
     }
 
     /**
+     * Retrieves the possible user preference attributes of a user object.
+     *
+     * @return
+     *     A collection of forms which describe the possible preference attributes of a
+     *     user object.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while retrieving the possible attributes.
+     */
+    @GET
+    @Path("userPreferenceAttributes")
+    public Collection<Form> getUserAttrigetUserPreferenceAttributesbutes()
+            throws GuacamoleException {
+
+        // Retrieve all possible user preference attributes
+        return userContext.getUserPreferenceAttributes();
+
+    }
+
+    /**
      * Retrieves the possible attributes of a user group object.
      *
      * @return

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserObjectTranslator.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserObjectTranslator.java
@@ -59,9 +59,22 @@ public class UserObjectTranslator
     public void filterExternalObject(UserContext userContext, APIUser object)
             throws GuacamoleException {
 
-        // Filter object attributes by defined schema
-        object.setAttributes(filterAttributes(userContext.getUserAttributes(),
-                object.getAttributes()));
+        // If a user is editing themselves ...
+        if (object.getUsername().equals(userContext.self().getIdentifier())) {
+
+            // ... they may only edit preference attributes
+            object.setAttributes(filterAttributes(userContext.getUserPreferenceAttributes(),
+                    object.getAttributes()));
+
+        }
+
+        else {
+
+            // In all other cases, filter object attributes by defined schema
+            object.setAttributes(filterAttributes(userContext.getUserAttributes(),
+                    object.getAttributes()));
+
+        }
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserResource.java
@@ -21,6 +21,11 @@ package org.apache.guacamole.rest.user;
 
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -145,9 +150,51 @@ public class UserResource
     @Override
     public void updateObject(APIUser modifiedObject) throws GuacamoleException {
 
-        // A user may not use this endpoint to modify himself
-        if (userContext.self().getIdentifier().equals(modifiedObject.getUsername()))
-            throw new GuacamoleSecurityException("Permission denied.");
+        User currentUser = userContext.self();
+
+        // A user may not use this endpoint to modify themself, except in the case
+        // that they are modifying one of the user attributes explicitly exposed
+        // in the user preferences form
+        if (currentUser.getIdentifier().equals(modifiedObject.getUsername())) {
+
+            // A user may not use this endpoint to update their password
+            if (currentUser.getPassword() != null)
+                throw new GuacamoleSecurityException(
+                        "Permission denied. The password update endpoint must"
+                        + " be used to change the current user's password.");
+
+            // All attributes exposed in the preferences forms
+            Set<String> preferenceAttributes = (
+                    userContext.getUserPreferenceAttributes().stream()
+                    .flatMap(form -> form.getFields().stream().map(
+                            field -> field.getName())))
+                    .collect(Collectors.toSet());
+
+            // Go through every attribute value and check if it's changed
+            Iterator<String> keyIterator = modifiedObject.getAttributes().keySet().iterator();
+            while(keyIterator.hasNext()) {
+
+                String key = keyIterator.next();
+                String newValue = modifiedObject.getAttributes().get(key);
+
+                // If it's not a preference attribute, editing is not allowed
+                if (!preferenceAttributes.contains(key)) {
+
+                    String currentValue = currentUser.getAttributes().get(key);
+
+                    // If the value of the attribute has been modified
+                    if (
+                            !(currentValue == null && newValue == null) && (
+                                (currentValue == null && newValue != null) ||
+                                !currentValue.equals(newValue)
+                            )
+                    )
+                        throw new GuacamoleSecurityException(
+                            "Permission denied. Only user preference attributes"
+                            + " can be modified for the current user.");
+                }
+            }
+        }
 
         super.updateObject(modifiedObject);
 


### PR DESCRIPTION
As mentioned in https://issues.apache.org/jira/browse/GUACAMOLE-1656, this allows users to specify their own KSM configurations, which can fill in any values not already provided by the admin-defined KSM configuration.

I've added a section to the end of the user preferences form for users to edit their own attributes. The Save button only applies to the user attributes immediately above - any existing preferences (mouse mode, language, etc) are still automatically updated whenever the changes are made.

![image](https://user-images.githubusercontent.com/4633119/182936508-461f4bc5-209b-4519-8bfd-60cd69520b93.png)
