### PR TITLE
GUACAMOLE-1614: Include chromium-driver in Docker build for sake of JS unit tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ ARG TOMCAT_JRE=jdk8
 # Use official maven image for the build
 FROM maven:3-jdk-8 AS builder
 
+# Install chromium-driver for sake of JavaScript unit tests
+RUN apt-get update && apt-get install -y chromium-driver
+
 # Use args to build radius auth extension such as
 # `--build-arg BUILD_PROFILE=lgpl-extensions`
 ARG BUILD_PROFILE


### PR DESCRIPTION
This change corrects the Docker build failures noted on https://issues.apache.org/jira/browse/GUACAMOLE-1614, which are ultimately due to the Jasmine Maven plugin requiring chromium-driver to run its tests.