### PR TITLE
GUACAMOLE-1628: Docker image of guacamole client is missing unzip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,10 @@ RUN /opt/guacamole/bin/build-guacamole.sh "$BUILD_DIR" /opt/guacamole
 # For the runtime image, we start with the official Tomcat distribution
 FROM tomcat:${TOMCAT_VERSION}-${TOMCAT_JRE}
 
-# Install XMLStarlet for server.xml alterations
+# Install XMLStarlet for server.xml alterations and unzip for LOGBACK_LEVEL case
 RUN apt-get update -qq \
-    && apt-get install -y xmlstarlet \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y xmlstarlet unzip\
+    && rm -rf /var/lib/apt/lists/* 
 
 # This is where the build artifacts go in the runtime image
 WORKDIR /opt/guacamole


### PR DESCRIPTION
This change reapplies the same commits from #766 against `staging/1.5.2`.