### PR TITLE
GUACAMOLE-1728: Allow Null User Object attributes to be saved.

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectTranslator.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/directory/DirectoryObjectTranslator.java
@@ -145,8 +145,9 @@ public abstract class DirectoryObjectTranslator<InternalType extends Identifiabl
                 String attributeValue = attributes.get(attributeName);
 
                 // Include attribute value within filtered map only if
-                // (1) defined and (2) present within provided map
-                if (attributeValue != null)
+                // defined or present within provided map
+                if (attributeValue != null || 
+                        attributes.containsKey(attributeName))
                     filtered.put(attributeName, attributeValue);
 
             }


### PR DESCRIPTION
This change reapplies the same commits from #783 against `staging/1.5.2`.