### PR TITLE
GUACAMOLE-1224: Add global logging and event handling around object management.

### DIFF
--- a/extensions/guacamole-auth-ban/src/main/java/org/apache/guacamole/auth/ban/status/InMemoryAuthenticationFailureTracker.java
+++ b/extensions/guacamole-auth-ban/src/main/java/org/apache/guacamole/auth/ban/status/InMemoryAuthenticationFailureTracker.java
@@ -21,7 +21,6 @@ package org.apache.guacamole.auth.ban.status;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import javax.servlet.http.HttpServletRequest;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.language.TranslatableGuacamoleClientTooManyException;
@@ -89,40 +88,6 @@ public class InMemoryAuthenticationFailureTracker implements AuthenticationFailu
     }
 
     /**
-     * Returns whether the given Credentials do not contain any specific
-     * authentication parameters, including HTTP parameters. An authentication
-     * request that contains no parameters whatsoever will tend to be the
-     * first, anonymous, credential-less authentication attempt that results in
-     * the initial login screen rendering.
-     *
-     * @param credentials
-     *     The Credentials object to test.
-     *
-     * @return
-     *     true if the given Credentials contain no authentication parameters
-     *     whatsoever, false otherwise.
-     */
-    private boolean isEmpty(Credentials credentials) {
-
-        // An authentication request that contains an explicit username or
-        // password (even if blank) is non-empty, regardless of how the values
-        // were passed
-        if (credentials.getUsername() != null || credentials.getPassword() != null)
-            return false;
-
-        // All further tests depend on HTTP request details
-        HttpServletRequest request = credentials.getRequest();
-        if (request == null)
-            return true;
-
-        // An authentication request is non-empty if it contains any HTTP
-        // parameters at all or contains an authentication token
-        return !request.getParameterNames().hasMoreElements()
-                && request.getHeader("Guacamole-Token") == null;
-
-    }
-
-    /**
      * Reports that the given address has just failed to authenticate and
      * returns the AuthenticationFailureStatus that represents that failure. If
      * the address isn't already being tracked, it will begin being tracked as
@@ -168,7 +133,7 @@ public class InMemoryAuthenticationFailureTracker implements AuthenticationFailu
             boolean failed) throws GuacamoleException {
 
         // Ignore requests that do not contain explicit parameters of any kind
-        if (isEmpty(credentials))
+        if (credentials.isEmpty())
             return;
 
         // Determine originating address of the authentication request

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connection.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Connection.java
@@ -34,20 +34,7 @@ import org.apache.guacamole.protocol.GuacamoleConfiguration;
  * backing GuacamoleConfiguration may be intentionally obfuscated or tokenized
  * to protect sensitive configuration information.
  */
