### PR TITLE
GUACAMOLE-1772: Allow user configuration of KSM API call timeout.

### DIFF
--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/conf/KsmConfigurationService.java
@@ -28,6 +28,7 @@ import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.properties.BooleanGuacamoleProperty;
+import org.apache.guacamole.properties.LongGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
 import org.apache.guacamole.vault.conf.VaultConfigurationService;
 
@@ -121,6 +122,17 @@ public class KsmConfigurationService extends VaultConfigurationService {
     };
 
     /**
+     * The minimum number of milliseconds between KSM API calls.
+     */
+    private static final LongGuacamoleProperty KSM_API_CALL_INTERVAL = new LongGuacamoleProperty() {
+
+        @Override
+        public String getName() {
+            return "ksm-api-call-interval";
+        }
+    };
+
+    /**
      * Creates a new KsmConfigurationService which reads the configuration
      * from "ksm-token-mapping.yml" and properties from
      * "guacamole.properties.ksm". The token mapping is a YAML file which lists
@@ -176,6 +188,20 @@ public class KsmConfigurationService extends VaultConfigurationService {
         return environment.getProperty(MATCH_USER_DOMAINS, false);
     }
 
+    /**
+     * Return the minimum number of milliseconds between KSM API calls. If not
+     * otherwise configured, this value will be 10 seconds.
+     *
+     * @return
+     *     The minimum number of milliseconds between KSM API calls.
+     *
+     * @throws GuacamoleException
+     *     If the value specified within guacamole.properties cannot be
+     *     parsed or does not exist.
+     */
+    public long getKsmApiInterval() throws GuacamoleException {
+        return environment.getProperty(KSM_API_CALL_INTERVAL, 10000L);
+    }
 
     /**
      * Return the globally-defined base-64-encoded JSON KSM configuration blob
@@ -189,7 +215,12 @@ public class KsmConfigurationService extends VaultConfigurationService {
      *     If the value specified within guacamole.properties cannot be
      *     parsed or does not exist.
      */
+    @Nonnull
+    @SuppressWarnings("null")
     public String getKsmConfig() throws GuacamoleException {
+
+        // This will always return a non-null value; an exception would be
+        // thrown if the required value is not set
         return environment.getRequiredProperty(KSM_CONFIG);
     }
 
@@ -235,6 +266,7 @@ public class KsmConfigurationService extends VaultConfigurationService {
      * @throws GuacamoleException
      *     If an invalid ksmConfig parameter is provided.
      */
+    @Nonnull
     public SecretsManagerOptions getSecretsManagerOptions(@Nonnull String ksmConfig) throws GuacamoleException {
 
         return new SecretsManagerOptions(

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClientFactory.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClientFactory.java
@@ -30,16 +30,21 @@ public interface KsmClientFactory {
 
     /**
      * Returns a new instance of a KsmClient instance associated with
-     * the provided KSM configuration options.
+     * the provided KSM configuration options and API interval.
      *
      * @param ksmConfigOptions
      *     The KSM config options to use when constructing the KsmClient
      *     object.
      *
+     * @param apiInterval
+     *     The minimum number of milliseconds that must elapse between KSM API
+     *     calls.
+     *
      * @return
      *     A new KsmClient instance associated with the provided KSM config
      *     options.
      */
-    KsmClient create(@Nonnull SecretsManagerOptions ksmConfigOptions);
+    KsmClient create(
+            @Nonnull SecretsManagerOptions ksmConfigOptions, long apiInterval);
 
 }

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmSecretService.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmSecretService.java
@@ -124,7 +124,7 @@ public class KsmSecretService implements VaultSecretService {
 
         // Create and store a new KSM client instance for the provided KSM config blob
         SecretsManagerOptions options = confService.getSecretsManagerOptions(ksmConfig);
-        ksmClient = ksmClientFactory.create(options);
+        ksmClient = ksmClientFactory.create(options, confService.getKsmApiInterval());
         KsmClient prevClient = ksmClientMap.putIfAbsent(ksmConfig, ksmClient);
 
         // If the client was already set before this thread got there, use the existing one
@@ -274,6 +274,7 @@ public class KsmSecretService implements VaultSecretService {
      *     no KSM config is found in the connection group tree, and the value is also not
      *     defined in the config file.
      */
+    @Nonnull
     private String getConnectionGroupKsmConfig(
             UserContext userContext, Connectable connectable) throws GuacamoleException {
 


### PR DESCRIPTION
As discussed in [GUACAMOLE-1772](https://issues.apache.org/jira/browse/GUACAMOLE-1722) this allows user configuration of the KSM API call timeout.

While I was in there, I also cleaned up some warnings about unchecked null references.