### PR TITLE
GUACAMOLE-1687: Leverage network activity to ensure keep-alive pings are sent.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -42,7 +42,36 @@ Guacamole.Client = function(tunnel) {
     var currentState = STATE_IDLE;
     
     var currentTimestamp = 0;
-    var pingInterval = null;
+
+    /**
+     * The rough number of milliseconds to wait between sending keep-alive
+     * pings. This may vary depending on how frequently the browser allows
+     * timers to run, as well as how frequently the client receives messages
+     * from the server.
+     *
+     * @private
+     * @constant
+     * @type {!number}
+     */
+    var KEEP_ALIVE_FREQUENCY = 5000;
+
+    /**
+     * The current keep-alive ping timeout ID, if any. This will only be set
+     * upon connecting.
+     *
+     * @private
+     * @type {number}
+     */
+    var keepAliveTimeout = null;
+
+    /**
+     * The timestamp of the point in time that the last keep-live ping was
+     * sent, in milliseconds elapsed since midnight of January 1, 1970 UTC.
+     *
+     * @private
+     * @type {!number}
+     */
+    var lastSentKeepAlive = 0;
 
     /**
      * Translation from Guacamole protocol line caps to Layer line caps.
@@ -1738,11 +1767,62 @@ Guacamole.Client = function(tunnel) {
 
     };
 
+    /**
+     * Sends a keep-alive ping to the Guacamole server, advising the server
+     * that the client is still connected and responding. The lastSentKeepAlive
+     * timestamp is automatically updated as a result of calling this function.
+     *
+     * @private
+     */
+    var sendKeepAlive = function sendKeepAlive() {
+        tunnel.sendMessage('nop');
+        lastSentKeepAlive = new Date().getTime();
+    };
+
+    /**
+     * Schedules the next keep-alive ping based on the KEEP_ALIVE_FREQUENCY and
+     * the time that the last ping was sent, if ever. If enough time has
+     * elapsed that a ping should have already been sent, calling this function
+     * will send that ping immediately.
+     *
+     * @private
+     */
+    var scheduleKeepAlive = function scheduleKeepAlive() {
+
+        window.clearTimeout(keepAliveTimeout);
+
+        var currentTime = new Date().getTime();
+        var keepAliveDelay = Math.max(lastSentKeepAlive + KEEP_ALIVE_FREQUENCY - currentTime, 0);
+
+        // Ping server regularly to keep connection alive, but send the ping
+        // immediately if enough time has elapsed that it should have already
+        // been sent
+        if (keepAliveDelay > 0)
+            keepAliveTimeout = window.setTimeout(sendKeepAlive, keepAliveDelay);
+        else
+            sendKeepAlive();
+
+    };
+
+    /**
+     * Stops sending any further keep-alive pings. If a keep-alive ping was
+     * scheduled to be sent, that ping is cancelled.
+     *
+     * @private
+     */
+    var stopKeepAlive = function stopKeepAlive() {
+        window.clearTimeout(keepAliveTimeout);
+    };
+
     tunnel.oninstruction = function(opcode, parameters) {
 
         var handler = instructionHandlers[opcode];
         if (handler)
             handler(parameters);
+
+        // Leverage network activity to ensure the next keep-alive ping is
+        // sent, even if the browser is currently throttling timers
+        scheduleKeepAlive();
 
     };
 
@@ -1757,9 +1837,8 @@ Guacamole.Client = function(tunnel) {
 
             setState(STATE_DISCONNECTING);
 
-            // Stop ping
-            if (pingInterval)
-                window.clearInterval(pingInterval);
+            // Stop sending keep-alive messages
+            stopKeepAlive();
 
             // Send disconnect message and disconnect
             tunnel.sendMessage("disconnect");
@@ -1793,10 +1872,9 @@ Guacamole.Client = function(tunnel) {
             throw status;
         }
 
-        // Ping every 5 seconds (ensure connection alive)
-        pingInterval = window.setInterval(function() {
-            tunnel.sendMessage("nop");
-        }, 5000);
+        // Regularly send keep-alive ping to ensure the server knows we're
+        // still here, even if not active
+        scheduleKeepAlive();
 
         setState(STATE_WAITING);
     };

--- a/guacamole-common-js/src/main/webapp/modules/Tunnel.js
+++ b/guacamole-common-js/src/main/webapp/modules/Tunnel.js
@@ -356,12 +356,16 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain, extraTunnelHeaders) {
     }
 
     /**
-     * Initiates a timeout which, if data is not received, causes the tunnel
-     * to close with an error.
-     * 
+     * Resets the state of timers tracking network activity and stability. If
+     * those timers are not yet started, invoking this function starts them.
+     * This function should be invoked when the tunnel is established and every
+     * time there is network activity on the tunnel, such that the timers can
+     * safely assume the network and/or server are not responding if this
+     * function has not been invoked for a significant period of time.
+     *
      * @private
      */
