### PR TITLE
GUACAMOLE-1594: Exclude optional JavaMail dependency from Logback.

### DIFF
--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -231,6 +231,15 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <exclusions>
+
+                <!-- Exclude optional dependency on JavaMail -->
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+
+            </exclusions>
         </dependency>
 
         <!-- Guacamole Extension API -->


### PR DESCRIPTION
This change un-breaks the build by excluding the optional JavaMail dependency introduced by the latest version of Logback 1.3.x.