### PR TITLE
GUACAMOLE-1219: Add support for disabling TOTP for specific users and groups.

### DIFF
--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUser.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUser.java
@@ -34,6 +34,12 @@ import org.apache.guacamole.net.auth.User;
 public class TOTPUser extends DelegatingUser {
 
     /**
+     * The name of the user attribute which disables the TOTP requirement
+     * for that specific user.
+     */
+    public static final String TOTP_KEY_DISABLED_ATTRIBUTE_NAME = "guac-totp-disabled";
+    
+    /**
      * The name of the user attribute which stores the TOTP key.
      */
     public static final String TOTP_KEY_SECRET_ATTRIBUTE_NAME = "guac-totp-key-secret";
@@ -56,13 +62,14 @@ public class TOTPUser extends DelegatingUser {
      * The string value used by TOTP user attributes to represent the boolean
      * value "true".
      */
-    private static final String TRUTH_VALUE = "true";
+    public static final String TRUTH_VALUE = "true";
 
     /**
      * The form which contains all configurable properties for this user.
      */
     public static final Form TOTP_ENROLLMENT_STATUS = new Form("totp-enrollment-status",
             Arrays.asList(
+                    new BooleanField(TOTP_KEY_DISABLED_ATTRIBUTE_NAME, TRUTH_VALUE),
                     new BooleanField(TOTP_KEY_SECRET_GENERATED_ATTRIBUTE_NAME, TRUTH_VALUE),
                     new BooleanField(TOTP_KEY_CONFIRMED_ATTRIBUTE_NAME, TRUTH_VALUE)
             )
@@ -95,6 +102,9 @@ public class TOTPUser extends DelegatingUser {
 
         // Create independent, mutable copy of attributes
         Map<String, String> attributes = new HashMap<>(super.getAttributes());
+        
+        if (!attributes.containsKey(TOTP_KEY_DISABLED_ATTRIBUTE_NAME))
+            attributes.put(TOTP_KEY_DISABLED_ATTRIBUTE_NAME, null);
 
         // Replace secret key with simple boolean attribute representing
         // whether a key has been generated at all

--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUserContext.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/TOTPUserContext.java
@@ -23,12 +23,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.totp.usergroup.TOTPUserGroup;
 import org.apache.guacamole.form.Form;
 import org.apache.guacamole.net.auth.DecoratingDirectory;
 import org.apache.guacamole.net.auth.DelegatingUserContext;
 import org.apache.guacamole.net.auth.Directory;
 import org.apache.guacamole.net.auth.User;
 import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.net.auth.UserGroup;
 
 /**
  * TOTP-specific UserContext implementation which wraps the UserContext of
@@ -66,10 +68,35 @@ public class TOTPUserContext extends DelegatingUserContext {
     }
     
     @Override
+    public Directory<UserGroup> getUserGroupDirectory() throws GuacamoleException {
+        return new DecoratingDirectory<UserGroup>(super.getUserGroupDirectory()) {
+           
+            @Override
+            protected UserGroup decorate(UserGroup object) {
+                return new TOTPUserGroup(object);
+            }
+            
+            @Override
+            protected UserGroup undecorate(UserGroup object) {
+                assert(object instanceof TOTPUserGroup);
+                return ((TOTPUserGroup) object).getUndecorated();
+            }
+            
+        };
+    }
+    
+    @Override
     public Collection<Form> getUserAttributes() {
         Collection<Form> userAttrs = new HashSet<>(super.getUserAttributes());
         userAttrs.add(TOTPUser.TOTP_ENROLLMENT_STATUS);
         return Collections.unmodifiableCollection(userAttrs);
+    }
+    
+    @Override
+    public Collection<Form> getUserGroupAttributes() {
+        Collection<Form> userGroupAttrs = new HashSet<>(super.getUserGroupAttributes());
+        userGroupAttrs.add(TOTPUserGroup.TOTP_USER_GROUP_CONFIG);
+        return Collections.unmodifiableCollection(userGroupAttrs);
     }
 
 }

--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/usergroup/TOTPUserGroup.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/usergroup/TOTPUserGroup.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.guacamole.auth.totp.usergroup;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.guacamole.form.BooleanField;
+import org.apache.guacamole.form.Form;
+import org.apache.guacamole.net.auth.DelegatingUserGroup;
+import org.apache.guacamole.net.auth.UserGroup;
+
+/**
+ * A UserGroup that wraps another UserGroup implementation, decorating it with
+ * attributes that control TOTP configuration for users that are members of that
+ * group.
+ */
+public class TOTPUserGroup extends DelegatingUserGroup {
+    
+    /**
+     * The attribute associated with a group that disables the TOTP requirement
+     * for any users that are a member of that group, or are members of any
+     * groups that are members of this group.
+     */
+    public static final String TOTP_KEY_DISABLED_ATTRIBUTE_NAME = "guac-totp-disabled";
+    
+    /**
+     * The string value used by TOTP user attributes to represent the boolean
+     * value "true".
+     */
+    public static final String TRUTH_VALUE = "true";
+    
+    /**
+     * The form that contains fields for configuring TOTP for members of this
+     * group.
+     */
+    public static final Form TOTP_USER_GROUP_CONFIG = new Form("totp-user-group-config",
+            Arrays.asList(
+                    new BooleanField(TOTP_KEY_DISABLED_ATTRIBUTE_NAME, TRUTH_VALUE)
+            )
+    );
+    
+    /**
+     * Create a new instance of this user group implementation, wrapping the
+     * provided UserGroup.
+     * 
+     * @param userGroup 
+     *     The UserGroup to be wrapped.
+     */
+    public TOTPUserGroup(UserGroup userGroup) {
+        super(userGroup);
+    }
+    
+    /**
+     * Return the original UserGroup that this implementation is wrapping.
+     * 
+     * @return 
+     *     The original UserGroup that this implementation wraps.
+     */
+    public UserGroup getUndecorated() {
+        return getDelegateUserGroupGroup();
+    }
+    
+    /**
+     * Returns whether or not TOTP has been disabled for members of this group.
+     * 
+     * @return 
+     *     True if TOTP has been disabled for members of this group, otherwise
+     *     false.
+     */
+    public boolean totpDisabled() {
+        return (TRUTH_VALUE.equals(getAttributes().get(TOTP_KEY_DISABLED_ATTRIBUTE_NAME)));
+    }
+    
+    @Override
+    public Map<String, String> getAttributes() {
+        
+        // Create a mutable copy of the attributes
+        Map<String, String> attributes = new HashMap<>(super.getAttributes());
+        
+        if (!attributes.containsKey(TOTP_KEY_DISABLED_ATTRIBUTE_NAME))
+            attributes.put(TOTP_KEY_DISABLED_ATTRIBUTE_NAME, null);
+        
+        return attributes;
+        
+    }
+    
+}

--- a/extensions/guacamole-auth-totp/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-totp/src/main/resources/translations/en.json
@@ -33,10 +33,19 @@
     
     "USER_ATTRIBUTES" : {
         
+        "FIELD_HEADER_GUAC_TOTP_DISABLED"      : "Disable TOTP:",
         "FIELD_HEADER_GUAC_TOTP_KEY_GENERATED" : "Secret key generated:",
         "FIELD_HEADER_GUAC_TOTP_KEY_CONFIRMED" : "Authentication device confirmed:",
         
         "SECTION_HEADER_TOTP_ENROLLMENT_STATUS" : "TOTP Enrollment Status"
+        
+    },
+    
+    "USER_GROUP_ATTRIBUTES" : {
+        
+        "FIELD_HEADER_GUAC_TOTP_DISABLED" : "Disable TOTP:",
+        
+        "SECTION_HEADER_TOTP_USER_GROUP_CONFIG" : "TOTP Configuration"
         
     }
 


### PR DESCRIPTION
Continuing the work started in #577, this adds an attribute to the TOTP module at both a user and group level that allows for disabling the TOTP requirement for a certain user or users who are members of one or more groups that have the requirement disabled.

This closes #577.