### PR TITLE
GUACAMOLE-1579: Stop including the auth token when making requests to the /api/patches endpoint.

### DIFF
--- a/guacamole/src/main/frontend/src/app/rest/services/patchService.js
+++ b/guacamole/src/main/frontend/src/app/rest/services/patchService.js
@@ -25,17 +25,16 @@ angular.module('rest').factory('patchService', ['$injector',
 
     // Required services
     var requestService        = $injector.get('requestService');
-    var authenticationService = $injector.get('authenticationService');
     var cacheService          = $injector.get('cacheService');
 
     var service = {};
-    
+
     /**
      * Makes a request to the REST API to get the list of patches, returning
      * a promise that provides the array of all applicable patches if
      * successful. Each patch is a string of raw HTML with meta information
      * describing the patch operation stored within meta tags.
-     *                          
+     *
      * @returns {Promise.<String[]>}
      *     A promise which will resolve with an array of HTML patches upon
      *     success.
@@ -43,14 +42,14 @@ angular.module('rest').factory('patchService', ['$injector',
     service.getPatches = function getPatches() {
 
         // Retrieve all applicable HTML patches
-        return authenticationService.request({
+        return requestService({
             cache   : cacheService.patches,
             method  : 'GET',
             url     : 'api/patches'
         });
 
     };
-    
+
     return service;
 
 }]);


### PR DESCRIPTION
This change reapplies the same commits from #716 against `staging/1.5.2`.