### PR TITLE
GUACAMOLE-839: Correct handling of possible null values within SSL/TLS client auth support.

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/src/main/java/org/apache/guacamole/auth/ssl/conf/WildcardURIGuacamoleProperty.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/src/main/java/org/apache/guacamole/auth/ssl/conf/WildcardURIGuacamoleProperty.java
@@ -45,6 +45,9 @@ public abstract class WildcardURIGuacamoleProperty extends URIGuacamoleProperty 
     @Override
     public URI parseValue(String value) throws GuacamoleException {
 
+        if (value == null)
+            return null;
+
         // Verify wildcard prefix is present
         Matcher matcher = WILDCARD_URI_PATTERN.matcher(value);
         if (matcher.matches()) {


### PR DESCRIPTION
This change:

* Updates `WildcardURIGuacamoleProperty` such that it explicitly handles possible `null` inputs (omitted properties).
* Updates handling of received PEM such that anything but a single X.509 certificate is rejected, including PEM that contains nothing at all.