### PR TITLE
GUACAMOLE-1744: Clean up UI only if user is not logged in.

### DIFF
--- a/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
+++ b/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
@@ -252,7 +252,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // that connection activity will already automatically check session
     // validity.
     $interval(function cleanUpViewIfSessionInvalid() {
-        if ($scope.applicationState === ApplicationState.READY && !hasActiveTunnel()) {
+        if (!!authenticationService.getCurrentToken() && !hasActiveTunnel()) {
             authenticationService.getValidity().then(function validityDetermined(valid) {
                 if (!valid)
                     $scope.reAuthenticate();


### PR DESCRIPTION
The changes recently merged via #798 erroneously navigate the user back to `#/` if they visit a custom, unauthenticated page from an extension while not logged in. This change corrects that logic to use the presence/absence of a cached auth token as the primary condition determining whether their session should be retested for validity.