### PR TITLE
GUACAMOLE-1813: Add support for history recording storage extension to Docker

### DIFF
--- a/guacamole-docker/bin/build-guacamole.sh
+++ b/guacamole-docker/bin/build-guacamole.sh
@@ -187,3 +187,12 @@ if [ -f extensions/guacamole-auth-json/target/guacamole-auth-json*.jar ]; then
     mkdir -p "$DESTINATION/json"
     cp extensions/guacamole-auth-json/target/guacamole-auth-json*.jar "$DESTINATION/json"
 fi
+
+#
+# Copy history recording storage extension if it was built
+#
+
+if [ -f extensions/guacamole-history-recording-storage/target/guacamole-history-recording-storage*.jar ]; then
+    mkdir -p "$DESTINATION/recordings"
+    cp extensions/guacamole-history-recording-storage/target/guacamole-history-recording-storage*.jar "$DESTINATION/recordings"
+fi

--- a/guacamole-docker/bin/start.sh
+++ b/guacamole-docker/bin/start.sh
@@ -937,6 +937,19 @@ associate_json() {
     # Add required .jar files to GUACAMOLE_EXT
     ln -s /opt/guacamole/json/guacamole-auth-*.jar "$GUACAMOLE_EXT"
 }
+
+##  
+## Adds properties to guacamole.properties which configure the recording
+## storage extension.
+##  
+associate_recordings() {
+    # Update config file
+    set_property "recording-search-path" "$RECORDING_SEARCH_PATH"
+    
+    # Add required .jar files to GUACAMOLE_EXT
+    ln -s /opt/guacamole/recordings/guacamole-history-recording-storage-*.jar "$GUACAMOLE_EXT"
+}
+
 ##
 ## Sets up Tomcat's remote IP valve that allows gathering the remote IP
 ## from headers set by a remote proxy
@@ -1159,6 +1172,11 @@ fi
 if [ -n "$JSON_SECRET_KEY" ]; then
     associate_json
     INSTALLED_AUTH="$INSTALLED_AUTH json"
+fi
+
+# Add in the history recording storage extension if configured
+if [ -n "$RECORDING_SEARCH_PATH" ]; then
+    associate_recordings
 fi
 
 #


### PR DESCRIPTION
This adds support for the guacamole-history-storage-extension to the Docker container. I went ahead and based it against 1.5.3 - if anyone feels it should get pushed out to 1.6.0 that's fine - it's a bit on the fence as to whether it's actually a bugfix or not.