### PR TITLE
GUACAMOLE-1793: Fix creation of SessionRecording from blob.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
+++ b/guacamole-common-js/src/main/webapp/modules/SessionRecording.js
@@ -398,8 +398,10 @@ Guacamole.SessionRecording = function SessionRecording(source) {
     };
 
     // Read instructions from provided blob, extracting each frame
-    if (source instanceof Blob)
+    if (source instanceof Blob) {
+        recordingBlob = source;
         parseBlob(recordingBlob, loadInstruction, notifyLoaded);
+    }
 
     // If tunnel provided instead of Blob, extract frames, etc. as instructions
     // are received, buffering things into a Blob for future seeks

--- a/guacamole-common-js/src/test/javascript/SessionRecordingSpec.js
+++ b/guacamole-common-js/src/test/javascript/SessionRecordingSpec.js
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global Guacamole, expect */
+
+describe('Guacamole.SessionRecording', function() {
+
+    it('should create new SessionRecording instance from Blob', function() {
+
+        const blob = new Blob(['4.size,1.1,1.0,1.0;']);
+        const recording = new Guacamole.SessionRecording(blob);
+        expect(recording).not.toBeNull();
+
+    });
+
+});


### PR DESCRIPTION
When creating a new SessionRecording from a blob an error is thrown in the `readNextBlock` function when reading `blob.size` since `blob` is undefined. My understanding is that this will always be the case when creating a new SessionRecording from a blob.