### PR TITLE
GUACAMOLE-1757: Ensure SSO provider list is added to login UI only once.

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/html/sso-providers.html
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/html/sso-providers.html
@@ -1,4 +1,4 @@
-<meta name="after" content=".login-ui .login-dialog-middle">
+<meta name="after" content=".login-ui .login-dialog-middle:not(:has(~ .sso-providers))">
 <div class="sso-providers">
     {{ 'LOGIN.SECTION_HEADER_SSO_OPTIONS' | translate }}
     <ul class="sso-provider-list"></ul>

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/styles/sso-providers.css
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/styles/sso-providers.css
@@ -24,12 +24,6 @@
     bottom: 0;
     left: 0;
 
-    display: none;
-
-}
-
-.login-ui .sso-providers:last-child {
-    display: block;
 }
 
 .sso-providers ul {

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/resources/html/sso-provider-cas.html
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/resources/html/sso-provider-cas.html
@@ -1,4 +1,4 @@
-<meta name="after-children" content=".login-ui .sso-provider-list:last-child">
+<meta name="after-children" content=".login-ui .sso-provider-list">
 <li class="sso-provider sso-provider-cas"><a href="api/ext/cas/login">{{
     'LOGIN.NAME_IDP_CAS' | translate
 }}</a></li>

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/resources/html/sso-provider-openid.html
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/resources/html/sso-provider-openid.html
@@ -1,4 +1,4 @@
-<meta name="after-children" content=".login-ui .sso-provider-list:last-child">
+<meta name="after-children" content=".login-ui .sso-provider-list">
 <li class="sso-provider sso-provider-openid"><a href="api/ext/openid/login">{{
     'LOGIN.NAME_IDP_OPENID' | translate
 }}</a></li>

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/resources/html/sso-provider-saml.html
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/resources/html/sso-provider-saml.html
@@ -1,4 +1,4 @@
-<meta name="after-children" content=".login-ui .sso-provider-list:last-child">
+<meta name="after-children" content=".login-ui .sso-provider-list">
 <li class="sso-provider sso-provider-saml"><a href="api/ext/saml/login">{{
     'LOGIN.NAME_IDP_SAML' | translate
 }}</a></li>

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/src/main/resources/html/sso-provider-ssl.html
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/src/main/resources/html/sso-provider-ssl.html
@@ -1,4 +1,4 @@
-<meta name="after-children" content=".login-ui .sso-provider-list:last-child">
+<meta name="after-children" content=".login-ui .sso-provider-list">
 <li class="sso-provider sso-provider-ssl"><a guac-ssl-auth href="">{{
     'LOGIN.NAME_IDP_SSL' | translate
 }}</a></li>


### PR DESCRIPTION
This change alters the HTML patches used by the various SSO extensions such that the common SSO provider list is added to the login UI no more than once. Additional SSO extensions that add to the UI after the first will simply add themselves to the existing list.