### PR TITLE
GUACAMOLE-1604: Bump version numbers to 1.5.0.

### DIFF
--- a/doc/guacamole-example/pom.xml
+++ b/doc/guacamole-example/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-example</artifactId>
     <packaging>war</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-example</name>
     <url>http://guacamole.apache.org/</url>
 
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/doc/guacamole-playback-example/pom.xml
+++ b/doc/guacamole-playback-example/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-playback-example</artifactId>
     <packaging>war</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-playback-example</name>
     <url>http://guacamole.apache.org/</url>
 
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/extensions/guacamole-auth-duo/pom.xml
+++ b/extensions/guacamole-auth-duo/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-duo</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-duo</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
         

--- a/extensions/guacamole-auth-duo/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-duo/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "Duo TFA Authentication Backend",
     "namespace" : "duo",

--- a/extensions/guacamole-auth-header/pom.xml
+++ b/extensions/guacamole-auth-header/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-header</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-header</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-header/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-header/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "HTTP Header Authentication Extension",
     "namespace" : "header",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -42,21 +42,21 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-mysql</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- PostgreSQL Authentication Extension -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-postgresql</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- SQL Server Authentication Extension -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-sqlserver</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "MySQL Authentication",
     "namespace" : "mysql",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "PostgreSQL Authentication",
     "namespace" : "postgresql",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/pom.xml
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-jdbc</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-jdbc-base</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "SQLServer Authentication",
     "namespace" : "sqlserver",

--- a/extensions/guacamole-auth-jdbc/pom.xml
+++ b/extensions/guacamole-auth-jdbc/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-jdbc</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-jdbc</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.apache.guacamole</groupId>
                 <artifactId>guacamole-ext</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.0</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/extensions/guacamole-auth-json/pom.xml
+++ b/extensions/guacamole-auth-json/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-json</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-json</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-json/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-json/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "Encrypted JSON Authentication",
     "namespace" : "json",

--- a/extensions/guacamole-auth-ldap/pom.xml
+++ b/extensions/guacamole-auth-ldap/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-ldap</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-ldap</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "LDAP Authentication",
     "namespace" : "ldap",

--- a/extensions/guacamole-auth-quickconnect/pom.xml
+++ b/extensions/guacamole-auth-quickconnect/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-quickconnect</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-quickconnect</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
         

--- a/extensions/guacamole-auth-quickconnect/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-quickconnect/src/main/resources/guac-manifest.json
@@ -1,5 +1,5 @@
 {
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"             : "Adhoc Guacamole Connections",
     "namespace"        : "quickconnect",

--- a/extensions/guacamole-auth-radius/pom.xml
+++ b/extensions/guacamole-auth-radius/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-radius</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-radius</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
         

--- a/extensions/guacamole-auth-radius/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-radius/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "RADIUS Authentication Backend",
     "namespace" : "radius",

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-sso</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-sso-cas</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-sso-cas</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-sso</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "CAS Authentication Extension",
     "namespace" : "cas",

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-dist/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-dist/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-sso</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -42,21 +42,21 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-sso-cas</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- OpenID Authentication Extension -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-sso-openid</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- SAML Authentication Extension -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-sso-saml</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-sso-openid</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-sso-openid</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-sso</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "OpenID Authentication Extension",
     "namespace" : "openid",

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-sso-saml</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-sso-saml</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-sso</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "SAML Authentication Extension",
     "namespace" : "saml",

--- a/extensions/guacamole-auth-sso/pom.xml
+++ b/extensions/guacamole-auth-sso/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-sso</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-sso</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.apache.guacamole</groupId>
                 <artifactId>guacamole-ext</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.0</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>org.apache.guacamole</groupId>
                 <artifactId>guacamole-auth-sso-base</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.0</version>
             </dependency>
 
             <!-- Java servlet API -->

--- a/extensions/guacamole-auth-totp/pom.xml
+++ b/extensions/guacamole-auth-totp/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-totp</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-auth-totp</name>
     <url>http://guacamole.incubator.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
         

--- a/extensions/guacamole-auth-totp/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-totp/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "TOTP TFA Authentication Backend",
     "namespace" : "totp",

--- a/extensions/guacamole-history-recording-storage/pom.xml
+++ b/extensions/guacamole-history-recording-storage/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-history-recording-storage</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-history-recording-storage</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/extensions/guacamole-history-recording-storage/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-history-recording-storage/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "Session Recording Storage",
     "namespace" : "recording-storage",

--- a/extensions/guacamole-vault/modules/guacamole-vault-base/pom.xml
+++ b/extensions/guacamole-vault/modules/guacamole-vault-base/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-vault</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-vault/modules/guacamole-vault-dist/pom.xml
+++ b/extensions/guacamole-vault/modules/guacamole-vault-dist/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-vault</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-vault-ksm</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
    </dependencies>

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/pom.xml
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-vault-ksm</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-vault-ksm</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-vault</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../../</relativePath>
     </parent>
 
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-vault-base</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <dependency>

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.4.0",
+    "guacamoleVersion" : "1.5.0",
 
     "name"      : "Keeper Secrets Manager",
     "namespace" : "keeper-secrets-manager",

--- a/extensions/guacamole-vault/pom.xml
+++ b/extensions/guacamole-vault/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-vault</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-vault</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.apache.guacamole</groupId>
                 <artifactId>guacamole-ext</artifactId>
-                <version>1.4.0</version>
+                <version>1.5.0</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>extensions</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>extensions</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/guacamole-common-js/pom.xml
+++ b/guacamole-common-js/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-common-js</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-common-js</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/guacamole-common-js/src/main/webapp/modules/Version.js
+++ b/guacamole-common-js/src/main/webapp/modules/Version.js
@@ -27,4 +27,4 @@ var Guacamole = Guacamole || {};
  *
  * @type {!string}
  */
-Guacamole.API_VERSION = "1.4.0";
+Guacamole.API_VERSION = "1.5.0";

--- a/guacamole-common/pom.xml
+++ b/guacamole-common/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-common</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-common</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-ext</artifactId>
     <packaging>jar</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-ext</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole</artifactId>
     <packaging>war</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-client</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -246,14 +246,14 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- Guacamole JavaScript API -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -67,7 +67,8 @@ public class ExtensionModule extends ServletModule {
             "1.1.0",
             "1.2.0",
             "1.3.0",
-            "1.4.0"
+            "1.4.0",
+            "1.5.0"
         ));
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-client</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>guacamole-client</name>
     <url>http://guacamole.apache.org/</url>
 


### PR DESCRIPTION
This change bumps the version numbers of all components to 1.5.0.

**NOTE:** While some extensions do not have explicit code changes, such as "guacamole-auth-header", they have effectively been modified for the 1.5.0 release via changes in dependencies inherited from the top-level `pom.xml` (particularly Guice).