### PR TITLE
GUACAMOLE-926: Fix loading bug and fuzzier group matching

### DIFF
--- a/guacamole/src/main/frontend/src/app/import/controllers/importConnectionsController.js
+++ b/guacamole/src/main/frontend/src/app/import/controllers/importConnectionsController.js
@@ -365,6 +365,7 @@ angular.module('import').controller('importConnectionsController', ['$scope', '$
      */
     function handleParseSuccess(parseResult) {
 
+        $scope.processing = false;
         $scope.parseResult = parseResult;
 
         // If errors were encounted during file parsing, abort further


### PR DESCRIPTION
This change does two things:
* Fix a bug where the loading spinner would be applied and never go away when file parsing succeeded, with connection errors
* Allow a bit more leeway for users in how they declare their group declarations:
   - They can (as before) specify the full path like "ROOT/parent/child"
   - They can use just a leading slash instead of the root group like "/parent/child"
   - They can leave off the leading slash, like "parent/child"
   - They can optionally include a trailing slash like "parent/child/"