### PR TITLE
GUACAMOLE-1775: Use header for auth token instead of a parameter in "session/tunnels/<tunnel ID>/protocol" request

### DIFF
--- a/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
+++ b/guacamole/src/main/frontend/src/app/rest/services/tunnelService.js
@@ -88,17 +88,10 @@ angular.module('rest').factory('tunnelService', ['$injector',
      */
     service.getProtocol = function getProtocol(tunnel) {
 
-        // Build HTTP parameters set
-        var httpParameters = {
-            token : authenticationService.getCurrentToken()
-        };
-
-        // Retrieve the protocol details of the specified tunnel
-        return requestService({
+        return authenticationService.request({
             method  : 'GET',
             url     : 'api/session/tunnels/' + encodeURIComponent(tunnel)
-                        + '/protocol',
-            params  : httpParameters
+                        + '/protocol'
         });
 
     };


### PR DESCRIPTION
This change reapplies the same commits from #841 against `staging/1.5.2`.