### PR TITLE
GUACAMOLE-1738: Update version of MySQL connector

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -94,7 +94,7 @@ tar -xzf extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/target/
 #
 
 echo "Downloading MySQL Connector/J ..."
-curl -L "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.46.tar.gz" | \
+curl -L "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-8.0.32.tar.gz" | \
 tar -xz                        \
     -C "$DESTINATION/mysql/"   \
     --wildcards                \


### PR DESCRIPTION
GUACAMOLE-1738 Update version of MySQL connector used to resolve issue 1738 where it can no longer connect to the MySQL server using the new extension and old connector: https://issues.apache.org/jira/projects/GUACAMOLE/issues/GUACAMOLE-1738