### PR TITLE
GUACAMOLE-1781: Update Simplified Chinese translation for totp auth extension

### DIFF
--- a/extensions/guacamole-auth-totp/src/main/resources/translations/zh.json
+++ b/extensions/guacamole-auth-totp/src/main/resources/translations/zh.json
@@ -1,7 +1,7 @@
 {
 
     "DATA_SOURCE_TOTP" : {
-        "NAME" : "TOTP TFA后端"
+        "NAME" : "TOTP TFA 后端"
     },
 
     "LOGIN" : {
@@ -13,22 +13,40 @@
         "ACTION_HIDE_DETAILS" : "隐藏",
         "ACTION_SHOW_DETAILS" : "显示",
 
-        "FIELD_HEADER_ALGORITHM"  : "算法:",
-        "FIELD_HEADER_DIGITS"     : "位数:",
-        "FIELD_HEADER_INTERVAL"   : "间隔:",
-        "FIELD_HEADER_SECRET_KEY" : "密钥:",
+        "FIELD_HEADER_ALGORITHM"  : "算法：",
+        "FIELD_HEADER_DIGITS"     : "数字位数：",
+        "FIELD_HEADER_INTERVAL"   : "时间间隔：",
+        "FIELD_HEADER_SECRET_KEY" : "密钥：",
 
-        "FIELD_PLACEHOLDER_CODE" : "授权码",
+        "FIELD_PLACEHOLDER_CODE" : "认证码",
 
-        "INFO_CODE_REQUIRED"       : "请输入您的授权码以验证您的身份。",
-        "INFO_ENROLL_REQUIRED"     : "您的帐户已启用多因素身份验证。",
-        "INFO_VERIFICATION_FAILED" : "验证失败， 请重试。",
+        "INFO_CODE_REQUIRED"       : "请输入您的认证码以验证您的身份。",
+        "INFO_ENROLL_REQUIRED"     : "您的账户已启用多因素身份验证。",
+        "INFO_VERIFICATION_FAILED" : "验证失败，请重试。",
 
-        "HELP_ENROLL_BARCODE" : "要完成注册过程，请使用手机或设备上的two-factor验证程序扫描下面的条形码。",
-        "HELP_ENROLL_VERIFY"  : "扫描条形码后，输入显示的{DIGITS}-数字授权码以验证注册是否成功。",
+        "HELP_ENROLL_BARCODE" : "为了完成注册流程，请使用您的手机或设备上的双因素身份验证应用程序扫描下面的条形码。",
+        "HELP_ENROLL_VERIFY"  : "扫描条形码后，输入显示的 {DIGITS} 位认证码以验证注册是否成功。",
 
-        "SECTION_HEADER_DETAILS" : "详情:"
+        "SECTION_HEADER_DETAILS" : "详细信息："
 
+    },
+
+    "USER_ATTRIBUTES" : {
+        
+        "FIELD_HEADER_GUAC_TOTP_DISABLED"      : "禁用 TOTP：",
+        "FIELD_HEADER_GUAC_TOTP_KEY_GENERATED" : "已生成密钥：",
+        "FIELD_HEADER_GUAC_TOTP_KEY_CONFIRMED" : "已确认身份验证设备：",
+        
+        "SECTION_HEADER_TOTP_ENROLLMENT_STATUS" : "TOTP 注册状态"
+        
+    },
+
+    "USER_GROUP_ATTRIBUTES" : {
+        
+        "FIELD_HEADER_GUAC_TOTP_DISABLED" : "禁用 TOTP：",
+        
+        "SECTION_HEADER_TOTP_USER_GROUP_CONFIG" : "TOTP 配置"
+        
     }
 
 }


### PR DESCRIPTION
Hello!

Found some missing translations in this extension during the trial.
So I updated the `zh.json` based on the `en.json` as well.

Also, tested locally by replacing the zh.json file directly, seems work well.