### PR TITLE
Allow overriding of guacd-[hostname/port/ssl] within the connection's json properties

### DIFF
--- a/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/connection/ConnectionService.java
@@ -178,19 +178,18 @@ public class ConnectionService {
         int port = proxyConfig.getPort();
 
         // handle guacd-[hostname/port/ssl] overrides
-        Map<String, String> params = connection.getParameters();
-        String overrideGuacdHostname = params.get(Environment.GUACD_HOSTNAME.getName());
+        String overrideGuacdHostname = connection.getGuacdHostname();
         if (overrideGuacdHostname != null && !overrideGuacdHostname.isEmpty()) {
             hostname = overrideGuacdHostname;
         }
-        String overrideGuacdPort = params.get(Environment.GUACD_PORT.getName());
-        if (overrideGuacdPort != null && !overrideGuacdPort.isEmpty()) {
-            port = Integer.parseInt(overrideGuacdPort);
+        Integer overrideGuacdPort = connection.getGuacdPort();
+        if (overrideGuacdPort != null) {
+            port = overrideGuacdPort;
         }
         EncryptionMethod proxyMethod = proxyConfig.getEncryptionMethod();
-        String overrideGuacdSSL = params.get(Environment.GUACD_SSL.getName());
-        if (overrideGuacdSSL != null && !overrideGuacdSSL.isEmpty()) {
-            proxyMethod = Boolean.getBoolean(overrideGuacdSSL) ? EncryptionMethod.SSL : EncryptionMethod.NONE;
+        Boolean overrideGuacdSSL = connection.getGuacdSsl();
+        if (overrideGuacdSSL != null) {
+            proxyMethod = overrideGuacdSSL ? EncryptionMethod.SSL : EncryptionMethod.NONE;
         }
 
         // Generate and verify connection configuration

--- a/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/user/UserData.java
+++ b/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/user/UserData.java
@@ -71,6 +71,21 @@ public class UserData {
         private String id;
 
         /**
+         * Allows to override the guacd-hostname setting on a 'per connection' basis
+         */
+        private String guacdHostname;
+
+        /**
+         * Allows to override the guacd-port setting on a 'per connection' basis
+         */
+        private Integer guacdPort;
+
+        /**
+         * Allows to override the guacd-ssl setting on a 'per connection' basis
+         */
+        private Boolean guacdSsl;
+
+        /**
          * The protocol that this connection should use, such as "vnc" or "rdp".
          */
         private String protocol;
@@ -123,6 +138,66 @@ public class UserData {
         public void setId(String id) {
             this.id = id;
         }
+
+        /**
+         * Returns the override for the guacd-hostname setting
+         *
+         * @return
+         *     The hostname to use when connecting guacd
+         */
+        public String getGuacdHostname() {
+			return guacdHostname;
+		}
+
+        /**
+         * Sets the guacd-hostname override for this connection
+         *
+         * @param guacdHostname
+         *     The hostname to use when connecting guacd
+         */
+        public void setGuacdHostname(String guacdHostname) {
+			this.guacdHostname = guacdHostname;
+		}
+
+        /**
+         * Returns the override for the guacd-port setting
+         *
+         * @return
+         *     The port to use when connecting guacd
+         */
+        public Integer getGuacdPort() {
+			return guacdPort;
+		}
+
+        /**
+         * Sets the guacd-port override for this connection
+         *
+         * @param guacdPort
+         *     The port to use when connecting guacd
+         */
+        public void setGuacdPort(Integer guacdPort) {
+			this.guacdPort = guacdPort;
+		}
+
+        /**
+         * Returns the override for the guacd-ssl setting
+         *
+         * @return
+         *     The flag if SSL should be enabled when connecting guacd
+         */
+        public Boolean getGuacdSsl() {
+			return guacdSsl;
+		}
+
+        /**
+         * Sets the guacd-ssl override for this connection
+         *
+         * @param guacdPort
+         *     The flag if SSL should be enabled when connecting guacd
+         */
+        public void setGuacdSsl(Boolean guacdSsl) {
+			this.guacdSsl = guacdSsl;
+		}
 
         /**
          * Returns the protocol that this connection should use, such as "vnc"


### PR DESCRIPTION
Hi,

this is just a simple extension to the guacamole-auth-json module allowing to specify `guacd-hostname`, `guacd-port` and `guacd-ssl` overrides within the [connection properties config](https://guacamole.apache.org/doc/gug/json-auth.html#json-format). Like it is also possible for connections configured via a database.

A config snipplet looks like be:
```json
{
    "username" : "arbitraryUsername",
    "expires" : TIMESTAMP,
    "connections" : {

        "Connection Name" : {
            "protocol" : "PROTOCOL",
            "parameters" : {
                "guacd-hostname" : "my-other-guacd-host",
                "guacd-port" : "4822",
                ...
            }
        },
        ...
    }
}
```

I'm opening this PR without a JIRA ticket as I don't have an ASF account and it's not stright-forward to register. Maybe someone creates the Issue on behalf of me ;)