### PR TITLE
GUACAMOLE-1740: Don't display clipboard contents in the clipboard editor until it is focused on.

### DIFF
--- a/guacamole/src/main/frontend/src/app/clipboard/directives/guacClipboard.js
+++ b/guacamole/src/main/frontend/src/app/clipboard/directives/guacClipboard.js
@@ -49,11 +49,29 @@ angular.module('clipboard').directive('guacClipboard', ['$injector',
 
         /**
          * The DOM element which will contain the clipboard contents within the
-         * user interface provided by this directive.
+         * user interface provided by this directive. We populate the clipboard
+         * editor via this DOM element rather than updating a model so that we
+         * are prepared for future support of rich text contents.
          *
          * @type Element
          */
-        var element = $element[0];
+        var element = $element[0].querySelectorAll('.clipboard.active')[0];
+
+        /**
+         * When isActive is set to true then the Clipboard data will be
+         * displayed in the Clipboard Editor. When false, the Clipboard Editor
+         * will not be displayed with Clipboard data.
+         *
+         * @type Boolean
+         */
+        $scope.isActive = false;
+
+        /**
+         * Updates clipboard editor to be active.
+         */
+        $scope.setActive = function setActive() {
+            $scope.isActive = true;
+        };
 
         /**
          * Rereads the contents of the clipboard field, updating the

--- a/guacamole/src/main/frontend/src/app/clipboard/styles/clipboard.css
+++ b/guacamole/src/main/frontend/src/app/clipboard/styles/clipboard.css
@@ -31,8 +31,6 @@
     width: 100%;
     height: 2in;
     white-space: pre;
-    font-size: 1em;
-    overflow: auto;
     padding: 0.25em;
 }
 
@@ -58,4 +56,15 @@
     height: 1em;
     white-space: pre;
     overflow: hidden;
+}
+
+.active {
+    overflow: auto;
+    font-size: 1em;
+}
+
+.inactive {
+    overflow: hidden;
+    font-size: 0.9em;
+    opacity: 0.5;
 }

--- a/guacamole/src/main/frontend/src/app/clipboard/templates/guacClipboard.html
+++ b/guacamole/src/main/frontend/src/app/clipboard/templates/guacClipboard.html
@@ -1,1 +1,4 @@
-<textarea class="clipboard"></textarea>
+<div>
+    <textarea ng-show="isActive" class="clipboard active"></textarea>
+    <textarea ng-show="!isActive" class="clipboard inactive" ng-focus="setActive()">{{'CLIENT.TEXT_CLIPBOARD_AWAITING_FOCUS' | translate}}</textarea>
+</div>

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -162,6 +162,7 @@
         "TEXT_USER_LEFT"                  : "{USERNAME} has left the connection.",
         "TEXT_RECONNECT_COUNTDOWN"        : "Reconnecting in {REMAINING} {REMAINING, plural, one{second} other{seconds}}...",
         "TEXT_FILE_TRANSFER_PROGRESS"     : "{PROGRESS} {UNIT, select, b{B} kb{KB} mb{MB} gb{GB} other{}}",
+        "TEXT_CLIPBOARD_AWAITING_FOCUS"   : "Click to view clipboard data...",
 
         "URL_OSK_LAYOUT" : "layouts/en-us-qwerty.json"
 

--- a/guacamole/src/main/frontend/src/translations/ja.json
+++ b/guacamole/src/main/frontend/src/translations/ja.json
@@ -132,7 +132,8 @@
         "TEXT_CLIENT_STATUS_DISCONNECTED" : "切断されました。",
         "TEXT_CLIENT_STATUS_UNSTABLE"     : "Guacamoleサーバへのネットワーク接続が不安定です。",
         "TEXT_CLIENT_STATUS_WAITING"      : "Guacamoleサーバに接続しました。応答を待っています",
-        "TEXT_RECONNECT_COUNTDOWN"        : "再接続しています... {REMAINING} {REMAINING, plural, one{second} other{seconds}}..."
+        "TEXT_RECONNECT_COUNTDOWN"        : "再接続しています... {REMAINING} {REMAINING, plural, one{second} other{seconds}}...",
+        "TEXT_CLIPBOARD_AWAITING_FOCUS"   : "クリックをしてコピー/カットされたテキストが表示されます..."
 
     },
 


### PR DESCRIPTION
When bringing up the Guacamole menu (Ctrl+Alt+Shift) the contents of your clipboard are immediately visible within the clipboard editor. For privacy purposes, the contents of the clipboard editor should be hidden/collapsed until the user chooses to expand/show them.

This Pull request updates the Clipboard Directive to prevent displaying clipboard data in the clipboard editor until the clipboard editor has been focused on.