### PR TITLE
GUACAMOLE-1775: Auth token as a parameter in "session/tunnels/<tunnel ID>/protocol" request

### DIFF
--- a/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
@@ -97,17 +97,10 @@ angular.module('rest').factory('tunnelService', ['$injector',
      */
     service.getProtocol = function getProtocol(tunnel) {
 
-        // Build HTTP parameters set
-        var httpParameters = {
-            token : authenticationService.getCurrentToken()
-        };
-
-        // Retrieve the protocol details of the specified tunnel
-        return requestService({
+        return authenticationService.request({
             method  : 'GET',
             url     : 'api/session/tunnels/' + encodeURIComponent(tunnel)
-                        + '/protocol',
-            params  : httpParameters
+                        + '/protocol'
         });
 
     };


### PR DESCRIPTION
Hello,

This change hides the authentication token from the http parameter by using the predefined header "Guacamole-Token" instead for the following API call.

GET /api/session/tunnels/<tunnel ID>/protocol?token=<token> 

<img width="1533" alt="image" src="https://user-images.githubusercontent.com/124109426/233201626-49d5dd8d-d461-4228-8ca3-84e0afcbb596.png">