### PR TITLE
GUACAMOLE-1799: Add Name and Version properties to all translation files

### DIFF
--- a/guacamole/src/main/frontend/src/translations/ca.json
+++ b/guacamole/src/main/frontend/src/translations/ca.json
@@ -4,6 +4,9 @@
     
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Cancel·lar",
         "ACTION_CLONE"              : "Clon",

--- a/guacamole/src/main/frontend/src/translations/cs.json
+++ b/guacamole/src/main/frontend/src/translations/cs.json
@@ -4,6 +4,8 @@
 
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
 
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Zrušit",

--- a/guacamole/src/main/frontend/src/translations/de.json
+++ b/guacamole/src/main/frontend/src/translations/de.json
@@ -4,6 +4,9 @@
     
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Abbruch",
         "ACTION_CLONE"              : "Kopieren",

--- a/guacamole/src/main/frontend/src/translations/es.json
+++ b/guacamole/src/main/frontend/src/translations/es.json
@@ -4,6 +4,9 @@
 
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Cancelar",
         "ACTION_CLONE"              : "Clonar",

--- a/guacamole/src/main/frontend/src/translations/fr.json
+++ b/guacamole/src/main/frontend/src/translations/fr.json
@@ -4,6 +4,9 @@
 
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "Confirmer",
         "ACTION_CANCEL"             : "Annuler",
         "ACTION_CLONE"              : "Cloner",

--- a/guacamole/src/main/frontend/src/translations/it.json
+++ b/guacamole/src/main/frontend/src/translations/it.json
@@ -4,6 +4,9 @@
     
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Annulla",
         "ACTION_CLONE"              : "Clona",

--- a/guacamole/src/main/frontend/src/translations/ja.json
+++ b/guacamole/src/main/frontend/src/translations/ja.json
@@ -4,6 +4,9 @@
     
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_CANCEL"             : "キャンセル",
         "ACTION_CLONE"              : "コピー",
         "ACTION_CONTINUE"           : "次へ",

--- a/guacamole/src/main/frontend/src/translations/ko.json
+++ b/guacamole/src/main/frontend/src/translations/ko.json
@@ -4,6 +4,9 @@
 
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "확인",
         "ACTION_CANCEL"             : "취소",
         "ACTION_CLONE"              : "복제",

--- a/guacamole/src/main/frontend/src/translations/nl.json
+++ b/guacamole/src/main/frontend/src/translations/nl.json
@@ -4,6 +4,9 @@
 
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Annuleer",
         "ACTION_CLONE"              : "Kloon",

--- a/guacamole/src/main/frontend/src/translations/no.json
+++ b/guacamole/src/main/frontend/src/translations/no.json
@@ -4,6 +4,9 @@
     
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Avbryt",
         "ACTION_CLONE"              : "Klone",
@@ -37,8 +40,6 @@
         "FORMAT_DATE_TIME_PRECISE" : "ååå-mm-dd TT:mm:ss",
 
         "INFO_ACTIVE_USER_COUNT" : "Blir brukt av {USERS} {USERS, plural, one{user} other{users}}.",
-
-        "NAME" : "Guacamole ${project.version}",
 
         "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}}"
 

--- a/guacamole/src/main/frontend/src/translations/pt.json
+++ b/guacamole/src/main/frontend/src/translations/pt.json
@@ -4,6 +4,9 @@
     
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "OK",
         "ACTION_CANCEL"             : "Cancelar",
         "ACTION_CLONE"              : "Clonar",

--- a/guacamole/src/main/frontend/src/translations/ru.json
+++ b/guacamole/src/main/frontend/src/translations/ru.json
@@ -4,6 +4,9 @@
 
     "APP" : {
 
+        "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
+
         "ACTION_ACKNOWLEDGE"        : "ОК",
         "ACTION_CANCEL"             : "Отмена",
         "ACTION_CLONE"              : "Клонировать",

--- a/guacamole/src/main/frontend/src/translations/zh.json
+++ b/guacamole/src/main/frontend/src/translations/zh.json
@@ -5,6 +5,7 @@
     "APP" : {
 
         "NAME"    : "Apache Guacamole",
+        "VERSION" : "${project.version}",
 
         "ACTION_ACKNOWLEDGE"        : "确定",
         "ACTION_CANCEL"             : "取消",


### PR DESCRIPTION
Only the English and Polish translation files contain the APP.NAME and APP.VERSION properties. The values of these properties are used by the login page for example.

Currently this does not seem to be a problem because the English translation file is *somehow* always loaded before the translation file of the language that the user requested.

To not have to rely on this behavior and to prepare things for the Angular frontend I would like to include these properties in all translation files.