### PR TITLE
GUACAMOLE-615: Correct JSDoc annotation for array of any type.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Parser.js
+++ b/guacamole-common-js/src/main/webapp/modules/Parser.js
@@ -312,7 +312,7 @@ Guacamole.Parser.codePointCount = function codePointCount(str, start, end) {
  * those strings as length-prefixed elements of a complete Guacamole
  * instruction.
  *
- * @param {!*[]} elements
+ * @param {!Array.<*>} elements
  *     The values that should be encoded as the elements of a Guacamole
  *     instruction. Order of these elements is preserved. This array MUST have
  *     at least one element.


### PR DESCRIPTION
The documentation build is currently failing with the following error:

```
$ jsdoc -c jsdoc-conf.json
ERROR: Unable to parse a tag's type expression for source file /home/mjumper/apache/guacamole/guacamole-client/guacamole-common-js/src/main/webapp/modules/Parser.js in line 310 with tag title "param" and text "{!*[]} elements
    The values that should be encoded as the elements of a Guacamole
    instruction. Order of these elements is preserved. This array MUST have
    at least one element.": Invalid type expression "!*[]": Expected "=", "|", or end of input but "[" found.
ERROR: Unable to parse a tag's type expression for source file /home/mjumper/apache/guacamole/guacamole-client/guacamole-common-js/src/main/webapp/modules/Parser.js in line 324 with tag title "param" and text "{!*[]} elements
    The values that should be encoded as the elements of a Guacamole
    instruction. Order of these elements is preserved. This array MUST have
    at least one element.": Invalid type expression "!*[]": Expected "=", "|", or end of input but "[" found.
$
```

Apparently `*[]` is not a valid JSDoc annotation for an array of any type, and `Array.<*>` must be used instead.