### PR TITLE
GUACAMOLE-926: Fix UTF-8 handling in batch import files.

### DIFF
--- a/guacamole/src/main/frontend/src/app/import/controllers/importConnectionsController.js
+++ b/guacamole/src/main/frontend/src/app/import/controllers/importConnectionsController.js
@@ -693,7 +693,7 @@ angular.module('import').controller('importConnectionsController', ['$scope', '$
         });
 
         // Read all the data into memory
-        $scope.fileReader.readAsBinaryString(file);
+        $scope.fileReader.readAsText(file);
     };
     
 }]);


### PR DESCRIPTION
I tried creating a connection with the name “平仮名” using CSV, JSON, and YAML file types. The existing file parsing logic will return a name of "å¹³ä»®å" instead.

Luckily, the fix was easy. All the file type checks (including the check of the first few bytes to see if the file is secretly a zip in disguise) still work as expected.