-public interface Connection extends Identifiable, Connectable, Attributes {
-
-    /**
-     * Returns the name assigned to this Connection.
-     * @return The name assigned to this Connection.
-     */
-    public String getName();
-
-    /**
-     * Sets the name assigned to this Connection.
-     *
-     * @param name The name to assign.
-     */
-    public void setName(String name);
+public interface Connection extends Identifiable, Connectable, Attributes, Nameable {
 
     /**
      * Returns the unique identifier of the parent ConnectionGroup for

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/ConnectionGroup.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/ConnectionGroup.java
@@ -26,7 +26,7 @@ import org.apache.guacamole.GuacamoleException;
  * Represents a connection group, which can contain both other connection groups
  * as well as connections.
  */
-public interface ConnectionGroup extends Identifiable, Connectable, Attributes {
+public interface ConnectionGroup extends Identifiable, Connectable, Attributes, Nameable {
   
     /**
      * All legal types of connection group.
@@ -50,19 +50,6 @@ public interface ConnectionGroup extends Identifiable, Connectable, Attributes {
         BALANCING
 
     };
-
-    /**
-     * Returns the name assigned to this ConnectionGroup.
-     * @return The name assigned to this ConnectionGroup.
-     */
-    public String getName();
-
-    /**
-     * Sets the name assigned to this ConnectionGroup.
-     *
-     * @param name The name to assign.
-     */
-    public void setName(String name);
 
     /**
      * Returns the unique identifier of the parent ConnectionGroup for

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -236,4 +236,36 @@ public class Credentials implements Serializable {
         this.remoteHostname = remoteHostname;
     }
 
+    /**
+     * Returns whether this Credentials object does not contain any specific
+     * authentication parameters, including HTTP parameters and the HTTP header
+     * used for the authentication token. An authentication request that
+     * contains no parameters whatsoever will tend to be the first, anonymous,
+     * credential-less authentication attempt that results in the initial login
+     * screen rendering.
+     *
+     * @return
+     *     true if this Credentials object contains no authentication
+     *     parameters whatsoever, false otherwise.
+     */
+    public boolean isEmpty() {
+
+        // An authentication request that contains an explicit username or
+        // password (even if blank) is non-empty, regardless of how the values
+        // were passed
+        if (getUsername() != null || getPassword() != null)
+            return false;
+
+        // All further tests depend on HTTP request details
+        HttpServletRequest httpRequest = getRequest();
+        if (httpRequest == null)
+            return true;
+
+        // An authentication request is non-empty if it contains any HTTP
+        // parameters at all or contains an authentication token
+        return !httpRequest.getParameterNames().hasMoreElements()
+                && httpRequest.getHeader("Guacamole-Token") == null;
+
+    }
+
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Directory.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Directory.java
@@ -35,6 +35,104 @@ import org.apache.guacamole.GuacamoleException;
 public interface Directory<ObjectType extends Identifiable> {
 
     /**
+     * All Directory types that may be found on the {@link UserContext}
+     * interface.
+     */
+    public enum Type {
+
+        /**
+         * The type of a Directory that contains {@link ActiveConnection}
+         * objects.
+         */
+        ACTIVE_CONNECTION(ActiveConnection.class),
+
+        /**
+         * The type of a Directory that contains {@link Connection}
+         * objects.
+         */
+        CONNECTION(Connection.class),
+
+        /**
+         * The type of a Directory that contains {@link ConnectionGroup}
+         * objects.
+         */
+        CONNECTION_GROUP(ConnectionGroup.class),
+
+        /**
+         * The type of a Directory that contains {@link SharingProfile}
+         * objects.
+         */
+        SHARING_PROFILE(SharingProfile.class),
+
+        /**
+         * The type of a Directory that contains {@link User} objects.
+         */
+        USER(User.class),
+
+        /**
+         * The type of a Directory that contains {@link UserGroup}
+         * objects.
+         */
+        USER_GROUP(UserGroup.class);
+
+        /**
+         * The base class of the type of object stored within the type of
+         * Directory represented by this Directory.Type.
+         */
+        private final Class<? extends Identifiable> objectType;
+
+        /**
+         * Creates a new Directory.Type representing the type of a Directory
+         * that contains only subclasses of the given class.
+         *
+         * @param objectType
+         *     The base class of the type of object stored within the type of
+         *     Directory represented by this Directory.Type.
+         */
+        private Type(Class<? extends Identifiable> objectType) {
+            this.objectType = objectType;
+        }
+
+        /**
+         * Returns the base class of the type of object stored within a
+         * {@link Directory} of this type.
+         *
+         * @return
+         *     The base class of the type of object stored within a
+         *     {@link Directory} of this type.
+         */
+        public Class<? extends Identifiable> getObjectType() {
+            return objectType;
+        }
+
+        /**
+         * Returns the Directory.Type representing the type of a Directory that
+         * could contain an object having the given class. The class may be a
+         * subclass of the overall base class of the objects stored within the
+         * Directory.
+         *
+         * @param objectType
+         *     The class to determine the Directory.Type of.
+         *
+         * @return
+         *     The Directory.Type representing the type of a Directory that
+         *     could contain an object having the given class, or null if there
+         *     is no such Directory available via the UserContext interface.
+         */
+        public static Type of(Class<? extends Identifiable> objectType) {
+
+            for (Type type : Type.values()) {
+                if (type.getObjectType().isAssignableFrom(objectType))
+                    return type;
+            }
+
+            return null;
+
+        }
+
+    }
+
+    /**
      * Returns the object having the given identifier. Note that changes to
      * the object returned will not necessarily affect the object stored within
      * the Directory. To update an object stored within an

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Nameable.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Nameable.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+/**
+ * An object which has a human-readable, arbitrary name. No requirement is
+ * imposed by this interface regarding whether this name must be unique,
+ * however implementations are free to impose such restrictions.
+ */
+public interface Nameable {
+
+    /**
+     * Returns the human-readable name assigned to this object.
+     *
+     * @return
+     *     The name assigned to this object.
+     */
+    String getName();
+
+    /**
+     * Sets the human-readable name assigned to this object.
+     *
+     * @param name
+     *     The name to assign.
+     */
+    void setName(String name);
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/SharingProfile.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/SharingProfile.java
@@ -25,23 +25,7 @@ import java.util.Map;
  * Represents the semantics which apply to an existing connection when shared,
  * along with a human-readable name and unique identifier.
  */
-public interface SharingProfile extends Identifiable, Attributes {
-
-    /**
-     * Returns the human-readable name assigned to this SharingProfile.
-     *
-     * @return
-     *     The name assigned to this SharingProfile.
-     */
-    public String getName();
-
-    /**
-     * Sets the human-readable name assigned to this SharingProfile.
-     *
-     * @param name
-     *     The name to assign.
-     */
-    public void setName(String name);
+public interface SharingProfile extends Identifiable, Attributes, Nameable {
 
     /**
      * Returns the identifier of the primary connection associated with this

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/ApplicationShutdownEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/ApplicationShutdownEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.event;
+
+import org.apache.guacamole.net.auth.AuthenticationProvider;
+import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.event.listener.Listener;
+
+/**
+ * Event that is dispatched when the web application has nearly completely shut
+ * down, including the authentication/authorization portion of extensions. Any
+ * installed extensions are still loaded (such that they may receive this event
+ * via {@link Listener#handleEvent(java.lang.Object)}, but their authentication
+ * providers will have been shut down via {@link AuthenticationProvider#shutdown()},
+ * and resources from user sessions will have been closed and released via
+ * {@link UserContext#invalidate()}.
+ */
+public interface ApplicationShutdownEvent {
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/ApplicationStartedEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/ApplicationStartedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.event;
+
+/**
+ * Event that is dispatched when the web application has finished starting up,
+ * including all extensions. This event indicates only that the web application
+ * startup process has completed and all extensions have been loaded. It does
+ * not indicate whether all extensions have started successfully.
+ */
+public interface ApplicationStartedEvent {
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/AuthenticationSuccessEvent.java
@@ -43,16 +43,46 @@ public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent,
     private final AuthenticatedUser authenticatedUser;
 
     /**
+     * Whether the successful authentication attempt represented by this event
+     * is related to an established Guacamole session.
+     */
+    private final boolean existingSession;
+    
+    /**
      * Creates a new AuthenticationSuccessEvent which represents a successful
      * authentication attempt by the user identified by the given
-     * AuthenticatedUser object.
+     * AuthenticatedUser object. The authentication attempt is presumed to be
+     * a fresh authentication attempt unrelated to an established session (a
+     * login attempt).
      *
      * @param authenticatedUser
      *     The AuthenticatedUser identifying the user that successfully
      *     authenticated.
      */
     public AuthenticationSuccessEvent(AuthenticatedUser authenticatedUser) {
+        this(authenticatedUser, false);
+    }
+
+    /**
+     * Creates a new AuthenticationSuccessEvent which represents a successful
+     * authentication attempt by the user identified by the given
+     * AuthenticatedUser object. Whether the authentication attempt is
+     * related to an established session (a periodic re-authentication attempt
+     * that updates session status) or not (a fresh login attempt) is
+     * determined by the value of the provided flag.
+     *
+     * @param authenticatedUser
+     *     The AuthenticatedUser identifying the user that successfully
+     *     authenticated.
+     *
+     * @param existingSession
+     *     Whether this AuthenticationSuccessEvent represents an
+     *     re-authentication attempt that updates the status of an established
+     *     Guacamole session.
+     */
+    public AuthenticationSuccessEvent(AuthenticatedUser authenticatedUser, boolean existingSession) {
         this.authenticatedUser = authenticatedUser;
+        this.existingSession = existingSession;
     }
 
     @Override
@@ -68,6 +98,23 @@ public class AuthenticationSuccessEvent implements UserEvent, CredentialEvent,
     @Override
     public AuthenticationProvider getAuthenticationProvider() {
         return getAuthenticatedUser().getAuthenticationProvider();
+    }
+
+    /**
+     * Returns whether the successful authentication attempt represented by
+     * this event is related to an established Guacamole session. During normal
+     * operation, the Guacamole web application will periodically
+     * re-authenticate with the server to verify its authentication token and
+     * update the session state, in which case the value returned by this
+     * function will be true. If the user was not already authenticated and has
+     * just initially logged in, false is returned.
+     *
+     * @return
+     *     true if this AuthenticationSuccessEvent is related to a Guacamole
+     *     session that was already established, false otherwise.
+     */
+    public boolean isExistingSession() {
+        return existingSession;
     }
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.event;
+
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Identifiable;
+
+/**
+ * Abstract basis for events which involve a modification made to the objects
+ * within a {@link Directory}.
+ *
+ * @param <ObjectType>
+ *     The type of object stored within the {@link Directory}.
+ */
+public interface DirectoryEvent<ObjectType extends Identifiable>
+        extends AuthenticationProviderEvent, UserEvent {
+
+    /**
+     * The types of directory operations that may be represented by a
+     * DirectoryEvent.
+     */
+    public enum Operation {
+
+        /**
+         * An object was added to the {@link Directory}. The object added can
+         * be accessed with {@link #getObject()}, and its identifier may be
+         * obtained from {@link #getObjectIdentifier()}.
+         */
+        ADD,
+
+        /**
+         * An object was retrieved from a {@link Directory}. The object
+         * retrieved can be accessed with {@link #getObject()}, and its
+         * identifier may be obtained from {@link #getObjectIdentifier()}.
+         */
+        GET,
+
+        /**
+         * An existing object within a {@link Directory} was modified. The
+         * modified object can be accessed with {@link #getObject()}, and its
+         * identifier may be obtained from {@link #getObjectIdentifier()}.
+         */
+        UPDATE,
+
+        /**
+         * An existing object within a {@link Directory} was deleted/removed.
+         * The identifier of the object that was deleted may be obtained from
+         * {@link #getObjectIdentifier()}. The full object that was deleted
+         * will be made available via {@link #getObject()} if possible, but
+         * this is not guaranteed for deletions.
+         */
+        REMOVE
+
+    }
+
+    /**
+     * Returns the type of objects stored within the {@link Directory}
+     * affected by the operation.
+     *
+     * @return
+     *     The type of objects stored within the {@link Directory}.
+     */
+    Directory.Type getDirectoryType();
+
+    /**
+     * Returns the operation that was performed/attempted.
+     *
+     * @return
+     *     The operation that was performed or attempted.
+     */
+    Operation getOperation();
+
+    /**
+     * Returns the identifier of the object affected by the operation. If the
+     * object was just created, this will be the identifier of the new object.
+     *
+     * @return
+     *     The identifier of the object affected by the operation.
+     */
+    String getObjectIdentifier();
+
+    /**
+     * Returns the object affected by the operation, if available. For
+     * deletions, there is no guarantee that the affected object will be
+     * available within this event. If the object is not available, null is
+     * returned.
+     *
+     * @return
+     *     The object affected by the operation performed, or null if that
+     *     object is not available in the context of this event.
+     */
+    ObjectType getObject();
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
@@ -91,11 +91,11 @@ public interface DirectoryEvent<ObjectType extends Identifiable>
     /**
      * {@inheritDoc}
      * <p>
-     * Currently, for object creation ({@link Operation#ADD}), retrieval
-     * ({@link Operation#GET}), modification and ({@link Operation#UPDATE}),
+     * Currently, for object creation ({@link Operation#ADD ADD}), retrieval
+     * ({@link Operation#GET GET}), and modification ({@link Operation#UPDATE UPDATE}),
      * it can be expected that the affected object will be available, however
      * the caller should verify this regardless. For deletions
-     * ({@link Operation#REMOVE}), the object can only be made available for
+     * ({@link Operation#REMOVE REMOVE}), the object can only be made available for
      * single deletions, and cannot be made available for batch deletions.
      */
     @Override

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
@@ -24,13 +24,14 @@ import org.apache.guacamole.net.auth.Identifiable;
 
 /**
  * Abstract basis for events which involve a modification made to the objects
- * within a {@link Directory}.
+ * within a {@link Directory} through the operations exposed by the Directory
+ * interface.
  *
  * @param <ObjectType>
  *     The type of object stored within the {@link Directory}.
  */
 public interface DirectoryEvent<ObjectType extends Identifiable>
-        extends AuthenticationProviderEvent, UserEvent {
+        extends DirectoryObjectEvent<ObjectType> {
 
     /**
      * The types of directory operations that may be represented by a
@@ -71,15 +72,6 @@ public interface DirectoryEvent<ObjectType extends Identifiable>
     }
 
     /**
-     * Returns the type of objects stored within the {@link Directory}
-     * affected by the operation.
-     *
-     * @return
-     *     The type of objects stored within the {@link Directory}.
-     */
-    Directory.Type getDirectoryType();
-
-    /**
      * Returns the operation that was performed/attempted.
      *
      * @return
@@ -88,24 +80,25 @@ public interface DirectoryEvent<ObjectType extends Identifiable>
     Operation getOperation();
 
     /**
-     * Returns the identifier of the object affected by the operation. If the
-     * object was just created, this will be the identifier of the new object.
-     *
-     * @return
-     *     The identifier of the object affected by the operation.
+     * {@inheritDoc}
+     * <p>
+     * If the object was just created, this will be the identifier of the new
+     * object.
      */
+    @Override
     String getObjectIdentifier();
 
     /**
-     * Returns the object affected by the operation, if available. For
-     * deletions, there is no guarantee that the affected object will be
-     * available within this event. If the object is not available, null is
-     * returned.
-     *
-     * @return
-     *     The object affected by the operation performed, or null if that
-     *     object is not available in the context of this event.
+     * {@inheritDoc}
+     * <p>
+     * Currently, for object creation ({@link Operation#ADD}), retrieval
+     * ({@link Operation#GET}), modification and ({@link Operation#UPDATE}),
+     * it can be expected that the affected object will be available, however
+     * the caller should verify this regardless. For deletions
+     * ({@link Operation#REMOVE}), the object can only be made available for
+     * single deletions, and cannot be made available for batch deletions.
      */
+    @Override
     ObjectType getObject();
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryEvent.java
@@ -31,7 +31,7 @@ import org.apache.guacamole.net.auth.Identifiable;
  *     The type of object stored within the {@link Directory}.
  */
 public interface DirectoryEvent<ObjectType extends Identifiable>
-        extends DirectoryObjectEvent<ObjectType> {
+        extends IdentifiableObjectEvent<ObjectType> {
 
     /**
      * The types of directory operations that may be represented by a

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryFailureEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryFailureEvent.java
@@ -17,30 +17,20 @@
  * under the License.
  */
 
-package org.apache.guacamole.rest.tunnel;
+package org.apache.guacamole.net.event;
 
-import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.tunnel.UserTunnel;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Identifiable;
 
 /**
- * Factory which creates resources that expose the contents of a given
- * tunnel.
+ * Event that is dispatched whenever a REST API request to create/modify/delete
+ * an object within a {@link Directory} fails. The specific failure is made
+ * available via {@link #getFailure()}.
+ *
+ * @param <ObjectType>
+ *     The type of object stored within the {@link Directory}.
  */
-public interface TunnelResourceFactory {
-
-    /**
-     * Creates a new TunnelResource which exposes the contents of the
-     * given tunnel.
-     *
-     * @param authenticatedUser
-     *     The user that is accessing the resource.
-     *
-     * @param tunnel
-     *     The tunnel whose contents should be exposed.
-     *
-     * @return
-     *     A new TunnelResource which exposes the contents of the given tunnel.
-     */
-    TunnelResource create(AuthenticatedUser authenticatedUser, UserTunnel tunnel);
+public interface DirectoryFailureEvent<ObjectType extends Identifiable>
+        extends DirectoryEvent<ObjectType>, FailureEvent {
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryObjectEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryObjectEvent.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.net.event;
 
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Identifiable;
 
@@ -31,6 +33,18 @@ import org.apache.guacamole.net.auth.Identifiable;
  */
 public interface DirectoryObjectEvent<ObjectType extends Identifiable>
         extends AuthenticationProviderEvent, UserEvent {
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * NOTE: For subclasses of {@link DirectoryObjectEvent}, this will be the
+     * AuthenticationProvider associated with the affected object. This is not
+     * necessarily the same as the AuthenticationProvider that authenticated
+     * the user performing the operation, which can be retrieved via
+     * {@link #getAuthenticatedUser()} and {@link AuthenticatedUser#getAuthenticationProvider()}.
+     */
+    @Override
+    AuthenticationProvider getAuthenticationProvider();
 
     /**
      * Returns the type of {@link Directory} that contains the object affected

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryObjectEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectoryObjectEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.event;
+
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Identifiable;
+
+/**
+ * Abstract basis for events which affect or directly relate to objects that
+ * may be stored within a {@link Directory}.
+ *
+ * @param <ObjectType>
+ *     The type of object stored within the {@link Directory}.
+ */
+public interface DirectoryObjectEvent<ObjectType extends Identifiable>
+        extends AuthenticationProviderEvent, UserEvent {
+
+    /**
+     * Returns the type of {@link Directory} that contains the object affected
+     * by the operation.
+     *
+     * @return
+     *     The type of objects stored within the {@link Directory}.
+     */
+    Directory.Type getDirectoryType();
+
+    /**
+     * Returns the identifier of the object affected by the operation.
+     *
+     * @return
+     *     The identifier of the object affected by the operation.
+     */
+    String getObjectIdentifier();
+
+    /**
+     * Returns the object affected by the operation, if available. Whether the
+     * affected object is available is context- and implementation-dependent.
+     * There is no general guarantee across all implementations of this event
+     * that the affected object will be available. If the object is not
+     * available, null is returned.
+     *
+     * @return
+     *     The object affected by the operation performed, or null if that
+     *     object is not available in the context of this event.
+     */
+    ObjectType getObject();
+
+}

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectorySuccessEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/DirectorySuccessEvent.java
@@ -17,30 +17,19 @@
  * under the License.
  */
 
-package org.apache.guacamole.rest.tunnel;
+package org.apache.guacamole.net.event;
 
-import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.tunnel.UserTunnel;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.Identifiable;
 
 /**
- * Factory which creates resources that expose the contents of a given
- * tunnel.
+ * Event that is dispatched whenever a REST API request to create/modify/delete
+ * an object within a {@link Directory} succeeds.
+ *
+ * @param <ObjectType>
+ *     The type of object stored within the {@link Directory}.
  */
-public interface TunnelResourceFactory {
-
-    /**
-     * Creates a new TunnelResource which exposes the contents of the
-     * given tunnel.
-     *
-     * @param authenticatedUser
-     *     The user that is accessing the resource.
-     *
-     * @param tunnel
-     *     The tunnel whose contents should be exposed.
-     *
-     * @return
-     *     A new TunnelResource which exposes the contents of the given tunnel.
-     */
-    TunnelResource create(AuthenticatedUser authenticatedUser, UserTunnel tunnel);
+public interface DirectorySuccessEvent<ObjectType extends Identifiable>
+        extends DirectoryEvent<ObjectType> {
 
 }

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/IdentifiableObjectEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/IdentifiableObjectEvent.java
@@ -26,29 +26,30 @@ import org.apache.guacamole.net.auth.Identifiable;
 
 /**
  * Abstract basis for events which affect or directly relate to objects that
- * may be stored within a {@link Directory}.
+ * are {@link Identifiable} and may be stored within a {@link Directory}.
  *
  * @param <ObjectType>
- *     The type of object stored within the {@link Directory}.
+ *     The type of object affected or related to the event.
  */
-public interface DirectoryObjectEvent<ObjectType extends Identifiable>
+public interface IdentifiableObjectEvent<ObjectType extends Identifiable>
         extends AuthenticationProviderEvent, UserEvent {
 
     /**
      * {@inheritDoc}
      * <p>
-     * NOTE: For subclasses of {@link DirectoryObjectEvent}, this will be the
-     * AuthenticationProvider associated with the affected object. This is not
-     * necessarily the same as the AuthenticationProvider that authenticated
-     * the user performing the operation, which can be retrieved via
-     * {@link #getAuthenticatedUser()} and {@link AuthenticatedUser#getAuthenticationProvider()}.
+     * NOTE: For subclasses of {@link IdentifiableObjectEvent}, this will be the
+     * AuthenticationProvider associated with the affected, {@link Identifiable}
+     * object. This is not necessarily the same as the AuthenticationProvider
+     * that authenticated the user performing the operation, which can be
+     * retrieved via {@link #getAuthenticatedUser()} and
+     * {@link AuthenticatedUser#getAuthenticationProvider()}.
      */
     @Override
     AuthenticationProvider getAuthenticationProvider();
 
     /**
-     * Returns the type of {@link Directory} that contains the object affected
-     * by the operation.
+     * Returns the type of {@link Directory} that may contains the object
+     * affected by the operation.
      *
      * @return
      *     The type of objects stored within the {@link Directory}.

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/event/UserSessionInvalidatedEvent.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/event/UserSessionInvalidatedEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.event;
+
+/**
+ * Event that is dispatched when a user has logged out or their session has
+ * expired.
+ */
+public interface UserSessionInvalidatedEvent extends UserEvent {
+}

--- a/guacamole-ext/src/test/java/org/apache/guacamole/net/auth/DirectoryTest.java
+++ b/guacamole-ext/src/test/java/org/apache/guacamole/net/auth/DirectoryTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.net.auth;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test that verifies the functionality provided by the Directory interface.
+ */
+public class DirectoryTest {
+
+    /**
+     * Returns a Collection of all classes that have associated Directories
+     * available via the UserContext interface. The classes are retrieved
+     * using reflection by enumerating the type parameters of the return types
+     * of all functions that return a Directory.
+     *
+     * @return
+     *     A Collection of all classes that have associated Directories
+     *     available via the UserContext interface.
+     */
+    @SuppressWarnings("unchecked") // Verified via calls to isAssignableFrom()
+    private Collection<Class<? extends Identifiable>> getDirectoryTypes() {
+
+        Set<Class<? extends Identifiable>> types = new HashSet<>();
+
+        Method[] methods = UserContext.class.getMethods();
+        for (Method method : methods) {
+
+            if (!Directory.class.isAssignableFrom(method.getReturnType()))
+                continue;
+
+            Type retType = method.getGenericReturnType();
+            Assert.assertTrue("UserContext functions that return directories "
+                    + "must have proper type parameters for the returned "
+                    + "directory.", retType instanceof ParameterizedType);
+
+            Type[] typeArgs = ((ParameterizedType) retType).getActualTypeArguments();
+            Assert.assertEquals("UserContext functions that return directories "
+                    + "must properly declare exactly one type argument for "
+                    + "those directories.", 1, typeArgs.length);
+
+            Class<?> directoryType = (Class<?>) typeArgs[0];
+            Assert.assertTrue("Directories returned by UserContext functions "
+                    + "must contain subclasses of Identifiable.",
+                    Identifiable.class.isAssignableFrom(directoryType));
+
+            types.add((Class<? extends Identifiable>) directoryType);
+
+        }
+
+        return Collections.unmodifiableSet(types);
+
+    }
+
+    /**
+     * Verifies that Directory.Type covers the types of all directories exposed
+     * by the UserContext interface.
+     */
+    @Test
+    public void testTypeCoverage() {
+
+        Collection<Class<? extends Identifiable>> types = getDirectoryTypes();
+
+        Assert.assertEquals("Directory.Type must provide exactly one value "
+                + "for each type of directory provideed by the UserContext "
+                + "interface.", types.size(), Directory.Type.values().length);
+
+        for (Class<? extends Identifiable> type : types) {
+
+            Directory.Type dirType = Directory.Type.of(type);
+            Assert.assertNotNull("of() must provide mappings for all directory "
+                    + "types defined on the UserContext interface.", dirType);
+
+            Assert.assertEquals("getObjectType() must return the same base "
+                    + "superclass used by UserContext for all directory "
+                    + "types defined on the UserContext interface.", type,
+                    dirType.getObjectType());
+
+        }
+
+    }
+
+    /**
+     * Verifies that each type declared by Directory.Type exposes an
+     * associated class via getObjectType() which then maps back to the same
+     * type via Directory.Type.of().
+     */
+    @Test
+    public void testTypeIdentity() {
+        for (Directory.Type dirType : Directory.Type.values()) {
+            Assert.assertEquals("For all defined directory types, "
+                    + "Directory.Type.of(theType.getObjectType()) must "
+                    + "correctly map back to theType.", dirType,
+                    Directory.Type.of(dirType.getObjectType()));
+        }
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
@@ -94,6 +94,10 @@ public class AffectedObject implements LoggableDetail {
 
             // Users
             case USER:
+
+                if (identifier.equals(event.getAuthenticatedUser().getIdentifier()))
+                    return "their own user account";
+
                 objectType = "user";
                 break;
 

--- a/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
@@ -22,7 +22,7 @@ package org.apache.guacamole.event;
 import org.apache.guacamole.net.auth.Nameable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.guacamole.net.event.DirectoryObjectEvent;
+import org.apache.guacamole.net.event.IdentifiableObjectEvent;
 
 /**
  * Loggable representation of the object affected by an operation.
@@ -37,7 +37,7 @@ public class AffectedObject implements LoggableDetail {
     /**
      * The event representing the requested operation.
      */
-    private final DirectoryObjectEvent<?> event;
+    private final IdentifiableObjectEvent<?> event;
 
     /**
      * Creates a new AffectedObject representing the object affected by the
@@ -46,7 +46,7 @@ public class AffectedObject implements LoggableDetail {
      * @param event
      *     The event representing the operation.
      */
-    public AffectedObject(DirectoryObjectEvent<?> event) {
+    public AffectedObject(IdentifiableObjectEvent<?> event) {
         this.event = event;
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.event;
+
+import org.apache.guacamole.net.auth.Nameable;
+import org.apache.guacamole.net.event.DirectoryEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loggable representation of the object affected by an operation.
+ */
+public class AffectedObject implements LoggableDetail {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(AffectedObject.class);
+    
+    /**
+     * The event representing the requested operation.
+     */
+    private final DirectoryEvent<?> event;
+
+    /**
+     * Creates a new AffectedObject representing the object affected by the
+     * operation described by the given event.
+     *
+     * @param event
+     *     The event representing the operation.
+     */
+    public AffectedObject(DirectoryEvent<?> event) {
+        this.event = event;
+    }
+
+    @Override
+    public String toString() {
+
+        Object object = event.getObject();
+        String identifier = event.getObjectIdentifier();
+
+        String objectType;
+        String name = null; // Not all objects have names
+
+        // Obtain name of object (if applicable and available)
+        if (object instanceof Nameable) {
+            try {
+                name = ((Nameable) object).getName();
+            }
+            catch (RuntimeException | Error e) {
+                logger.debug("Name of object \"{}\" could not be retrieved.", identifier, e);
+            }
+        }
+
+        // Determine type of object
+        switch (event.getDirectoryType()) {
+
+            // Active connections
+            case ACTIVE_CONNECTION:
+                objectType = "active connection";
+                break;
+
+            // Connections
+            case CONNECTION:
+                objectType = "connection";
+                break;
+
+            // Connection groups
+            case CONNECTION_GROUP:
+                objectType = "connection group";
+                break;
+
+            // Sharing profiles
+            case SHARING_PROFILE:
+                objectType = "sharing profile";
+                break;
+
+            // Users
+            case USER:
+                objectType = "user";
+                break;
+
+            // User groups
+            case USER_GROUP:
+                objectType = "user group";
+                break;
+
+            // Unknown
+            default:
+                objectType = (object != null) ? object.getClass().toString() : "an unknown object";
+                
+        }
+
+        // Describe at least the type of the object and its identifier,
+        // including the name of the object, as well, if available
+        if (identifier != null) {
+            if (name != null)
+                return objectType + " \"" + identifier + "\" (currently named \"" + name + "\")";
+            else
+                return objectType + " \"" + identifier + "\"";
+        }
+        else
+            return objectType;
+
+    }
+    
+}

--- a/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
@@ -20,9 +20,9 @@
 package org.apache.guacamole.event;
 
 import org.apache.guacamole.net.auth.Nameable;
-import org.apache.guacamole.net.event.DirectoryEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.guacamole.net.event.DirectoryObjectEvent;
 
 /**
  * Loggable representation of the object affected by an operation.
@@ -37,7 +37,7 @@ public class AffectedObject implements LoggableDetail {
     /**
      * The event representing the requested operation.
      */
-    private final DirectoryEvent<?> event;
+    private final DirectoryObjectEvent<?> event;
 
     /**
      * Creates a new AffectedObject representing the object affected by the
@@ -46,7 +46,7 @@ public class AffectedObject implements LoggableDetail {
      * @param event
      *     The event representing the operation.
      */
-    public AffectedObject(DirectoryEvent<?> event) {
+    public AffectedObject(DirectoryObjectEvent<?> event) {
         this.event = event;
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/AffectedObject.java
@@ -55,6 +55,7 @@ public class AffectedObject implements LoggableDetail {
 
         Object object = event.getObject();
         String identifier = event.getObjectIdentifier();
+        String dataSource = event.getAuthenticationProvider().getIdentifier();
 
         String objectType;
         String name = null; // Not all objects have names
@@ -95,8 +96,8 @@ public class AffectedObject implements LoggableDetail {
             // Users
             case USER:
 
-                if (identifier.equals(event.getAuthenticatedUser().getIdentifier()))
-                    return "their own user account";
+                if (identifier != null && identifier.equals(event.getAuthenticatedUser().getIdentifier()))
+                    return "their own user account within \"" + dataSource + "\"";
 
                 objectType = "user";
                 break;
@@ -116,12 +117,12 @@ public class AffectedObject implements LoggableDetail {
         // including the name of the object, as well, if available
         if (identifier != null) {
             if (name != null)
-                return objectType + " \"" + identifier + "\" (currently named \"" + name + "\")";
+                return objectType + " \"" + identifier + "\" within \"" + dataSource + "\" (currently named \"" + name + "\")";
             else
-                return objectType + " \"" + identifier + "\"";
+                return objectType + " \"" + identifier + "\" within \"" + dataSource + "\"";
         }
         else
-            return objectType;
+            return objectType + " within \"" + dataSource + "\"";
 
     }
     

--- a/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
@@ -22,6 +22,8 @@ package org.apache.guacamole.event;
 import javax.annotation.Nonnull;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleResourceNotFoundException;
+import org.apache.guacamole.net.event.ApplicationShutdownEvent;
+import org.apache.guacamole.net.event.ApplicationStartedEvent;
 import org.apache.guacamole.net.event.DirectoryEvent;
 import org.apache.guacamole.net.event.DirectoryFailureEvent;
 import org.apache.guacamole.net.event.DirectorySuccessEvent;
@@ -115,12 +117,19 @@ public class EventLoggingListener implements Listener {
     @Override
     public void handleEvent(@Nonnull Object event) throws GuacamoleException {
 
+        // General object creation/modification/deletion
         if (event instanceof DirectorySuccessEvent)
             logSuccess((DirectorySuccessEvent<?>) event);
-
         else if (event instanceof DirectoryFailureEvent)
             logFailure((DirectoryFailureEvent<?>) event);
 
+        // Application startup/shutdown
+        else if (event instanceof ApplicationStartedEvent)
+            logger.info("The Apache Guacamole web application has started.");
+        else if (event instanceof ApplicationShutdownEvent)
+            logger.info("The Apache Guacamole web application has shut down.");
+
+        // Unknown events
         else
             logger.debug("Ignoring unknown/unimplemented event type: {}",
                     event.getClass());

--- a/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
@@ -30,6 +30,7 @@ import org.apache.guacamole.net.auth.credentials.GuacamoleInsufficientCredential
 import org.apache.guacamole.net.event.ApplicationShutdownEvent;
 import org.apache.guacamole.net.event.ApplicationStartedEvent;
 import org.apache.guacamole.net.event.AuthenticationFailureEvent;
+import org.apache.guacamole.net.event.AuthenticationRequestReceivedEvent;
 import org.apache.guacamole.net.event.AuthenticationSuccessEvent;
 import org.apache.guacamole.net.event.DirectoryEvent;
 import org.apache.guacamole.net.event.DirectoryFailureEvent;
@@ -227,6 +228,9 @@ public class EventLoggingListener implements Listener {
         else if (event instanceof UserSessionInvalidatedEvent)
             logger.info("{} has logged out, or their session has expired or "
                     + "been terminated.", new RequestingUser((UserSessionInvalidatedEvent) event));
+        else if (event instanceof AuthenticationRequestReceivedEvent)
+            logger.trace("Authentication request received from {}",
+                    new RemoteAddress(((AuthenticationRequestReceivedEvent) event).getCredentials()));
 
         // Application startup/shutdown
         else if (event instanceof ApplicationStartedEvent)

--- a/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
@@ -27,6 +27,7 @@ import org.apache.guacamole.net.event.ApplicationStartedEvent;
 import org.apache.guacamole.net.event.DirectoryEvent;
 import org.apache.guacamole.net.event.DirectoryFailureEvent;
 import org.apache.guacamole.net.event.DirectorySuccessEvent;
+import org.apache.guacamole.net.event.UserSessionInvalidatedEvent;
 import org.apache.guacamole.net.event.listener.Listener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,6 +123,11 @@ public class EventLoggingListener implements Listener {
             logSuccess((DirectorySuccessEvent<?>) event);
         else if (event instanceof DirectoryFailureEvent)
             logFailure((DirectoryFailureEvent<?>) event);
+
+        // Logout / session expiration
+        else if (event instanceof UserSessionInvalidatedEvent)
+            logger.info("{} has logged out, or their session has expired or "
+                    + "been terminated.", new RequestingUser((UserSessionInvalidatedEvent) event));
 
         // Application startup/shutdown
         else if (event instanceof ApplicationStartedEvent)

--- a/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/EventLoggingListener.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.event;
+
+import javax.annotation.Nonnull;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleResourceNotFoundException;
+import org.apache.guacamole.net.event.DirectoryEvent;
+import org.apache.guacamole.net.event.DirectoryFailureEvent;
+import org.apache.guacamole.net.event.DirectorySuccessEvent;
+import org.apache.guacamole.net.event.listener.Listener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Listener that records each event that occurs in the logs, such as changes
+ * made to objects via the REST API.
+ */
+public class EventLoggingListener implements Listener {
+
+    /**
+     * Logger for this class.
+     */
+    private final Logger logger = LoggerFactory.getLogger(EventLoggingListener.class);
+
+    /**
+     * Logs that an operation was performed on an object within a Directory
+     * successfully.
+     *
+     * @param event
+     *     The event describing the operation successfully performed on the
+     *     object.
+     */
+    private void logSuccess(DirectorySuccessEvent<?> event) {
+        DirectoryEvent.Operation op = event.getOperation();
+        switch (op) {
+
+            case GET:
+                logger.debug("{} successfully accessed/retrieved {}", new RequestingUser(event), new AffectedObject(event));
+                break;
+
+            case ADD:
+                logger.info("{} successfully created {}", new RequestingUser(event), new AffectedObject(event));
+                break;
+
+            case UPDATE:
+                logger.info("{} successfully updated {}", new RequestingUser(event), new AffectedObject(event));
+                break;
+
+            case REMOVE:
+                logger.info("{} successfully deleted {}", new RequestingUser(event), new AffectedObject(event));
+                break;
+
+            default:
+                logger.warn("DirectoryEvent operation type has no corresponding log message implemented: {}", op);
+                logger.info("{} successfully performed an unknown action on {} {}", new RequestingUser(event), new AffectedObject(event));
+
+        }
+    }
+
+    /**
+     * Logs that an operation failed to be performed on an object within a
+     * Directory.
+     *
+     * @param event
+     *     The event describing the operation that failed.
+     */
+    private void logFailure(DirectoryFailureEvent<?> event) {
+        DirectoryEvent.Operation op = event.getOperation();
+        switch (op) {
+
+            case GET:
+                if (event.getFailure() instanceof GuacamoleResourceNotFoundException)
+                    logger.debug("{} failed to access/retrieve {}: {}", new RequestingUser(event), new AffectedObject(event), new Failure(event));
+                else
+                    logger.info("{} failed to access/retrieve {}: {}", new RequestingUser(event), new AffectedObject(event), new Failure(event));
+                break;
+
+            case ADD:
+                logger.info("{} failed to create {}: {}", new RequestingUser(event), new AffectedObject(event), new Failure(event));
+                break;
+
+            case UPDATE:
+                logger.info("{} failed to update {}: {}", new RequestingUser(event), new AffectedObject(event), new Failure(event));
+                break;
+
+            case REMOVE:
+                logger.info("{} failed to delete {}: {}", new RequestingUser(event), new AffectedObject(event), new Failure(event));
+                break;
+
+            default:
+                logger.warn("DirectoryEvent operation type has no corresponding log message implemented: {}", op);
+                logger.info("{} failed to perform an unknown action on {}: {}", new RequestingUser(event), new AffectedObject(event), new Failure(event));
+
+        }
+    }
+
+    @Override
+    public void handleEvent(@Nonnull Object event) throws GuacamoleException {
+
+        if (event instanceof DirectorySuccessEvent)
+            logSuccess((DirectorySuccessEvent<?>) event);
+
+        else if (event instanceof DirectoryFailureEvent)
+            logFailure((DirectoryFailureEvent<?>) event);
+
+        else
+            logger.debug("Ignoring unknown/unimplemented event type: {}",
+                    event.getClass());
+
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/event/Failure.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/Failure.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.event;
+
+import org.apache.guacamole.net.event.FailureEvent;
+
+/**
+ * Loggable representation of a failure that occurred.
+ */
+public class Failure implements LoggableDetail {
+
+    /**
+     * The event representing the failure.
+     */
+    private final FailureEvent event;
+
+    /**
+     * Creates a new Failure representing the failure described by the given
+     * event.
+     *
+     * @param event 
+     *     The event representing the failure.
+     */
+    public Failure(FailureEvent event) {
+        this.event = event;
+    }
+
+    @Override
+    public String toString() {
+
+        Throwable failure = event.getFailure();
+        if (failure == null)
+            return "unknown error (no specific failure recorded)";
+
+        return failure.getMessage();
+        
+    }
+    
+}

--- a/guacamole/src/main/java/org/apache/guacamole/event/LoggableDetail.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/LoggableDetail.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.event;
+
+/**
+ * Provides a {@link #toString()} implementation that returns a human-readable
+ * string that is intended to be logged and which describes a particular detail
+ * of an event.
+ */
+public interface LoggableDetail {
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A LoggableDetail implementation of toString() is required to return a
+     * string that is human-readable, describes a detail of a provided event,
+     * and that is intended to be logged.
+     */
+    @Override
+    String toString();
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/event/RemoteAddress.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/RemoteAddress.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.event;
+
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.guacamole.net.auth.Credentials;
+
+/**
+ * Loggable representation of the remote address of a user, including any
+ * intervening proxies noted by "X-Forwarded-For". This representation takes
+ * into account the fact that "X-Forwarded-For" may come from an untrusted
+ * source, logging such addresses within square brackets alongside the trusted
+ * source IP.
+ */
+public class RemoteAddress implements LoggableDetail {
+
+    /**
+     * Regular expression which matches any IPv4 address.
+     */
+    private static final String IPV4_ADDRESS_REGEX = "([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})";
+
+    /**
+     * Regular expression which matches any IPv6 address.
+     */
+    private static final String IPV6_ADDRESS_REGEX = "([0-9a-fA-F]*(:[0-9a-fA-F]*){0,7})";
+
+    /**
+     * Regular expression which matches any IP address, regardless of version.
+     */
+    private static final String IP_ADDRESS_REGEX = "(" + IPV4_ADDRESS_REGEX + "|" + IPV6_ADDRESS_REGEX + ")";
+
+    /**
+     * Regular expression which matches any Port Number.
+     */
+    private static final String PORT_NUMBER_REGEX = "(:[0-9]{1,5})?";
+
+    /**
+     * Pattern which matches valid values of the de-facto standard
+     * "X-Forwarded-For" header.
+     */
+    private static final Pattern X_FORWARDED_FOR = Pattern.compile("^" + IP_ADDRESS_REGEX + PORT_NUMBER_REGEX + "(, " + IP_ADDRESS_REGEX + PORT_NUMBER_REGEX + ")*$");
+
+    /**
+     * The credentials supplied by the user when they authenticated.
+     */
+    private final Credentials creds;
+
+    /**
+     * Creates a new RemoteAddress representing the source address of the HTTP
+     * request that provided the given Credentials.
+     *
+     * @param creds
+     *     The Credentials associated with the request whose source address
+     *     should be represented by this RemoteAddress.
+     */
+    public RemoteAddress(Credentials creds) {
+        this.creds = creds;
+    }
+
+    @Override
+    public String toString() {
+
+        HttpServletRequest request = creds.getRequest();
+        if (request == null)
+            return creds.getRemoteAddress();
+
+        // Log X-Forwarded-For, if present and valid
+        String header = request.getHeader("X-Forwarded-For");
+        if (header != null && X_FORWARDED_FOR.matcher(header).matches())
+            return "[" + header + ", " + request.getRemoteAddr() + "]";
+
+        // If header absent or invalid, just use source IP
+        return request.getRemoteAddr();
+
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/event/RequestingUser.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/RequestingUser.java
@@ -20,7 +20,7 @@
 package org.apache.guacamole.event;
 
 import org.apache.guacamole.net.auth.AuthenticatedUser;
-import org.apache.guacamole.net.event.DirectoryEvent;
+import org.apache.guacamole.net.event.UserEvent;
 
 /**
  * Loggable representation of the user that requested an operation.
@@ -30,7 +30,7 @@ public class RequestingUser implements LoggableDetail {
     /**
      * The event representing the requested operation.
      */
-    private final DirectoryEvent<?> event;
+    private final UserEvent event;
 
     /**
      * Creates a new RequestingUser that represents the user that requested the
@@ -39,7 +39,7 @@ public class RequestingUser implements LoggableDetail {
      * @param event
      *     The event representing the requested operation.
      */
-    public RequestingUser(DirectoryEvent<?> event) {
+    public RequestingUser(UserEvent event) {
         this.event = event;
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/event/RequestingUser.java
+++ b/guacamole/src/main/java/org/apache/guacamole/event/RequestingUser.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.event;
+
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+import org.apache.guacamole.net.event.DirectoryEvent;
+
+/**
+ * Loggable representation of the user that requested an operation.
+ */
+public class RequestingUser implements LoggableDetail {
+
+    /**
+     * The event representing the requested operation.
+     */
+    private final DirectoryEvent<?> event;
+
+    /**
+     * Creates a new RequestingUser that represents the user that requested the
+     * operation described by the given event.
+     *
+     * @param event
+     *     The event representing the requested operation.
+     */
+    public RequestingUser(DirectoryEvent<?> event) {
+        this.event = event;
+    }
+
+    @Override
+    public String toString() {
+
+        AuthenticatedUser user = event.getAuthenticatedUser();
+        String identifier = user.getIdentifier();
+
+        if (AuthenticatedUser.ANONYMOUS_IDENTIFIER.equals(identifier))
+            return "Anonymous user (authenticated by \"" + user.getAuthenticationProvider().getIdentifier() + "\")";
+
+        return "User \"" + identifier + "\" (authenticated by \"" + user.getAuthenticationProvider().getIdentifier() + "\")";
+        
+    }
+
+}

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -35,6 +35,7 @@ import org.apache.guacamole.auth.file.FileAuthenticationProvider;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.environment.Environment;
+import org.apache.guacamole.event.EventLoggingListener;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.event.listener.Listener;
 import org.apache.guacamole.properties.StringSetProperty;
@@ -628,8 +629,9 @@ public class ExtensionModule extends ServletModule {
         final Set<String> toleratedAuthProviders = getToleratedAuthenticationProviders();
         loadExtensions(javaScriptResources, cssResources, toleratedAuthProviders);
 
-        // Always bind default file-driven auth last
+        // Always bind default file-driven auth and event logging last
         bindAuthenticationProvider(FileAuthenticationProvider.class, toleratedAuthProviders);
+        bindListener(EventLoggingListener.class);
 
         // Dynamically generate app.js and app.css from extensions
         serve("/app.js").with(new ResourceServlet(new SequenceResource(javaScriptResources)));

--- a/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/activeconnection/ActiveConnectionDirectoryResource.java
@@ -26,6 +26,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.ActiveConnection;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.UserContext;
@@ -48,6 +49,9 @@ public class ActiveConnectionDirectoryResource
      * operations and subresources available for the given ActiveConnection
      * Directory.
      *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
+     *
      * @param userContext
      *     The UserContext associated with the given Directory.
      *
@@ -63,11 +67,13 @@ public class ActiveConnectionDirectoryResource
      *     representing ActiveConnections.
      */
     @AssistedInject
-    public ActiveConnectionDirectoryResource(@Assisted UserContext userContext,
+    public ActiveConnectionDirectoryResource(
+            @Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext,
             @Assisted Directory<ActiveConnection> directory,
             DirectoryObjectTranslator<ActiveConnection, APIActiveConnection> translator,
             DirectoryObjectResourceFactory<ActiveConnection, APIActiveConnection> resourceFactory) {
-        super(userContext, directory, translator, resourceFactory);
+        super(authenticatedUser, userContext, ActiveConnection.class, directory, translator, resourceFactory);
     }
 
     @Override

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -21,9 +21,7 @@ package org.apache.guacamole.rest.auth;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
@@ -97,57 +95,6 @@ public class AuthenticationService {
      * token used by the Guacamole REST API.
      */
     public static final String TOKEN_PARAMETER_NAME = "token";
-
-    /**
-     * Regular expression which matches any IPv4 address.
-     */
-    private static final String IPV4_ADDRESS_REGEX = "([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})";
-
-    /**
-     * Regular expression which matches any IPv6 address.
-     */
-    private static final String IPV6_ADDRESS_REGEX = "([0-9a-fA-F]*(:[0-9a-fA-F]*){0,7})";
-
-    /**
-     * Regular expression which matches any IP address, regardless of version.
-     */
-    private static final String IP_ADDRESS_REGEX = "(" + IPV4_ADDRESS_REGEX + "|" + IPV6_ADDRESS_REGEX + ")";
-
-    /**
-     * Regular expression which matches any Port Number.
-     */
-    private static final String PORT_NUMBER_REGEX = "(:[0-9]{1,5})?";
-    
-    /**
-     * Pattern which matches valid values of the de-facto standard
-     * "X-Forwarded-For" header.
-     */
-    private static final Pattern X_FORWARDED_FOR = Pattern.compile("^" + IP_ADDRESS_REGEX + PORT_NUMBER_REGEX + "(, " + IP_ADDRESS_REGEX + PORT_NUMBER_REGEX + ")*$");
-
-    /**
-     * Returns a formatted string containing an IP address, or list of IP
-     * addresses, which represent the HTTP client and any involved proxies. As
-     * the headers used to determine proxies can easily be forged, this data is
-     * superficially validated to ensure that it at least looks like a list of
-     * IPs.
-     *
-     * @param request
-     *     The HTTP request to format.
-     *
-     * @return
-     *     A formatted string containing one or more IP addresses.
-     */
-    private String getLoggableAddress(HttpServletRequest request) {
-
-        // Log X-Forwarded-For, if present and valid
-        String header = request.getHeader("X-Forwarded-For");
-        if (header != null && X_FORWARDED_FOR.matcher(header).matches())
-            return "[" + header + ", " + request.getRemoteAddr() + "]";
-
-        // If header absent or invalid, just use source IP
-        return request.getRemoteAddr();
-
-    }
 
     /**
      * Attempts authentication against all AuthenticationProviders, in order,
@@ -437,12 +384,12 @@ public class AuthenticationService {
             else {
                 authToken = authTokenGenerator.getToken();
                 tokenSessionMap.put(authToken, new GuacamoleSession(listenerService, authenticatedUser, userContexts));
-                logger.debug("Login was successful for user \"{}\".", authenticatedUser.getIdentifier());
             }
 
             // Report authentication success
             try {
-                listenerService.handleEvent(new AuthenticationSuccessEvent(authenticatedUser));
+                listenerService.handleEvent(new AuthenticationSuccessEvent(authenticatedUser,
+                        existingSession != null));
             }
             catch (GuacamoleException e) {
                 throw new GuacamoleAuthenticationProcessException("User "
@@ -454,24 +401,8 @@ public class AuthenticationService {
         // Log and rethrow any authentication errors
         catch (GuacamoleAuthenticationProcessException e) {
 
-            // Get request and username for sake of logging
-            HttpServletRequest request = credentials.getRequest();
-            String username = credentials.getUsername();
-
             listenerService.handleEvent(new AuthenticationFailureEvent(credentials,
                     e.getAuthenticationProvider(), e.getCause()));
-
-            // Log authentication failures with associated usernames
-            if (username != null) {
-                if (logger.isWarnEnabled())
-                    logger.warn("Authentication attempt from {} for user \"{}\" failed.",
-                            getLoggableAddress(request), username);
-            }
-
-            // Log anonymous authentication failures
-            else if (logger.isDebugEnabled())
-                logger.debug("Anonymous authentication attempt from {} failed.",
-                        getLoggableAddress(request));
 
             // Rethrow exception
             e.rethrowCause();
@@ -489,11 +420,6 @@ public class AuthenticationService {
             throw e.getCauseAsGuacamoleException();
 
         }
-
-        if (logger.isInfoEnabled())
-            logger.info("User \"{}\" successfully authenticated from {}.",
-                    authenticatedUser.getIdentifier(),
-                    getLoggableAddress(credentials.getRequest()));
 
         return authToken;
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/AuthenticationService.java
@@ -30,7 +30,6 @@ import org.apache.guacamole.GuacamoleSecurityException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.GuacamoleUnauthorizedException;
 import org.apache.guacamole.GuacamoleSession;
-import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
@@ -55,12 +54,6 @@ public class AuthenticationService {
      * Logger for this class.
      */
     private static final Logger logger = LoggerFactory.getLogger(AuthenticationService.class);
-
-    /**
-     * The Guacamole server environment.
-     */
-    @Inject
-    private Environment environment;
 
     /**
      * All configured authentication providers which can be used to
@@ -443,7 +436,7 @@ public class AuthenticationService {
             // If no existing session, generate a new token/session pair
             else {
                 authToken = authTokenGenerator.getToken();
-                tokenSessionMap.put(authToken, new GuacamoleSession(environment, authenticatedUser, userContexts));
+                tokenSessionMap.put(authToken, new GuacamoleSession(listenerService, authenticatedUser, userContexts));
                 logger.debug("Login was successful for user \"{}\".", authenticatedUser.getIdentifier());
             }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/HashTokenSessionMap.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/HashTokenSessionMap.java
@@ -225,7 +225,13 @@ public class HashTokenSessionMap implements TokenSessionMap {
 
     @Override
     public void shutdown() {
+
+        // Terminate the automatic session invalidation thread
         executor.shutdownNow();
+
+        // Forcibly invalidate any remaining sessions
+        sessionMap.values().stream().forEach(GuacamoleSession::invalidate);
+
     }
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connection/ConnectionDirectoryResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
@@ -47,6 +48,9 @@ public class ConnectionDirectoryResource
      * Creates a new ConnectionDirectoryResource which exposes the operations
      * and subresources available for the given Connection Directory.
      *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
+     *
      * @param userContext
      *     The UserContext associated with the given Directory.
      *
@@ -62,11 +66,11 @@ public class ConnectionDirectoryResource
      *     representing Connections.
      */
     @AssistedInject
-    public ConnectionDirectoryResource(@Assisted UserContext userContext,
-            @Assisted Directory<Connection> directory,
+    public ConnectionDirectoryResource(@Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext, @Assisted Directory<Connection> directory,
             DirectoryObjectTranslator<Connection, APIConnection> translator,
             DirectoryObjectResourceFactory<Connection, APIConnection> resourceFactory) {
-        super(userContext, directory, translator, resourceFactory);
+        super(authenticatedUser, userContext, Connection.class, directory, translator, resourceFactory);
     }
 
     @Override

--- a/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/connectiongroup/ConnectionGroupResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.UserContext;
@@ -46,19 +47,11 @@ public class ConnectionGroupResource
         extends DirectoryObjectResource<ConnectionGroup, APIConnectionGroup> {
 
     /**
-     * The UserContext associated with the Directory which contains the
-     * ConnectionGroup exposed by this resource.
-     */
-    private final UserContext userContext;
-
-    /**
-     * The ConnectionGroup object represented by this ConnectionGroupResource.
-     */
-    private final ConnectionGroup connectionGroup;
-
-    /**
      * Creates a new ConnectionGroupResource which exposes the operations and
      * subresources available for the given ConnectionGroup.
+     *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
      *
      * @param userContext
      *     The UserContext associated with the given Directory.
@@ -75,13 +68,13 @@ public class ConnectionGroupResource
      *     object given.
      */
     @AssistedInject
-    public ConnectionGroupResource(@Assisted UserContext userContext,
+    public ConnectionGroupResource(
+            @Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext,
             @Assisted Directory<ConnectionGroup> directory,
             @Assisted ConnectionGroup connectionGroup,
             DirectoryObjectTranslator<ConnectionGroup, APIConnectionGroup> translator) {
-        super(userContext, directory, connectionGroup, translator);
-        this.userContext = userContext;
-        this.connectionGroup = connectionGroup;
+        super(authenticatedUser, userContext, ConnectionGroup.class, directory, connectionGroup, translator);
     }
 
     /**
@@ -107,8 +100,8 @@ public class ConnectionGroupResource
             throws GuacamoleException {
 
         // Retrieve the requested tree, filtering by the given permissions
-        ConnectionGroupTree tree = new ConnectionGroupTree(userContext,
-                connectionGroup, permissions);
+        ConnectionGroupTree tree = new ConnectionGroupTree(getUserContext(),
+                getInternalObject(), permissions);
 
         // Return tree as a connection group
         return tree.getRootAPIConnectionGroup();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectResourceFactory.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectResourceFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.rest.directory;
 
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Identifiable;
 import org.apache.guacamole.net.auth.UserContext;
@@ -41,6 +42,9 @@ public interface DirectoryObjectResourceFactory<InternalType extends Identifiabl
     /**
      * Creates a new DirectoryObjectResource which exposes the given object.
      *
+     * @param authenticatedUser
+     *     The user that is accessing the resource.
+     *
      * @param userContext
      *     The UserContext which contains the given Directory.
      *
@@ -55,7 +59,7 @@ public interface DirectoryObjectResourceFactory<InternalType extends Identifiabl
      *     A new DirectoryObjectResource which exposes the given object.
      */
     DirectoryObjectResource<InternalType, ExternalType>
-        create(UserContext userContext, Directory<InternalType> directory,
-                InternalType object);
+        create(AuthenticatedUser authenticatedUser, UserContext userContext,
+                Directory<InternalType> directory, InternalType object);
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResourceFactory.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResourceFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.rest.directory;
 
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Identifiable;
 import org.apache.guacamole.net.auth.UserContext;
@@ -41,6 +42,9 @@ public interface DirectoryResourceFactory<InternalType extends Identifiable, Ext
     /**
      * Creates a new DirectoryResource which exposes the given Directory.
      *
+     * @param authenticatedUser
+     *     The user that is accessing the resource.
+     *
      * @param userContext
      *     The UserContext from which the given Directory was obtained.
      *
@@ -52,6 +56,7 @@ public interface DirectoryResourceFactory<InternalType extends Identifiable, Ext
      *     A new DirectoryResource which exposes the given Directory.
      */
     DirectoryResource<InternalType, ExternalType>
-        create(UserContext userContext, Directory<InternalType> directory);
+        create(AuthenticatedUser authenticatedUser, UserContext userContext,
+                Directory<InternalType> directory);
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/session/SessionResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/session/SessionResource.java
@@ -116,7 +116,7 @@ public class SessionResource {
         UserContext userContext = session.getUserContext(authProviderIdentifier);
 
         // Return a resource exposing the retrieved UserContext
-        return userContextResourceFactory.create(userContext);
+        return userContextResourceFactory.create(session.getAuthenticatedUser(), userContext);
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.ActiveConnection;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.SharingProfile;
@@ -58,6 +59,11 @@ public class UserContextResource {
      * The UserContext being exposed through this resource.
      */
     private final UserContext userContext;
+
+    /**
+     * The user that is accessing this resource.
+     */
+    private final AuthenticatedUser authenticatedUser;
 
     /**
      * Factory for creating DirectoryObjectResources which expose a given User.
@@ -115,12 +121,17 @@ public class UserContextResource {
      * Creates a new UserContextResource which exposes the data within the
      * given UserContext.
      *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
+     *
      * @param userContext
      *     The UserContext which should be exposed through this
      *     UserContextResource.
      */
     @AssistedInject
-    public UserContextResource(@Assisted UserContext userContext) {
+    public UserContextResource(@Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext) {
+        this.authenticatedUser = authenticatedUser;
         this.userContext = userContext;
     }
 
@@ -140,7 +151,7 @@ public class UserContextResource {
     @Path("self")
     public DirectoryObjectResource<User, APIUser> getSelfResource()
             throws GuacamoleException {
-        return userResourceFactory.create(userContext,
+        return userResourceFactory.create(authenticatedUser, userContext,
                 userContext.getUserDirectory(), userContext.self());
     }
 
@@ -158,8 +169,8 @@ public class UserContextResource {
     @Path("activeConnections")
     public DirectoryResource<ActiveConnection, APIActiveConnection>
         getActiveConnectionDirectoryResource() throws GuacamoleException {
-        return activeConnectionDirectoryResourceFactory.create(userContext,
-                userContext.getActiveConnectionDirectory());
+        return activeConnectionDirectoryResourceFactory.create(authenticatedUser,
+                userContext, userContext.getActiveConnectionDirectory());
     }
 
     /**
@@ -176,8 +187,8 @@ public class UserContextResource {
     @Path("connections")
     public DirectoryResource<Connection, APIConnection> getConnectionDirectoryResource()
             throws GuacamoleException {
-        return connectionDirectoryResourceFactory.create(userContext,
-                userContext.getConnectionDirectory());
+        return connectionDirectoryResourceFactory.create(authenticatedUser,
+                userContext, userContext.getConnectionDirectory());
     }
 
     /**
@@ -194,8 +205,8 @@ public class UserContextResource {
     @Path("connectionGroups")
     public DirectoryResource<ConnectionGroup, APIConnectionGroup> getConnectionGroupDirectoryResource()
             throws GuacamoleException {
-        return connectionGroupDirectoryResourceFactory.create(userContext,
-                userContext.getConnectionGroupDirectory());
+        return connectionGroupDirectoryResourceFactory.create(authenticatedUser,
+                userContext, userContext.getConnectionGroupDirectory());
     }
 
     /**
@@ -212,8 +223,8 @@ public class UserContextResource {
     @Path("sharingProfiles")
     public DirectoryResource<SharingProfile, APISharingProfile>
         getSharingProfileDirectoryResource() throws GuacamoleException {
-        return sharingProfileDirectoryResourceFactory.create(userContext,
-                userContext.getSharingProfileDirectory());
+        return sharingProfileDirectoryResourceFactory.create(authenticatedUser,
+                userContext, userContext.getSharingProfileDirectory());
     }
 
     /**
@@ -230,8 +241,8 @@ public class UserContextResource {
     @Path("users")
     public DirectoryResource<User, APIUser> getUserDirectoryResource()
             throws GuacamoleException {
-        return userDirectoryResourceFactory.create(userContext,
-                userContext.getUserDirectory());
+        return userDirectoryResourceFactory.create(authenticatedUser,
+                userContext, userContext.getUserDirectory());
     }
 
     /**
@@ -248,8 +259,8 @@ public class UserContextResource {
     @Path("userGroups")
     public DirectoryResource<UserGroup, APIUserGroup> getUserGroupDirectoryResource()
             throws GuacamoleException {
-        return userGroupDirectoryResourceFactory.create(userContext,
-                userContext.getUserGroupDirectory());
+        return userGroupDirectoryResourceFactory.create(authenticatedUser,
+                userContext, userContext.getUserGroupDirectory());
     }
 
     /**

--- a/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResourceFactory.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/session/UserContextResourceFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.guacamole.rest.session;
 
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.UserContext;
 
 /**
@@ -31,6 +32,9 @@ public interface UserContextResourceFactory {
      * Creates a new UserContextResource which exposes the contents of the
      * given UserContext.
      *
+     * @param authenticatedUser
+     *     The user that is accessing the resource.
+     *
      * @param userContext
      *     The UserContext whose contents should be exposed.
      *
@@ -38,6 +42,7 @@ public interface UserContextResourceFactory {
      *     A new UserContextResource which exposes the contents of the given
      *     UserContext.
      */
-    UserContextResource create(UserContext userContext);
+    UserContextResource create(AuthenticatedUser authenticatedUser,
+            UserContext userContext);
 
 }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileDirectoryResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.SharingProfile;
@@ -48,6 +49,9 @@ public class SharingProfileDirectoryResource
      * operations and subresources available for the given SharingProfile
      * Directory.
      *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
+     *
      * @param userContext
      *     The UserContext associated with the given Directory.
      *
@@ -63,11 +67,13 @@ public class SharingProfileDirectoryResource
      *     representing SharingProfiles.
      */
     @AssistedInject
-    public SharingProfileDirectoryResource(@Assisted UserContext userContext,
+    public SharingProfileDirectoryResource(
+            @Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext,
             @Assisted Directory<SharingProfile> directory,
             DirectoryObjectTranslator<SharingProfile, APISharingProfile> translator,
             DirectoryObjectResourceFactory<SharingProfile, APISharingProfile> resourceFactory) {
-        super(userContext, directory, translator, resourceFactory);
+        super(authenticatedUser, userContext, SharingProfile.class, directory, translator, resourceFactory);
     }
 
     @Override

--- a/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/sharingprofile/SharingProfileResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleSecurityException;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
 import org.apache.guacamole.net.auth.SharingProfile;
@@ -50,19 +51,11 @@ public class SharingProfileResource
         extends DirectoryObjectResource<SharingProfile, APISharingProfile> {
 
     /**
-     * The UserContext associated with the Directory which contains the
-     * SharingProfile exposed by this resource.
-     */
-    private final UserContext userContext;
-
-    /**
-     * The SharingProfile object represented by this SharingProfileResource.
-     */
-    private final SharingProfile sharingProfile;
-
-    /**
      * Creates a new SharingProfileResource which exposes the operations and
      * subresources available for the given SharingProfile.
+     *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
      *
      * @param userContext
      *     The UserContext associated with the given Directory.
@@ -78,13 +71,12 @@ public class SharingProfileResource
      *     object given.
      */
     @AssistedInject
-    public SharingProfileResource(@Assisted UserContext userContext,
+    public SharingProfileResource(@Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext,
             @Assisted Directory<SharingProfile> directory,
             @Assisted SharingProfile sharingProfile,
             DirectoryObjectTranslator<SharingProfile, APISharingProfile> translator) {
-        super(userContext, directory, sharingProfile, translator);
-        this.userContext = userContext;
-        this.sharingProfile = sharingProfile;
+        super(authenticatedUser, userContext, SharingProfile.class, directory, sharingProfile, translator);
     }
 
     /**
@@ -103,8 +95,10 @@ public class SharingProfileResource
     public Map<String, String> getParameters()
             throws GuacamoleException {
 
+        SharingProfile sharingProfile = getInternalObject();
+        
         // Pull effective permissions
-        Permissions effective = userContext.self().getEffectivePermissions();
+        Permissions effective = getUserContext().self().getEffectivePermissions();
 
         // Retrieve permission sets
         SystemPermissionSet systemPermissions = effective.getSystemPermissions();

--- a/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelCollectionResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelCollectionResource.java
@@ -105,7 +105,7 @@ public class TunnelCollectionResource {
             throw new GuacamoleResourceNotFoundException("No such tunnel.");
 
         // Return corresponding tunnel resource
-        return tunnelResourceFactory.create(tunnel);
+        return tunnelResourceFactory.create(session.getAuthenticatedUser(), tunnel);
 
     }
 

--- a/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/tunnel/TunnelResource.java
@@ -34,6 +34,7 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleResourceNotFoundException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.net.auth.ActiveConnection;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.UserContext;
 import org.apache.guacamole.protocols.ProtocolInfo;
 import org.apache.guacamole.rest.activeconnection.APIActiveConnection;
@@ -55,6 +56,11 @@ public class TunnelResource {
      */
     private static final String DEFAULT_MEDIA_TYPE = MediaType.APPLICATION_OCTET_STREAM;
 
+    /**
+     * The user that is accessing this resource.
+     */
+    private final AuthenticatedUser authenticatedUser;
+    
     /**
      * The tunnel that this TunnelResource represents.
      */
@@ -78,11 +84,16 @@ public class TunnelResource {
      * Creates a new TunnelResource which exposes the operations and
      * subresources available for the given tunnel.
      *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
+     *
      * @param tunnel
      *     The tunnel that this TunnelResource should represent.
      */
     @AssistedInject
-    public TunnelResource(@Assisted UserTunnel tunnel) {
+    public TunnelResource(@Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserTunnel tunnel) {
+        this.authenticatedUser = authenticatedUser;
         this.tunnel = tunnel;
     }
 
@@ -110,7 +121,7 @@ public class TunnelResource {
             throw new GuacamoleResourceNotFoundException("No readable active connection for tunnel.");
 
         // Return the associated ActiveConnection as a resource
-        return activeConnectionResourceFactory.create(userContext,
+        return activeConnectionResourceFactory.create(authenticatedUser, userContext,
                 userContext.getActiveConnectionDirectory(), activeConnection);
 
     }

--- a/guacamole/src/main/java/org/apache/guacamole/rest/user/UserDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/user/UserDirectoryResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
@@ -46,6 +47,9 @@ public class UserDirectoryResource extends DirectoryResource<User, APIUser> {
      * Creates a new UserDirectoryResource which exposes the operations and
      * subresources available for the given User Directory.
      *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
+     *
      * @param userContext
      *     The UserContext associated with the given Directory.
      *
@@ -61,11 +65,12 @@ public class UserDirectoryResource extends DirectoryResource<User, APIUser> {
      *     representing Users.
      */
     @AssistedInject
-    public UserDirectoryResource(@Assisted UserContext userContext,
+    public UserDirectoryResource(@Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext,
             @Assisted Directory<User> directory,
             DirectoryObjectTranslator<User, APIUser> translator,
             DirectoryObjectResourceFactory<User, APIUser> resourceFactory) {
-        super(userContext, directory, translator, resourceFactory);
+        super(authenticatedUser, userContext, User.class, directory, translator, resourceFactory);
     }
 
     @Override

--- a/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupDirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupDirectoryResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.UserGroup;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.Permissions;
@@ -46,6 +47,9 @@ public class UserGroupDirectoryResource extends DirectoryResource<UserGroup, API
      * Creates a new UserGroupDirectoryResource which exposes the operations
      * and subresources available for the given UserGroup Directory.
      *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
+     *
      * @param userContext
      *     The UserContext associated with the given Directory.
      *
@@ -61,11 +65,13 @@ public class UserGroupDirectoryResource extends DirectoryResource<UserGroup, API
      *     representing UserGroups.
      */
     @AssistedInject
-    public UserGroupDirectoryResource(@Assisted UserContext userContext,
+    public UserGroupDirectoryResource(
+            @Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext,
             @Assisted Directory<UserGroup> directory,
             DirectoryObjectTranslator<UserGroup, APIUserGroup> translator,
             DirectoryObjectResourceFactory<UserGroup, APIUserGroup> resourceFactory) {
-        super(userContext, directory, translator, resourceFactory);
+        super(authenticatedUser, userContext, UserGroup.class, directory, translator, resourceFactory);
     }
 
     @Override

--- a/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupResource.java
@@ -26,6 +26,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.UserGroup;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.UserContext;
@@ -44,13 +45,11 @@ public class UserGroupResource
         extends DirectoryObjectResource<UserGroup, APIUserGroup> {
 
     /**
-     * The UserGroup object represented by this UserGroupResource.
-     */
-    private final UserGroup userGroup;
-
-    /**
      * Creates a new UserGroupResource which exposes the operations and
      * subresources available for the given UserGroup.
+     *
+     * @param authenticatedUser
+     *     The user that is accessing this resource.
      *
      * @param userContext
      *     The UserContext associated with the given Directory.
@@ -65,12 +64,12 @@ public class UserGroupResource
      *     A DirectoryObjectTranslator implementation which handles Users.
      */
     @AssistedInject
-    public UserGroupResource(@Assisted UserContext userContext,
+    public UserGroupResource(@Assisted AuthenticatedUser authenticatedUser,
+            @Assisted UserContext userContext,
             @Assisted Directory<UserGroup> directory,
             @Assisted UserGroup userGroup,
             DirectoryObjectTranslator<UserGroup, APIUserGroup> translator) {
-        super(userContext, directory, userGroup, translator);
-        this.userGroup = userGroup;
+        super(authenticatedUser, userContext, UserGroup.class, directory, userGroup, translator);
     }
 
     /**
@@ -87,7 +86,7 @@ public class UserGroupResource
      */
     @Path("userGroups")
     public RelatedObjectSetResource getUserGroups() throws GuacamoleException {
-        return new RelatedObjectSetResource(userGroup.getUserGroups());
+        return new RelatedObjectSetResource(getInternalObject().getUserGroups());
     }
 
     /**
@@ -104,7 +103,7 @@ public class UserGroupResource
      */
     @Path("memberUsers")
     public RelatedObjectSetResource getMemberUsers() throws GuacamoleException {
-        return new RelatedObjectSetResource(userGroup.getMemberUsers());
+        return new RelatedObjectSetResource(getInternalObject().getMemberUsers());
     }
 
     /**
@@ -121,7 +120,7 @@ public class UserGroupResource
      */
     @Path("memberUserGroups")
     public RelatedObjectSetResource getMemberUserGroups() throws GuacamoleException {
-        return new RelatedObjectSetResource(userGroup.getMemberUserGroups());
+        return new RelatedObjectSetResource(getInternalObject().getMemberUserGroups());
     }
 
     /**
@@ -135,7 +134,7 @@ public class UserGroupResource
      */
     @Path("permissions")
     public PermissionSetResource getPermissions() {
-        return new PermissionSetResource(userGroup);
+        return new PermissionSetResource(getInternalObject());
     }
 
 }


### PR DESCRIPTION
This change expands the types of events provided by guacamole-ext, adding events for modifications to objects stored in a `Directory` off the `UserContext`. Combined with an event listener bundled with the webapp, the following events are now logged:

* Startup/shutdown of the webapp (though shutdown may not be visible in the logs if Tomcat stops its logger first)
* Creation, modification, and deletion of **all** objects (active connections, connections, connection groups, users, user groups, and sharing profiles)
* User logout / session expiration

Authentication events that used to be logged manually by the webapp have also now been migrated to that bundled, global listener.

Further changes will be made to add the following in a future PR:

* Permission changes
* Group membership changes
* Connection sharing and usage
