### PR TITLE
GUACAMOLE-926: Batch import - fix UI issue with permission checkbox, fix replace error when using decorating extension.

### DIFF
--- a/guacamole/src/main/frontend/src/app/import/templates/connectionImport.html
+++ b/guacamole/src/main/frontend/src/app/import/templates/connectionImport.html
@@ -51,7 +51,7 @@
             <li>
                 <input type="checkbox"
                     id="existing-permission-mode" ng-model="importConfig.existingPermissionMode"
-                    ng-disabled="importConfig.replaceConnectionMode === 'REJECT'"
+                    ng-disabled="importConfig.existingConnectionMode === 'REJECT'"
                     ng-true-value="'REPLACE'" ng-false-value="'PRESERVE'" />
                 <label for="existing-permission-mode">
                     {{'IMPORT.FIELD_HEADER_EXISTING_PERMISSION_MODE' | translate}}

--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryResource.java
@@ -430,6 +430,10 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
      * @param identifier
      *     The identifier of the object to retrieve from the directory.
      *
+     * @param directory
+     *     The directory to fetch the object from. If null, the directory
+     *     associated with this DirectoryResource instance will be used.
+     *
      * @return
      *     The object from the directory with the provided identifier.
      *
@@ -439,8 +443,14 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
      *     the object.
      */
     @Nonnull
-    private InternalType getObjectByIdentifier(String identifier)
+    private InternalType getObjectByIdentifier(
+            String identifier, @Nullable Directory<InternalType> directory)
             throws GuacamoleException {
+
+        // Use the directory associated with this instance if not otherwise
+        // specified
+        if (directory == null)
+            directory = this.directory;
 
         // Retrieve the object having the given identifier
         InternalType object;
@@ -639,10 +649,11 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
 
                         try {
 
-                            // Fetch the object to be updated. If no object is
-                            // found, a directory GET failure event will be
-                            // logged, and the update attempt will be aborted.
-                            original = getObjectByIdentifier(identifier);
+                            // Fetch the object to be updated from the atomic
+                            // directory instance. If no object is found, a 
+                            // directory GET failure event will be logged, and
+                            // the update attempt will be aborted.
+                            original = getObjectByIdentifier(identifier, directory);
                             
                             // Apply the changes to the original object
                             translator.applyExternalChanges(
@@ -849,7 +860,7 @@ public abstract class DirectoryResource<InternalType extends Identifiable, Exter
         // Fetch the object to be updated. If no object is found, a directory
         // GET failure event will be logged. If no exception is thrown, the
         // object is guaranteed to exist
-        InternalType object = getObjectByIdentifier(identifier);
+        InternalType object = getObjectByIdentifier(identifier, null);
 
         // Return a resource which provides access to the retrieved object
         DirectoryObjectResource<InternalType, ExternalType> resource = resourceFactory.create(authenticatedUser, userContext, directory, object);


### PR DESCRIPTION
Yet again I failed to find these when I was fixing the earlier issues that I also failed to find earlier.

Anyway, this PR fixes 2 more problems:
* The permission replacement checkbox wasn't getting disabled properly
* An exception is thrown when trying to use the REPLACE verb in the patch directory endpoint, if a decorating extension e.g. `guacamole-history-recording-storage` is used.