### PR TITLE
GUACAMOLE-1788: Fix build against Maven 3.9.x.

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -1,3 +1,4 @@
 CONTRIBUTING
 doc/licenses/*/**/*
 doc/**/html/*.html
+guacamole-docker/*.pref

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,21 @@ ARG TOMCAT_VERSION=8.5
 ARG TOMCAT_JRE=jdk8
 
 # Use official maven image for the build
-FROM maven:3-jdk-8 AS builder
+FROM maven:3-eclipse-temurin-8-focal AS builder
+
+# Use Mozilla's Firefox PPA (newer Ubuntu lacks a "firefox-esr" package and
+# provides only a transitional "firefox" package that actually requires Snap
+# and thus can't be used within Docker)
+RUN    apt-get update                                \
+    && apt-get upgrade -y                            \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:mozillateam/ppa
+
+# Explicitly prefer packages from the Firefox PPA
+COPY guacamole-docker/mozilla-firefox.pref /etc/apt/preferences.d/
 
 # Install firefox browser for sake of JavaScript unit tests
-RUN apt-get update && apt-get install -y firefox-esr
+RUN apt-get update && apt-get install -y firefox
 
 # Arbitrary arguments that can be passed to the maven build. By default, an
 # argument will be provided to explicitly unskip any skipped tests. To, for

--- a/guacamole-docker/mozilla-firefox.pref
+++ b/guacamole-docker/mozilla-firefox.pref
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=LP-PPA-mozillateam
+Pin-Priority: 1001

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,13 @@
                     <groupId>com.github.buckelieg</groupId>
                     <artifactId>minify-maven-plugin</artifactId>
                     <version>2.0.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-utils</artifactId>
+                            <version>3.5.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
 
                 <!-- Explicitly use latest versions of core plugins -->


### PR DESCRIPTION
This change:

1. Updates the Docker image build to use an up-to-date tag (`maven:3-jdk-8` does not appear to be updated any longer).
2. Manually updates the dependencies of `minify-maven-plugin` to pull in `plexus-utils`, which is no longer included automatically as of Maven 3.9.x.

The update to the Docker image build causes the same breakage as can be seen in CI (https://ci-builds.apache.org/job/Guacamole/job/guacamole-client-master/235/), while the update to the `pom.xml` fixes that breakage.