### PR TITLE
GUACAMOLE-1756: Display login failures regardless of whether the interactive login form was used.

### DIFF
--- a/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
+++ b/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
@@ -285,6 +285,22 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     }, true);
 
     /**
+     * Sets the current overall state of the client side of the
+     * application to the given value. Possible values are defined by
+     * {@link ApplicationState}. The title and class associated with the
+     * current page are automatically reset to the standard values applicable
+     * to the application as a whole (rather than any specific page).
+     *
+     * @param {!string} state
+     *     The state to assign, as defined by {@link ApplicationState}.
+     */
+    const setApplicationState = function setApplicationState(state) {
+        $scope.applicationState = state;
+        $scope.page.title = 'APP.NAME';
+        $scope.page.bodyClassName = '';
+    };
+
+    /**
      * Navigates the user back to the root of the application (or reloads the
      * current route and controller if the user is already there), effectively
      * forcing reauthentication. If the user is not logged in, this will result
@@ -306,9 +322,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Display login screen if a whole new set of credentials is needed
     $scope.$on('guacInvalidCredentials', function loginInvalid(event, parameters, error) {
 
-        $scope.applicationState = ApplicationState.AWAITING_CREDENTIALS;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
+        setApplicationState(ApplicationState.AWAITING_CREDENTIALS);
 
         $scope.loginHelpText = null;
         $scope.acceptedCredentials = {};
@@ -319,9 +333,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Prompt for remaining credentials if provided credentials were not enough
     $scope.$on('guacInsufficientCredentials', function loginInsufficient(event, parameters, error) {
 
-        $scope.applicationState = ApplicationState.AWAITING_CREDENTIALS;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
+        setApplicationState(ApplicationState.AWAITING_CREDENTIALS);
 
         $scope.loginHelpText = error.translatableMessage;
         $scope.acceptedCredentials = parameters;
@@ -339,10 +351,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
                 || error.type === Error.Type.INVALID_CREDENTIALS)
             return;
 
-        $scope.applicationState = ApplicationState.AUTOMATIC_LOGIN_REJECTED;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
-
+        setApplicationState(ApplicationState.AUTOMATIC_LOGIN_REJECTED);
         $scope.reAuthenticating = false;
         $scope.fatalError = error;
 
@@ -351,13 +360,8 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Replace absolutely all content with an error message if the page itself
     // cannot be displayed due to an error
     $scope.$on('guacFatalPageError', function fatalPageError(error) {
-
-        $scope.applicationState = ApplicationState.FATAL_ERROR;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
-
+        setApplicationState(ApplicationState.FATAL_ERROR);
         $scope.fatalError = error;
-
     });
 
     // Replace the overall user interface with an informational message if the

--- a/guacamole/src/main/frontend/src/app/index/styles/automatic-login-rejected.css
+++ b/guacamole/src/main/frontend/src/app/index/styles/automatic-login-rejected.css
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.automatic-login-rejected-modal guac-modal {
+    background: white;
+    z-index: 20;
+}
+
+.automatic-login-rejected-modal .notification {
+    display: inline-block;
+    max-width: 5in;
+    padding: 1em;
+    width: 100%;
+}

--- a/guacamole/src/main/frontend/src/index.html
+++ b/guacamole/src/main/frontend/src/index.html
@@ -64,6 +64,20 @@
             </guac-modal>
         </div>
 
+        <!-- Authentication error without a corresponding login form -->
+        <div class="automatic-login-rejected-modal" ng-switch-when="automaticLoginRejected">
+            <guac-modal>
+                <div class="notification">
+                    <p translate="{{ fatalError.translatableMessage.key }}"
+                       translate-values="{{ fatalError.translatableMessage.variables }}"></p>
+                    <p>
+                        <button translate="APP.ACTION_LOGIN_AGAIN" ng-disabled="reAuthenticating"
+                                ng-click="reAuthenticate()"></button>
+                    </p>
+                </div>
+            </guac-modal>
+        </div>
+
         <!-- Login screen for logged-out users -->
         <guac-login ng-switch-when="awaitingCredentials"
                     help-text="loginHelpText"


### PR DESCRIPTION
This change adds an additional overall application state for the case that an error occurred during authentication without the use of a login form, and provides an alternative location for that error to be rendered when no login form is present.

For example, if authentication is attempted via some sort of SSO, but is repeatedly failing and is now being throttled by "guacamole-auth-ban", the following will appear (instead of a mysterious blank page):

![A modal error dialog presenting a login failure message above a "Re-login" button. The error message reads: "Too many failed authentication attempts. Please try again later."](https://user-images.githubusercontent.com/4632905/227041762-49f10246-3a05-4495-9d5d-0526d6e8f2c9.png)
