### PR TITLE
GUACAMOLE-990: Ensure internal errors during auth reach global error handling/logging.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
+import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.GuacamoleUnauthorizedException;
 import org.apache.guacamole.GuacamoleSession;
 import org.apache.guacamole.environment.Environment;
@@ -480,6 +481,18 @@ public class AuthenticationService {
                         getLoggableAddress(request));
 
             // Rethrow exception
+            e.rethrowCause();
+
+            // This line SHOULD be unreachable unless a bug causes
+            // rethrowCause() to not actually rethrow the underlying failure
+            Throwable cause = e.getCause();
+            if (cause != null) {
+                logger.warn("An underlying internal error was not correctly rethrown by rethrowCause(): {}", cause.getMessage());
+                logger.debug("Internal error not rethrown by rethrowCause().", cause);
+            }
+            else
+                logger.warn("An underlying internal error was not correctly rethrown by rethrowCause().");
+
             throw e.getCauseAsGuacamoleException();
 
         }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/GuacamoleAuthenticationProcessException.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/GuacamoleAuthenticationProcessException.java
@@ -146,6 +146,38 @@ public class GuacamoleAuthenticationProcessException extends GuacamoleException 
         return guacCause;
     }
 
+    /**
+     * Rethrows the original GuacamoleException wrapped within this
+     * GuacamoleAuthenticationProcessException. If there is no such exception,
+     * and the cause of this failure is an unchecked RuntimeException or Error,
+     * that unchecked exception/error is rethrown as-is.
+     *
+     * @throws GuacamoleException
+     *     If the underlying cause of this exception is a checked
+     *     GuacamoleException subclass.
+     *
+     * @throws RuntimeException
+     *     If the underlying cause of this exception is an unchecked
+     *     RuntimeException.
+     *
+     * @throws Error
+     *     If the underlying cause of this exception is an unchecked Error.
+     */
+    public void rethrowCause() throws GuacamoleException, RuntimeException, Error {
+
+        // Rethrow any unchecked exceptions/errors as-is
+        Throwable cause = getCause();
+        if (cause instanceof RuntimeException)
+            throw (RuntimeException) cause;
+        if (cause instanceof Error)
+            throw (Error) cause;
+
+        // Pass through all other exceptions as normal GuacamoleException
+        // subclassses
+        throw getCauseAsGuacamoleException();
+
+    }
+
     @Override
     public GuacamoleStatus getStatus() {
         return getCauseAsGuacamoleException().getStatus();


### PR DESCRIPTION
The recent changes adding support for automatically banning IP addresses that repeatedly fail to authenticate (#758) have resulted in the details of internal errors being omitted from the Tomcat logs, instead being logged as “User authentication was aborted”.

For example, if PostgreSQL is being used but the database server has not been started, the following is logged:

```
12:12:59.935 [http-nio-8080-exec-2] WARN  o.a.g.e.AuthenticationProviderFacade - The "postgresql" authentication provider has encountered an internal error which will halt the authentication process. If this is unexpected or you are the developer of this authentication provider, you may wish to enable debug-level logging. If this is expected and you wish to ignore such failures in the future, please set "skip-if-unavailable: postgresql" within your guacamole.properties.
12:12:59.949 [http-nio-8080-exec-2] ERROR o.a.g.rest.RESTExceptionMapper - Request could not be processed: User authentication was aborted.
```

These changes rethrow the underlying cause when authentication fails due to an unchecked internal error. For other errors (subclasses of `GuacamoleException`), the original underlying exception is unwrapped and rethrown as before.