### PR TITLE
GUACAMOLE-1656: Fix user preferences permissioning.

### DIFF
--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmAttributeService.java
@@ -145,11 +145,6 @@ public class KsmAttributeService implements VaultAttributeService {
 
     @Override
     public Collection<Form> getUserAttributes() {
-        return KSM_ATTRIBUTES;
-    }
-
-    @Override
-    public Collection<Form> getUserPreferenceAttributes() {
 
         try {
 
@@ -161,15 +156,24 @@ public class KsmAttributeService implements VaultAttributeService {
         catch (GuacamoleException e) {
 
             logger.warn(
-                    "Unable to determine if user preference attributes "
+                    "Unable to determine if KSM user attributes "
                     + "should be exposed due to config parsing error: {}.", e.getMessage());
             logger.debug(
-                    "Config parsing error prevented checking user preference configuration",
+                    "Config parsing error prevented checking user attribute configuration",
                     e);
 
-            // If the configuration can't be parsed, default to not exposing the attribute
+            // If the configuration can't be parsed, default to not exposing the attributes
             return Collections.emptyList();
         }
+
+    }
+
+    @Override
+    public Collection<Form> getUserPreferenceAttributes() {
+
+        // KSM-specific user preference attributes have the same semantics as
+        // user attributes
+        return getUserAttributes();
     }
 
     /**

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
@@ -150,11 +150,13 @@ public class KsmConfigurationService extends VaultConfigurationService {
     }
 
     /**
-     * Return whether users should be able to provide their own KSM configs.
+     * Return whether user-level KSM configs should be enabled. If this
+     * flag is set to true, users can edit their own KSM configs, as can
+     * admins. If set to false, no existing user-specific KSM configuration
+     * will be exposed through the UI or used when looking up secrets.
      *
      * @return
-     *     true if users should be able to provide their own KSM configs,
-     *     false otherwise.
+     *     true if user-specific KSM configuration is enabled, false otherwise.
      *
      * @throws GuacamoleException
      *     If the value specified within guacamole.properties cannot be

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmDirectoryService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/user/KsmDirectoryService.java
@@ -23,7 +23,6 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.net.auth.Connection;
 import org.apache.guacamole.net.auth.ConnectionGroup;
 import org.apache.guacamole.net.auth.DecoratingDirectory;
-import org.apache.guacamole.net.auth.DelegatingDirectory;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.vault.ksm.conf.KsmAttributeService;

--- a/guacamole/src/main/frontend/src/app/settings/directives/guacSettingsPreferences.js
+++ b/guacamole/src/main/frontend/src/app/settings/directives/guacSettingsPreferences.js
@@ -143,12 +143,13 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
             $scope.newPasswordMatch = null;
 
             /**
-             * Whether the current user can change their own password, or null
-             * if this is not yet known.
+             * Whether the current user can edit themselves - i.e. update their
+             * password or change user preference attributes, or null if this
+             * is not yet known.
              *
              * @type Boolean
              */
-            $scope.canChangePassword = null;
+            $scope.canUpdateSelf = null;
 
             /**
              * Update the current user's password to the password currently set within
@@ -206,13 +207,13 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
             permissionService.getEffectivePermissions(dataSource, username)
             .then(function permissionsRetrieved(permissions) {
 
-                // Add action for changing password if permission is granted
-                $scope.canChangePassword = PermissionSet.hasUserPermission(permissions,
+                // Add action for updaing password or user preferences if permission is granted
+                $scope.canUpdateSelf = PermissionSet.hasUserPermission(permissions,
                         PermissionSet.ObjectPermissionType.UPDATE, username);
                         
             })
             ['catch'](requestService.createErrorCallback(function permissionsFailed(error) {
-                $scope.canChangePassword = false;
+                $scope.canUpdateSelf = false;
             }));
 
             /**
@@ -224,8 +225,8 @@ angular.module('settings').directive('guacSettingsPreferences', [function guacSe
              */
             $scope.isLoaded = function isLoaded() {
 
-                return $scope.canChangePassword !== null
-                    && $scope.languages         !== null;
+                return $scope.canUpdateSelf !== null
+                    && $scope.languages     !== null;
 
             };
 

--- a/guacamole/src/main/frontend/src/app/settings/templates/settingsPreferences.html
+++ b/guacamole/src/main/frontend/src/app/settings/templates/settingsPreferences.html
@@ -7,8 +7,8 @@
     </div>
     
     <!-- Password update -->
-    <h2 class="header" ng-show="canChangePassword">{{'SETTINGS_PREFERENCES.SECTION_HEADER_UPDATE_PASSWORD' | translate}}</h2>
-    <div class="settings section update-password" ng-show="canChangePassword">
+    <h2 class="header" ng-show="canUpdateSelf">{{'SETTINGS_PREFERENCES.SECTION_HEADER_UPDATE_PASSWORD' | translate}}</h2>
+    <div class="settings section update-password" ng-show="canUpdateSelf">
         <p>{{'SETTINGS_PREFERENCES.HELP_UPDATE_PASSWORD' | translate}}</p>
 
         <!-- Password editor -->
@@ -90,7 +90,7 @@
     </div>
 
     <!-- User attributes section -->
-    <div class="attributes" ng-show="attributes.length">
+    <div class="attributes" ng-show="canUpdateSelf && attributes.length">
         <guac-form namespace="'USER_ATTRIBUTES'" content="attributes"
                    model="user.attributes"></guac-form>
 


### PR DESCRIPTION
This change ensures that:
* Users only see the KSM config attribute on their preferences if they have permission to edit it (i.e. update access to their own user).
* Admins do not see the user KSM config attribute for users if user-specific KSM attributes are not enabled.
* Clarified the meaning of the user-specific KSM attribute in light of the above.