### PR TITLE
GUACAMOLE-839: Redirect user to proper URI for SSL/TLS client auth (rather than just refuse).

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/resources/translations/en.json
@@ -21,6 +21,7 @@
         "FIELD_HEADER_STATE"         : "",
         "FIELD_HEADER_TICKET"        : "",
         "INFO_IDP_REDIRECT_PENDING"  : "Please wait, redirecting to identity provider...",
+        "INFO_REDIRECT_PENDING"      : "Please wait while you are redirected...",
         "NAME_IDP_CAS"               : "CAS",
         "NAME_IDP_OPENID"            : "OpenID",
         "NAME_IDP_SAML"              : "SAML",


### PR DESCRIPTION
If a user attempts to navigate to a Guacamole deployment using SSL/TLS authentication, but uses that deployment's IP address (or an incorrect hostname) to do so, they will see the following error message:

> Direct authentication against this endpoint is not valid without first requesting to authenticate at the primary URL of this Guacamole instance.

This is because the SSL/TLS authentication strictly enforces which hostnames may be used, but this is confusing. A user or administrator that inadvertently visits the wrong URL and sees this message will not know why things are failing.

These changes replace the above error with a simple redirect to the proper URL.