### PR TITLE
GUACAMOLE-926: Batch Import: Attempt to correct incorrectly-cased parameter values if possible

### DIFF
--- a/guacamole/src/main/frontend/src/app/import/services/connectionCSVService.js
+++ b/guacamole/src/main/frontend/src/app/import/services/connectionCSVService.js
@@ -389,17 +389,17 @@ angular.module('import').factory('connectionCSVService',
             // Fail if the name wasn't provided. Note that this is a file-level
             // error, not specific to any connection.
             if (!nameGetter)
-                throw new ParseError({
+                deferred.reject(new ParseError({
                     message: 'The connection name must be provided',
                     key: 'IMPORT.ERROR_REQUIRED_NAME_FILE'
-                });
+                }));
 
             // Fail if the protocol wasn't provided
             if (!protocolGetter)
-                throw new ParseError({
+                deferred.reject(new ParseError({
                     message: 'The connection protocol must be provided',
                     key: 'IMPORT.ERROR_REQUIRED_PROTOCOL_FILE'
-                });
+                }));
 
             // The function to transform a CSV row into a connection object
             deferred.resolve(function transformCSVRow(row) {


### PR DESCRIPTION
Yet another batch import bugfix / improvement!? Nobody could have seen _this_ coming!

This change does two things:
* Fixes an issue where file-level CSV errors didn't get surfaced to the user
* Attempts to correct any invalidly-cased user-provided connection parameter values, when the parameter has a limited number of possible options.

The latter is intended to help out with the case where a user may, while editing a CSV in many popular spreadsheets, have their "true" values for boolean parameters converted to "TRUE", which the backend will not understand.

