### PR TITLE
GUACAMOLE-615: Correct potential parse failures in webapp parser implementations.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Parser.js
+++ b/guacamole-common-js/src/main/webapp/modules/Parser.js
@@ -86,6 +86,29 @@ Guacamole.Parser = function Parser() {
     var elementCodepoints = 0;
 
     /**
+     * The number of parsed characters that must accumulate in the begining of
+     * the parse buffer before processing time is expended to truncate that
+     * buffer and conserve memory.
+     *
+     * @private
+     * @constant
+     * @type {!number}
+     */
+    var BUFFER_TRUNCATION_THRESHOLD = 4096;
+
+    /**
+     * The lowest Unicode codepoint to require a surrogate pair when encoded
+     * with UTF-16. In UTF-16, characters with codepoints at or above this
+     * value are represented with a surrogate pair, while characters with
+     * codepoints below this value are represented with a single character.
+     *
+     * @private
+     * @constant
+     * @type {!number}
+     */
+    var MIN_CODEPOINT_REQUIRES_SURROGATE = 0x10000;
+
+    /**
      * Appends the given instruction data packet to the internal buffer of
      * this Guacamole.Parser, executing all completed instructions at
      * the beginning of this buffer, if any.
@@ -109,7 +132,7 @@ Guacamole.Parser = function Parser() {
         else {
 
             // Truncate buffer as necessary
-            if (startIndex > 4096 && elementEnd >= startIndex) {
+            if (startIndex > BUFFER_TRUNCATION_THRESHOLD && elementEnd >= startIndex) {
 
                 buffer = buffer.substring(startIndex);
 
@@ -157,7 +180,7 @@ Guacamole.Parser = function Parser() {
                 // a high and low surrogate, elementEnd points to the low
                 // surrogate and NOT the element terminator. We must shift the
                 // end and reevaluate.
-                else if (elementCodepoints && buffer.codePointAt(elementEnd - 1) >= 0x10000) {
+                else if (elementCodepoints && buffer.codePointAt(elementEnd - 1) >= MIN_CODEPOINT_REQUIRES_SURROGATE) {
                     elementEnd++;
                     continue;
                 }

--- a/guacamole-common-js/src/main/webapp/modules/Parser.js
+++ b/guacamole-common-js/src/main/webapp/modules/Parser.js
@@ -164,7 +164,7 @@ Guacamole.Parser = function Parser() {
 
                 // We now have enough data for the element. Parse.
                 var element = buffer.substring(startIndex, elementEnd);
-                var terminator = buffer.substring(elementEnd, elementEnd+1);
+                var terminator = buffer.substring(elementEnd, elementEnd + 1);
 
                 // Add element to array
                 elementBuffer.push(element);
@@ -205,7 +205,7 @@ Guacamole.Parser = function Parser() {
             if (lengthEnd !== -1) {
 
                 // Parse length
-                elementCodepoints = parseInt(buffer.substring(elementEnd+1, lengthEnd));
+                elementCodepoints = parseInt(buffer.substring(elementEnd + 1, lengthEnd));
                 if (isNaN(elementCodepoints))
                     throw new Error('Non-numeric character in element length.');
 

--- a/guacamole-common-js/src/main/webapp/modules/Parser.js
+++ b/guacamole-common-js/src/main/webapp/modules/Parser.js
@@ -268,9 +268,20 @@ Guacamole.Parser = function Parser() {
  *     given string.
  */
 Guacamole.Parser.codePointCount = function codePointCount(str, start, end) {
+
+    // Count only characters within the specified region
     str = str.substring(start || 0, end);
+
+    // Locate each proper Unicode surrogate pair (one high surrogate followed
+    // by one low surrogate)
     var surrogatePairs = str.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g);
+
+    // Each surrogate pair represents a single codepoint but is represented by
+    // two characters in a JavaScript string, and thus is counted twice toward
+    // string length. Subtracting the number of surrogate pairs adjusts that
+    // length value such that it gives us the number of codepoints.
     return str.length - (surrogatePairs ? surrogatePairs.length : 0);
+
 };
 
 /**

--- a/guacamole-common-js/src/test/javascript/ParserSpec.js
+++ b/guacamole-common-js/src/test/javascript/ParserSpec.js
@@ -174,4 +174,33 @@ describe('Guacamole.Parser', function ParserSpec() {
 
     });
 
+    // Verify codePointCount() utility function correctly counts codepoints in
+    // full strings
+    describe('when a string is provided to codePointCount()', function() {
+
+        it('should return the number of codepoints in that string', function() {
+            expect(Guacamole.Parser.codePointCount('')).toBe(0);
+            expect(Guacamole.Parser.codePointCount('test string')).toBe(11);
+            expect(Guacamole.Parser.codePointCount('surrogate' + SURROGATE_PAIR + 'pair')).toBe(14);
+            expect(Guacamole.Parser.codePointCount('missing' + HIGH_SURROGATE + 'surrogates' + LOW_SURROGATE)).toBe(19);
+            expect(Guacamole.Parser.codePointCount(HIGH_SURROGATE + LOW_SURROGATE + HIGH_SURROGATE)).toBe(2);
+            expect(Guacamole.Parser.codePointCount(HIGH_SURROGATE + HIGH_SURROGATE + LOW_SURROGATE)).toBe(2);
+        });
+
+    });
+
+    // Verify codePointCount() utility function correctly counts codepoints in
+    // substrings
+    describe('when a substring is provided to codePointCount()', function() {
+
+        it('should return the number of codepoints in that substring', function() {
+            expect(Guacamole.Parser.codePointCount('test string', 0)).toBe(11);
+            expect(Guacamole.Parser.codePointCount('surrogate' + SURROGATE_PAIR + 'pair', 5)).toBe(9);
+            expect(Guacamole.Parser.codePointCount('missing' + HIGH_SURROGATE + 'surrogates' + LOW_SURROGATE, 2, 17)).toBe(15);
+            expect(Guacamole.Parser.codePointCount(HIGH_SURROGATE + LOW_SURROGATE + HIGH_SURROGATE, 0, 2)).toBe(1);
+            expect(Guacamole.Parser.codePointCount(HIGH_SURROGATE + HIGH_SURROGATE + LOW_SURROGATE, 1, 2)).toBe(1);
+        });
+
+    });
+
 });

--- a/guacamole-common-js/src/test/javascript/ParserSpec.js
+++ b/guacamole-common-js/src/test/javascript/ParserSpec.js
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global Guacamole, jasmine, expect */
+
+describe('Guacamole.Parser', function ParserSpec() {
+
+    /**
+     * A single Unicode high surrogate character (any character between U+D800
+     * and U+DB7F).
+     *
+     * @constant
+     * @type {!string}
+     */
+    const HIGH_SURROGATE = '\uD802';
+
+    /**
+     * A single Unicode low surrogate character (any character between U+DC00
+     * and U+DFFF).
+     *
+     * @constant
+     * @type {!string}
+     */
+    const LOW_SURROGATE = '\uDF00';
+
+    /**
+     * A Unicode surrogate pair, consisting of a high and low surrogate.
+     *
+     * @constant
+     * @type {!string}
+     */
+    const SURROGATE_PAIR = HIGH_SURROGATE + LOW_SURROGATE;
+
+    /**
+     * A 4-character test string containing Unicode characters that require
+     * multiple bytes when encoded as UTF-8, including at least one character
+     * that is encoded as a surrogate pair in UTF-16.
+     *
+     * @constant
+     * @type {!string}
+     */
+    const UTF8_MULTIBYTE = '\u72AC' + SURROGATE_PAIR + 'z\u00C1';
+
+    /**
+     * The Guacamole.Parser instance to test. This instance is (re)created prior
+     * to each test via beforeEach().
+     *
+     * @type {Guacamole.Parser}
+     */
+    var parser;
+
+    // Provide each test with a fresh parser
+    beforeEach(function() {
+        parser = new Guacamole.Parser();
+    });
+
+    // Empty instruction
+    describe('when an empty instruction is received', function() {
+
+        it('should parse the single empty opcode and invoke oninstruction', function() {
+            parser.oninstruction = jasmine.createSpy('oninstruction');
+            parser.receive('0.;');
+            expect(parser.oninstruction).toHaveBeenCalledOnceWith('', [ ]);
+        });
+
+    });
+
+    // Instruction using basic Latin characters
+    describe('when an instruction is containing only basic Latin characters', function() {
+
+        it('should correctly parse each element and invoke oninstruction', function() {
+            parser.oninstruction = jasmine.createSpy('oninstruction');
+            parser.receive('5.test2,'
+                + '10.hellohello,'
+                + '15.worldworldworld;'
+            );
+            expect(parser.oninstruction).toHaveBeenCalledOnceWith('test2', [
+                'hellohello',
+                'worldworldworld'
+            ]);
+        });
+
+    });
+
+    // Instruction using characters requiring multiple bytes in UTF-8 and
+    // surrogate pairs in UTF-16, including an element ending with a surrogate
+    // pair
+    describe('when an instruction is received containing elements that '
+           + 'contain characters involving surrogate pairs', function() {
+
+        it('should correctly parse each element and invoke oninstruction', function() {
+            parser.oninstruction = jasmine.createSpy('oninstruction');
+            parser.receive('4.test,'
+                + '6.a' + UTF8_MULTIBYTE + 'b,'
+                + '5.1234' + SURROGATE_PAIR + ','
+                + '10.a' + UTF8_MULTIBYTE + UTF8_MULTIBYTE + 'c;'
+            );
+            expect(parser.oninstruction).toHaveBeenCalledOnceWith('test', [
+                'a' + UTF8_MULTIBYTE + 'b',
+                '1234' + SURROGATE_PAIR,
+                'a' + UTF8_MULTIBYTE + UTF8_MULTIBYTE + 'c'
+            ]);
+        });
+
+    });
+
+    // Instruction with an element values ending with an incomplete surrogate
+    // pair (high or low surrogate only)
+    describe('when an instruction is received containing elements that end '
+           + 'with incomplete surrogate pairs', function() {
+
+        it('should correctly parse each element and invoke oninstruction', function() {
+            parser.oninstruction = jasmine.createSpy('oninstruction');
+            parser.receive('4.test,'
+                + '5.1234' + HIGH_SURROGATE + ','
+                + '5.4567' + LOW_SURROGATE + ';'
+            );
+            expect(parser.oninstruction).toHaveBeenCalledOnceWith('test', [
+                '1234' + HIGH_SURROGATE,
+                '4567' + LOW_SURROGATE
+            ]);
+        });
+
+    });
+
+    // Instruction with element values containing incomplete surrogate pairs,
+    describe('when an instruction is received containing incomplete surrogate pairs', function() {
+
+        it('should correctly parse each element and invoke oninstruction', function() {
+            parser.oninstruction = jasmine.createSpy('oninstruction');
+            parser.receive('5.te' + LOW_SURROGATE + 'st,'
+                + '5.12' + HIGH_SURROGATE + '3' + LOW_SURROGATE + ','
+                + '6.5' + LOW_SURROGATE + LOW_SURROGATE + '4' + HIGH_SURROGATE + HIGH_SURROGATE + ','
+                + '10.' + UTF8_MULTIBYTE + HIGH_SURROGATE + UTF8_MULTIBYTE + HIGH_SURROGATE + ';',
+            );
+            expect(parser.oninstruction).toHaveBeenCalledOnceWith('te' + LOW_SURROGATE + 'st', [
+                '12' + HIGH_SURROGATE + '3' + LOW_SURROGATE,
+                '5' + LOW_SURROGATE + LOW_SURROGATE + '4' + HIGH_SURROGATE + HIGH_SURROGATE,
+                UTF8_MULTIBYTE + HIGH_SURROGATE + UTF8_MULTIBYTE + HIGH_SURROGATE
+            ]);
+        });
+
+    });
+
+
+
+});

