### PR TITLE
GUACAMOLE-956: Use header instead of http parameter for session/tunnels/<tunnel ID>/protocol

### DIFF
--- a/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
@@ -97,17 +97,15 @@ angular.module('rest').factory('tunnelService', ['$injector',
      */
     service.getProtocol = function getProtocol(tunnel) {
 
-        // Build HTTP parameters set
-        var httpParameters = {
-            token : authenticationService.getCurrentToken()
-        };
-
         // Retrieve the protocol details of the specified tunnel
         return requestService({
             method  : 'GET',
             url     : 'api/session/tunnels/' + encodeURIComponent(tunnel)
                         + '/protocol',
-            params  : httpParameters
+            headers: {
+                'Guacamole-Token': authenticationService.getCurrentToken(),
+            }
+
         });
 
     };

--- a/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
@@ -96,7 +96,7 @@ angular.module('rest').factory('tunnelService', ['$injector',
      *     success.
      */
     service.getProtocol = function getProtocol(tunnel) {
-
+        // GUACAMOLE-956: replace http parameter with header | START
         // Retrieve the protocol details of the specified tunnel
         return requestService({
             method  : 'GET',
@@ -107,7 +107,7 @@ angular.module('rest').factory('tunnelService', ['$injector',
             }
 
         });
-
+        // GUACAMOLE-956: replace http parameter with header | END
     };
 
     /**


### PR DESCRIPTION
Hello,

This change hides the authentication token from the http parameter by using the predefined header "Guacamole-Token" instead for the following API call.

`GET /api/session/tunnels/<tunnel ID>/protocol?token=<token>
`

<img width="838" alt="image" src="https://user-images.githubusercontent.com/124109426/231601862-62f966ff-846c-406f-861b-6577ea04d592.png">

Related Jira: https://issues.apache.org/jira/browse/GUACAMOLE-956

