### PR TITLE
GUACAMOLE-1606: UserGroup should retrieve UserGroup attributes, not User attributes.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupObjectTranslator.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/usergroup/UserGroupObjectTranslator.java
@@ -57,7 +57,7 @@ public class UserGroupObjectTranslator
             throws GuacamoleException {
 
         // Filter object attributes by defined schema
-        object.setAttributes(filterAttributes(userContext.getUserAttributes(),
+        object.setAttributes(filterAttributes(userContext.getUserGroupAttributes(),
                 object.getAttributes()));
 
     }


### PR DESCRIPTION
This change reapplies the same commits from #733 against `staging/1.5.2`.