--- a/guacamole-common-js/src/test/javascript/ParserSpec.js
+++ b/guacamole-common-js/src/test/javascript/ParserSpec.js
@@ -158,6 +158,20 @@ describe('Guacamole.Parser', function ParserSpec() {
 
     });
 
+    // Instruction fed via blocks of characters that accumulate via an external
+    // buffer
+    describe('when an instruction is received via an external buffer', function() {
 
+        it('should correctly parse each element and invoke oninstruction once ready', function() {
+            parser.oninstruction = jasmine.createSpy('oninstruction');
+            parser.receive('5.test2,10.hello', true);
+            expect(parser.oninstruction).not.toHaveBeenCalled();
+            parser.receive('5.test2,10.hellohello,15', true);
+            expect(parser.oninstruction).not.toHaveBeenCalled();
+            parser.receive('5.test2,10.hellohello,15.worldworldworld;', true);
+            expect(parser.oninstruction).toHaveBeenCalledOnceWith('test2', [ 'hellohello', 'worldworldworld' ]);
+        });
+
+    });
 
 });

--- a/guacamole-common-js/src/test/javascript/ParserSpec.js
+++ b/guacamole-common-js/src/test/javascript/ParserSpec.js
@@ -203,4 +203,19 @@ describe('Guacamole.Parser', function ParserSpec() {
 
     });
 
