### PR TITLE
GUACAMOLE-1628: Docker image of guacamole client is missing unzip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,10 @@ RUN /opt/guacamole/bin/build-guacamole.sh "$BUILD_DIR" /opt/guacamole "$BUILD_PR
 # For the runtime image, we start with the official Tomcat distribution
 FROM tomcat:${TOMCAT_VERSION}-${TOMCAT_JRE}
 
-# Install XMLStarlet for server.xml alterations
+# Install XMLStarlet for server.xml alterations and unzip for LOGBACK_LEVEL case
 RUN apt-get update -qq \
-    && apt-get install -y xmlstarlet \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y xmlstarlet unzip\
+    && rm -rf /var/lib/apt/lists/* 
 
 # This is where the build artifacts go in the runtime image
 WORKDIR /opt/guacamole


### PR DESCRIPTION
Installs unzip and fixes docker start.sh to support setting LOGBACK_LEVEL to file path without delimiter problems