### PR TITLE
GUACAMOLE-1740: Prevent collisions of clipboard inactive and active classes with other classes of the same name.

### DIFF
--- a/guacamole/src/main/frontend/src/app/clipboard/styles/clipboard.css
+++ b/guacamole/src/main/frontend/src/app/clipboard/styles/clipboard.css
@@ -58,12 +58,12 @@
     overflow: hidden;
 }
 
-.active {
+#clipboard-settings .clipboard.active {
     overflow: auto;
     font-size: 1em;
 }
 
-.inactive {
+#clipboard-settings .clipboard.inactive {
     overflow: hidden;
     font-size: 0.9em;
     opacity: 0.5;


### PR DESCRIPTION
This pull request corrects the new CSS rules for the guacamole clipboard settings such that they affect strictly what they are intended to affect.