+    // Verify toInstruction() utility function correctly encodes instructions
+    describe('when an array of elements is provided to toInstruction()', function() {
+
+        it('should return a correctly-encoded Guacamole instruction', function() {
+            expect(Guacamole.Parser.toInstruction([ 'test', 'instruction' ])).toBe('4.test,11.instruction;');
+            expect(Guacamole.Parser.toInstruction([ 'test' + SURROGATE_PAIR, 'instruction' ]))
+                    .toBe('5.test' + SURROGATE_PAIR + ',11.instruction;');
+            expect(Guacamole.Parser.toInstruction([ UTF8_MULTIBYTE, HIGH_SURROGATE + 'xyz' + LOW_SURROGATE ]))
+                    .toBe('4.' + UTF8_MULTIBYTE + ',5.' + HIGH_SURROGATE + 'xyz' + LOW_SURROGATE + ';');
+            expect(Guacamole.Parser.toInstruction([ UTF8_MULTIBYTE, LOW_SURROGATE + 'xyz' + HIGH_SURROGATE ]))
+                    .toBe('4.' + UTF8_MULTIBYTE + ',5.' + LOW_SURROGATE + 'xyz' + HIGH_SURROGATE + ';');
+        });
+
+    });
+
 });

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleInstruction.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleInstruction.java
@@ -94,6 +94,22 @@ public class GuacamoleInstruction {
     }
 
     /**
+     * Appends the given value to the provided StringBuilder as a Guacamole
+     * instruction element, including length prefix.
+     *
+     * @param buff
+     *     The StringBuilder to append the element to.
+     *
+     * @param element
+     *     The string value of the element to append.
+     */
+    private static void appendElement(StringBuilder buff, String element) {
+        buff.append(element.codePointCount(0, element.length()));
+        buff.append('.');
+        buff.append(element);
+    }
+
+    /**
      * Returns this GuacamoleInstruction in the form it would be sent over the
      * Guacamole protocol.
      *
@@ -111,16 +127,12 @@ public class GuacamoleInstruction {
             StringBuilder buff = new StringBuilder();
 
             // Write opcode
-            buff.append(opcode.length());
-            buff.append('.');
-            buff.append(opcode);
+            appendElement(buff, opcode);
 
             // Write argument values
             for (String value : args) {
                 buff.append(',');
-                buff.append(value.length());
-                buff.append('.');
-                buff.append(value);
+                appendElement(buff, value);
             }
 
             // Write terminator

--- a/guacamole-common/src/test/java/org/apache/guacamole/protocol/GuacamoleInstructionTest.java
+++ b/guacamole-common/src/test/java/org/apache/guacamole/protocol/GuacamoleInstructionTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.protocol;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ * Unit test for GuacamoleParser. Verifies that parsing of the Guacamole
+ * protocol works as required.
+ */
+public class GuacamoleInstructionTest {
+
+    /**
+     * A single test case for verifying that Guacamole protocol implementations
+     * correctly parse or encode Guacamole instructions.
+     */
+    public static class TestCase extends GuacamoleInstruction {
+
+        /**
+         * The full and correct Guacamole protocol representation of this
+         * instruction.
+         */
+        public final String UNPARSED;
+
+        /**
+         * The opcode that should be present in the Guacamole instruction;
+         */
+        public final String OPCODE;
+
+        /**
+         * All arguments that should be present in the Guacamole instruction;
+         */
+        public final List<String> ARGS;
+
+        /**
+         * Creates a new TestCase representing the given Guacamole instruction.
+         *
+         * @param unparsed
+         *     The full and correct Guacamole protocol representation of this
+         *     instruction.
+         *
+         * @param opcode
+         *     The opcode of the Guacamole instruction.
+         *
+         * @param args
+         *     The arguments of the Guacamole instruction, if any.
+         */
+        public TestCase(String unparsed, String opcode, String... args) {
+            super(opcode, Arrays.copyOf(args, args.length));
+            this.UNPARSED = unparsed;
+            this.OPCODE = opcode;
+            this.ARGS = Collections.unmodifiableList(Arrays.asList(args));
+        }
+
+    }
+
+    /**
+     * A single Unicode high surrogate character (any character between U+D800
+     * and U+DB7F).
+     */
+    public static final String HIGH_SURROGATE = "\uD802";
+
+    /**
+     * A single Unicode low surrogate character (any character between U+DC00
+     * and U+DFFF).
+     */
+    public static final String LOW_SURROGATE = "\uDF00";
+
+    /**
+     * A Unicode surrogate pair, consisting of a high and low surrogate.
+     */
+    public static final String SURROGATE_PAIR = HIGH_SURROGATE + LOW_SURROGATE;
+
+    /**
+     * A 4-character test string containing Unicode characters that require
+     * multiple bytes when encoded as UTF-8, including at least one character
+     * that is encoded as a surrogate pair in UTF-16.
+     */
+    public static final String UTF8_MULTIBYTE = "\u72AC" + SURROGATE_PAIR + "z\u00C1";
+
+    /**
+     * Pre-defined set of test cases for verifying Guacamole instructions are
+     * correctly parsed and encoded.
+     */
+    public static List<TestCase> TEST_CASES = Collections.unmodifiableList(Arrays.asList(
+
+        // Empty instruction
+        new TestCase(
+            "0.;",
+            ""
+        ),
+
+        // Instruction using basic Latin characters
+        new TestCase(
+
+              "5.test2,"
+            + "10.hellohello,"
+            + "15.worldworldworld;",
+
+            "test2",
+            "hellohello",
+            "worldworldworld"
+
+        ),
+
+        // Instruction using characters requiring multiple bytes in UTF-8 and
+        // surrogate pairs in UTF-16, including an element ending with a surrogate
+        // pair
+        new TestCase(
+
+              "4.ab" + HIGH_SURROGATE + HIGH_SURROGATE + ","
+            + "6.a" + UTF8_MULTIBYTE + "b,"
+            + "5.12345,"
+            + "10.a" + UTF8_MULTIBYTE + UTF8_MULTIBYTE + "c;",
+
+            "ab" + HIGH_SURROGATE + HIGH_SURROGATE,
+            "a" + UTF8_MULTIBYTE + "b",
+            "12345",
+            "a" + UTF8_MULTIBYTE + UTF8_MULTIBYTE + "c"
+
+        ),
+
+        // Instruction with an element values ending with an incomplete surrogate
+        // pair (high or low surrogate only)
+        new TestCase(
+
+              "4.test,"
+            + "5.1234" + HIGH_SURROGATE + ","
+            + "5.4567" + LOW_SURROGATE + ";",
+
+            "test",
+            "1234" + HIGH_SURROGATE,
+            "4567" + LOW_SURROGATE
+
+        ),
+
+        // Instruction with element values containing incomplete surrogate pairs
+        new TestCase(
+
+              "5.te" + LOW_SURROGATE + "st,"
+            + "5.12" + HIGH_SURROGATE + "3" + LOW_SURROGATE + ","
+            + "6.5" + LOW_SURROGATE + LOW_SURROGATE + "4" + HIGH_SURROGATE + HIGH_SURROGATE + ","
+            + "10." + UTF8_MULTIBYTE + HIGH_SURROGATE + UTF8_MULTIBYTE + HIGH_SURROGATE + ";",
+
+            "te" + LOW_SURROGATE + "st",
+            "12" + HIGH_SURROGATE + "3" + LOW_SURROGATE,
+            "5" + LOW_SURROGATE + LOW_SURROGATE + "4" + HIGH_SURROGATE + HIGH_SURROGATE,
+            UTF8_MULTIBYTE + HIGH_SURROGATE + UTF8_MULTIBYTE + HIGH_SURROGATE
+
+        )
+
+    ));
+
+    /**
+     * Verifies that instruction opcodes are represented correctly.
+     */
+    @Test
+    public void testGetOpcode() {
+        for (TestCase testCase : TEST_CASES) {
+            assertEquals(testCase.OPCODE, testCase.getOpcode());
+        }
+    }
+
+    /**
+     * Verifies that instruction arguments are represented correctly.
+     */
+    @Test
+    public void testGetArgs() {
+        for (TestCase testCase : TEST_CASES) {
+            assertEquals(testCase.ARGS, testCase.getArgs());
+        }
+    }
+
+    /**
+     * Verifies that instructions are encoded correctly.
+     */
+    @Test
+    public void testToString() {
+        for (TestCase testCase : TEST_CASES) {
+            assertEquals(testCase.UNPARSED, testCase.toString());
+        }
+    }
+
+}


### PR DESCRIPTION
The Java and JavaScript implementations of the Guacamole protocol parser may cause unexpected parsing failures due to those languages' use of UTF-16 internally for string representations and string length. In particular, characters involving high/low surrogates may end up with miscalculated length prefixes, ultimately causing the resulting instruction to fail to parse.

These changes refactor both implementations to calculate lengths in a way that takes high/low surrogates into account, and refactor the tunnel implementations to use a common parser.

The internal implementations of the length calculation (`codePointCount()` in Java and regex in JavaScript) were chosen after benchmarking the parser to verify that performance is not impacted. The "naive" solution (walking the string and counting codepoints manually) is _significantly_ slower, whereas the solution here is as fast as the old implementation (if not faster).