### PR TITLE
GUACAMOLE-1738: Update version of MySQL connector

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -94,7 +94,7 @@ tar -xzf extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-dist/target/
 #
 
 echo "Downloading MySQL Connector/J ..."
-curl -L "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.46.tar.gz" | \
+curl -L "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-8.0.32.tar.gz" | \
 tar -xz                        \
     -C "$DESTINATION/mysql/"   \
     --wildcards                \


### PR DESCRIPTION
This is an exact copy of #802, cherry-picked onto `staging/1.5.1`.

Testing a merge of this to `staging/1.5.1`, and then `staging/1.5.1` back to `master`, git seems happy and is able to handle the merges without conflicts.