### PR TITLE
GUACAMOLE-1728: Allow Null User Object attributes to be saved.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectTranslator.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectTranslator.java
@@ -145,8 +145,9 @@ public abstract class DirectoryObjectTranslator<InternalType extends Identifiabl
                 String attributeValue = attributes.get(attributeName);
 
                 // Include attribute value within filtered map only if
-                // (1) defined and (2) present within provided map
-                if (attributeValue != null)
+                // defined or present within provided map
+                if (attributeValue != null || 
+                        attributes.containsKey(attributeName))
                     filtered.put(attributeName, attributeValue);
 
             }


### PR DESCRIPTION
Attributes with a value of `null` get filtered out when saving objects. An empty `timezone` attribute is `null`, but we want to save null value attributes.