### PR TITLE
GUACAMOLE-1756: Display login failures regardless of whether the interactive login form was used.

### DIFF
--- a/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
+++ b/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
@@ -23,6 +23,9 @@
 angular.module('index').controller('indexController', ['$scope', '$injector',
         function indexController($scope, $injector) {
 
+    // Required types
+    const Error = $injector.get('Error');
+
     // Required services
     const $document         = $injector.get('$document');
     const $location         = $injector.get('$location');
@@ -93,6 +96,11 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
      * @enum {string}
      */
     var ApplicationState = {
+
+        /**
+         * A non-interactive authentication attempt failed.
+         */
+        AUTOMATIC_LOGIN_REJECTED : 'automaticLoginRejected',
 
         /**
          * The application has fully loaded but is awaiting credentials from
@@ -262,6 +270,25 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
         $scope.loginHelpText = error.translatableMessage;
         $scope.acceptedCredentials = parameters;
         $scope.expectedCredentials = error.expected;
+
+    });
+
+    // Alert user to authentication errors that occur in the absence of an
+    // interactive login form
+    $scope.$on('guacLoginFailed', function loginFailed(event, parameters, error) {
+
+        // All errors related to an interactive login form are handled elsewhere
+        if ($scope.applicationState === ApplicationState.AWAITING_CREDENTIALS
+                || error.type === Error.Type.INSUFFICIENT_CREDENTIALS
+                || error.type === Error.Type.INVALID_CREDENTIALS)
+            return;
+
+        $scope.applicationState = ApplicationState.AUTOMATIC_LOGIN_REJECTED;
+        $scope.page.title = 'APP.NAME';
+        $scope.page.bodyClassName = '';
+
+        $scope.reAuthenticating = false;
+        $scope.fatalError = error;
 
     });
 

--- a/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
+++ b/guacamole/src/main/frontend/src/app/index/controllers/indexController.js
@@ -229,6 +229,22 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     }, true);
 
     /**
+     * Sets the current overall state of the client side of the
+     * application to the given value. Possible values are defined by
+     * {@link ApplicationState}. The title and class associated with the
+     * current page are automatically reset to the standard values applicable
+     * to the application as a whole (rather than any specific page).
+     *
+     * @param {!string} state
+     *     The state to assign, as defined by {@link ApplicationState}.
+     */
+    const setApplicationState = function setApplicationState(state) {
+        $scope.applicationState = state;
+        $scope.page.title = 'APP.NAME';
+        $scope.page.bodyClassName = '';
+    };
+
+    /**
      * Navigates the user back to the root of the application (or reloads the
      * current route and controller if the user is already there), effectively
      * forcing reauthentication. If the user is not logged in, this will result
@@ -250,9 +266,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Display login screen if a whole new set of credentials is needed
     $scope.$on('guacInvalidCredentials', function loginInvalid(event, parameters, error) {
 
-        $scope.applicationState = ApplicationState.AWAITING_CREDENTIALS;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
+        setApplicationState(ApplicationState.AWAITING_CREDENTIALS);
 
         $scope.loginHelpText = null;
         $scope.acceptedCredentials = {};
@@ -263,9 +277,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Prompt for remaining credentials if provided credentials were not enough
     $scope.$on('guacInsufficientCredentials', function loginInsufficient(event, parameters, error) {
 
-        $scope.applicationState = ApplicationState.AWAITING_CREDENTIALS;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
+        setApplicationState(ApplicationState.AWAITING_CREDENTIALS);
 
         $scope.loginHelpText = error.translatableMessage;
         $scope.acceptedCredentials = parameters;
@@ -283,10 +295,7 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
                 || error.type === Error.Type.INVALID_CREDENTIALS)
             return;
 
-        $scope.applicationState = ApplicationState.AUTOMATIC_LOGIN_REJECTED;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
-
+        setApplicationState(ApplicationState.AUTOMATIC_LOGIN_REJECTED);
         $scope.reAuthenticating = false;
         $scope.fatalError = error;
 
@@ -295,13 +304,8 @@ angular.module('index').controller('indexController', ['$scope', '$injector',
     // Replace absolutely all content with an error message if the page itself
     // cannot be displayed due to an error
     $scope.$on('guacFatalPageError', function fatalPageError(error) {
-
-        $scope.applicationState = ApplicationState.FATAL_ERROR;
-        $scope.page.title = 'APP.NAME';
-        $scope.page.bodyClassName = '';
-
+        setApplicationState(ApplicationState.FATAL_ERROR);
         $scope.fatalError = error;
-
     });
 
     // Replace the overall user interface with an informational message if the

--- a/guacamole/src/main/frontend/src/app/index/styles/automatic-login-rejected.css
+++ b/guacamole/src/main/frontend/src/app/index/styles/automatic-login-rejected.css
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.automatic-login-rejected-modal guac-modal {
+    background: white;
+    z-index: 20;
+}
+
+.automatic-login-rejected-modal .notification {
+    display: inline-block;
+    max-width: 5in;
+    padding: 1em;
+    width: 100%;
+}

--- a/guacamole/src/main/frontend/src/index.html
+++ b/guacamole/src/main/frontend/src/index.html
@@ -64,6 +64,20 @@
             </guac-modal>
         </div>
 
+        <!-- Authentication error without a corresponding login form -->
+        <div class="automatic-login-rejected-modal" ng-switch-when="automaticLoginRejected">
+            <guac-modal>
+                <div class="notification">
+                    <p translate="{{ fatalError.translatableMessage.key }}"
+                       translate-values="{{ fatalError.translatableMessage.variables }}"></p>
+                    <p>
+                        <button translate="APP.ACTION_LOGIN_AGAIN" ng-disabled="reAuthenticating"
+                                ng-click="reAuthenticate()"></button>
+                    </p>
+                </div>
+            </guac-modal>
+        </div>
+
         <!-- Login screen for logged-out users -->
         <guac-login ng-switch-when="awaitingCredentials"
                     help-text="loginHelpText"


### PR DESCRIPTION
This change reapplies the same commits from #815 against `staging/1.5.2`.

**NOTE:** This will result in merge conflicts when `staging/1.5.2` is merged back to `master` due to the non-bugfix changes on `master` from #798. The single conflict is on `indexController.js` and should be fairly trivial to resolve:

```
<<<<<<< HEAD
    /**
     * The number of milliseconds that should elapse between client-side
     * session checks. This DOES NOT impact whether a session expires at all;
     * such checks will always be server-side. This only affects how quickly
     * the client-side view can recognize that a user's session has expired
     * absent any action taken by the user.
     *
     * @type {!number}
     */ 
    const SESSION_VALIDITY_RECHECK_INTERVAL = 15000;

    // Required types
    const Error              = $injector.get('Error');
    const ManagedClientState = $injector.get('ManagedClientState');
=======
    // Required types
    const Error = $injector.get('Error');
>>>>>>> test-merge-1.5.2
```

As these changes only require the addition of `Error`, something already present on `master`, it's sufficient to just accept the `HEAD` version:

```js
    /**
     * The number of milliseconds that should elapse between client-side
     * session checks. This DOES NOT impact whether a session expires at all;
     * such checks will always be server-side. This only affects how quickly
     * the client-side view can recognize that a user's session has expired
     * absent any action taken by the user.
     *
     * @type {!number}
     */ 
    const SESSION_VALIDITY_RECHECK_INTERVAL = 15000;

    // Required types
    const Error              = $injector.get('Error');
    const ManagedClientState = $injector.get('ManagedClientState');
```