-    function reset_timeout() {
+    var resetTimers = function resetTimers() {
 
         // Get rid of old timeouts (if any)
         window.clearTimeout(receive_timeout);
@@ -381,7 +385,7 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain, extraTunnelHeaders) {
             tunnel.setState(Guacamole.Tunnel.State.UNSTABLE);
         }, tunnel.unstableThreshold);
 
-    }
+    };
 
     /**
      * Closes this tunnel, signaling the given status and corresponding
@@ -491,7 +495,7 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain, extraTunnelHeaders) {
             message_xmlhttprequest.onreadystatechange = function() {
                 if (message_xmlhttprequest.readyState === 4) {
 
-                    reset_timeout();
+                    resetTimers();
 
                     // If an error occurs during send, handle it
                     if (message_xmlhttprequest.status !== 200)
@@ -581,7 +585,7 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain, extraTunnelHeaders) {
             if (xmlhttprequest.readyState === 3 ||
                 xmlhttprequest.readyState === 4) {
 
-                reset_timeout();
+                resetTimers();
 
                 // Also poll every 30ms (some browsers don't repeatedly call onreadystatechange for new data)
                 if (pollingMode === POLLING_ENABLED) {
@@ -742,7 +746,7 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain, extraTunnelHeaders) {
     this.connect = function(data) {
 
         // Start waiting for connect
-        reset_timeout();
+        resetTimers();
 
         // Mark the tunnel as connecting
         tunnel.setState(Guacamole.Tunnel.State.CONNECTING);
@@ -760,7 +764,7 @@ Guacamole.HTTPTunnel = function(tunnelURL, crossDomain, extraTunnelHeaders) {
                 return;
             }
 
-            reset_timeout();
+            resetTimers();
 
             // Get UUID and HTTP-specific tunnel session token from response
             tunnel.setUUID(connect_xmlhttprequest.responseText);
@@ -932,12 +936,16 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
     };
 
     /**
-     * Initiates a timeout which, if data is not received, causes the tunnel
-     * to close with an error.
-     * 
+     * Resets the state of timers tracking network activity and stability. If
+     * those timers are not yet started, invoking this function starts them.
+     * This function should be invoked when the tunnel is established and every
+     * time there is network activity on the tunnel, such that the timers can
+     * safely assume the network and/or server are not responding if this
+     * function has not been invoked for a significant period of time.
+     *
      * @private
      */
-    function reset_timeout() {
+    var resetTimers = function resetTimers() {
 
         // Get rid of old timeouts (if any)
         window.clearTimeout(receive_timeout);
@@ -968,7 +976,7 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
         else
             sendPing();
 
-    }
+    };
 
     /**
      * Closes this tunnel, signaling the given status and corresponding
@@ -1043,7 +1051,7 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
 
     this.connect = function(data) {
 
-        reset_timeout();
+        resetTimers();
 
         // Mark the tunnel as connecting
         tunnel.setState(Guacamole.Tunnel.State.CONNECTING);
@@ -1052,7 +1060,7 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
         socket = new WebSocket(tunnelURL + "?" + data, "guacamole");
 
         socket.onopen = function(event) {
-            reset_timeout();
+            resetTimers();
         };
 
         socket.onclose = function(event) {
@@ -1074,7 +1082,7 @@ Guacamole.WebSocketTunnel = function(tunnelURL) {
         
         socket.onmessage = function(event) {
 
-            reset_timeout();
+            resetTimers();
 
             var message = event.data;
             var startIndex = 0;


### PR DESCRIPTION
This change reapplies the same commits from #764 against `staging/1.5.2`.