### PR TITLE
GUACAMOLE-1113: Restore right alt in keyboard handler.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -295,6 +295,10 @@ Guacamole.Keyboard = function Keyboard(element) {
         // Determine whether default action for Alt+combinations must be prevented
         var prevent_alt = !this.modifiers.ctrl && !quirks.altIsTypableOnly;
 
+        // If alt is typeable only, and this is actually an alt key event, treat as AltGr instead
+        if (quirks.altIsTypableOnly && (this.keysym === 0xFFE9 || this.keysym === 0xFFEA))
+            this.keysym = 0xFE03;
+
         // Determine whether default action for Ctrl+combinations must be prevented
         var prevent_ctrl = !this.modifiers.alt;
 

--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -395,7 +395,7 @@ Guacamole.Keyboard = function Keyboard(element) {
         13:  [0xFF0D], // enter
         16:  [0xFFE1, 0xFFE1, 0xFFE2], // shift
         17:  [0xFFE3, 0xFFE3, 0xFFE4], // ctrl
-        18:  [0xFFE9, 0xFFE9, 0xFE03], // alt
+        18:  [0xFFE9, 0xFFE9, 0xFFEA], // alt
         19:  [0xFF13], // pause/break
         20:  [0xFFE5], // caps lock
         27:  [0xFF1B], // escape
@@ -456,7 +456,7 @@ Guacamole.Keyboard = function Keyboard(element) {
         "Again": [0xFF66],
         "AllCandidates": [0xFF3D],
         "Alphanumeric": [0xFF30],
-        "Alt": [0xFFE9, 0xFFE9, 0xFE03],
+        "Alt": [0xFFE9, 0xFFE9, 0xFFEA],
         "Attn": [0xFD0E],
         "AltGraph": [0xFE03],
         "ArrowDown": [0xFF54],


### PR DESCRIPTION
This is essentially a revert of https://github.com/apache/guacamole-client/commit/2a30cadb1e8163e6228e03816d452eb4a5b98e06

I've verified that right alt / altgr work both correctly windows / linux, ~but there's some kind of Mac-specific issue mentioned in https://issues.apache.org/jira/browse/GUACAMOLE-1113 that I'm not sure of, so drafting for now.~