### PR TITLE
GUACAMOLE-1798: Add extension that supports connection templates.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/connection/ModeledConnection.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.guacamole.auth.jdbc.tunnel.GuacamoleTunnelService;

--- a/extensions/guacamole-template-ext/.gitignore
+++ b/extensions/guacamole-template-ext/.gitignore
@@ -1,0 +1,3 @@
+src/main/resources/generated/
+target/
+*~

--- a/extensions/guacamole-template-ext/pom.xml
+++ b/extensions/guacamole-template-ext/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                        http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.guacamole</groupId>
+    <artifactId>guacamole-template-ext</artifactId>
+    <packaging>jar</packaging>
+    <version>1.5.2</version>
+    <name>guacamole-template-ext</name>
+    <url>http://guacamole.apache.org/</url>
+
+    <parent>
+        <groupId>org.apache.guacamole</groupId>
+        <artifactId>extensions</artifactId>
+        <version>1.5.2</version>
+        <relativePath>../</relativePath>
+    </parent>
+    
+    <build>
+        <plugins>
+
+            <!-- Pre-cache Angular templates with maven-angular-plugin -->
+            <plugin>
+                <groupId>com.keithbranton.mojo</groupId>
+                <artifactId>angular-maven-plugin</artifactId>
+                <version>0.3.4</version>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>html2js</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDir>${basedir}/src/main/resources</sourceDir>
+                    <include>**/*.html</include>
+                    <target>${basedir}/src/main/resources/generated/templates-main/templates.js</target>
+                    <prefix>app/ext/template-ext</prefix>
+                </configuration>
+            </plugin>
+
+            <!-- JS/CSS Minification Plugin -->
+            <plugin>
+                <groupId>com.github.buckelieg</groupId>
+                <artifactId>minify-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <charset>UTF-8</charset>
+
+                            <webappSourceDir>${basedir}/src/main/resources</webappSourceDir>
+                            <webappTargetDir>${project.build.directory}/classes</webappTargetDir>
+
+                            <cssSourceDir>/</cssSourceDir>
+                            <cssTargetDir>/</cssTargetDir>
+                            <cssFinalFile>templateExt.css</cssFinalFile>
+
+                            <cssSourceFiles>
+                                <cssSourceFile>license.txt</cssSourceFile>
+                            </cssSourceFiles>
+
+                            <cssSourceIncludes>
+                                <cssSourceInclude>**/*.css</cssSourceInclude>
+                            </cssSourceIncludes>
+
+                            <jsSourceDir>/</jsSourceDir>
+                            <jsTargetDir>/</jsTargetDir>
+                            <jsFinalFile>templateExt.js</jsFinalFile>
+
+                            <jsSourceFiles>
+                                <jsSourceFile>license.txt</jsSourceFile>
+                            </jsSourceFiles>
+
+                            <jsSourceIncludes>
+                                <jsSourceInclude>**/*.js</jsSourceInclude>
+                            </jsSourceIncludes>
+
+                            <!-- Do not minify and include tests -->
+                            <jsSourceExcludes>
+                                <jsSourceExclude>**/*.test.js</jsSourceExclude>
+                            </jsSourceExcludes>
+                            <jsEngine>CLOSURE</jsEngine>
+
+                            <!-- Disable warnings for JSDoc annotations -->
+                            <closureWarningLevels>
+                                <misplacedTypeAnnotation>OFF</misplacedTypeAnnotation>
+                                <nonStandardJsDocs>OFF</nonStandardJsDocs>
+                            </closureWarningLevels>
+
+                        </configuration>
+                        <goals>
+                            <goal>minify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+
+       <!-- Guacamole Extension API -->
+        <dependency>
+            <groupId>org.apache.guacamole</groupId>
+            <artifactId>guacamole-ext</artifactId>
+            <version>1.5.2</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <!-- Guice -->
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <!-- Guava - Utility Library -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/extensions/guacamole-template-ext/src/main/assembly/dist.xml
+++ b/extensions/guacamole-template-ext/src/main/assembly/dist.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+
+    <id>dist</id>
+    <baseDirectory>${project.artifactId}-${project.version}</baseDirectory>
+
+    <!-- Output tar.gz -->
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+
+    <!-- Include licenses and extension .jar -->
+    <fileSets>
+
+        <!-- Include licenses -->
+        <fileSet>
+            <outputDirectory></outputDirectory>
+            <directory>target/licenses</directory>
+        </fileSet>
+
+        <!-- Include extension .jar -->
+        <fileSet>
+            <directory>target</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+
+    </fileSets>
+
+</assembly>

--- a/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/TemplateAuthenticationProvider.java
+++ b/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/TemplateAuthenticationProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.templates;
+
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.net.auth.AbstractAuthenticationProvider;
+import org.apache.guacamole.net.auth.AuthenticatedUser;
+import org.apache.guacamole.net.auth.Credentials;
+import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.templates.user.TemplateUserContext;
+
+/**
+ * An implementation of an Authentication Provider which allows users to
+ * associate a connection with another connection as a template, pulling
+ * the values of parameters specified in the selected "template connection"
+ * into the connection.
+ */
+public class TemplateAuthenticationProvider extends AbstractAuthenticationProvider {
+    
+    @Override
+    public String getIdentifier() {
+        return "template-ext";
+    }
+    
+    @Override
+    public UserContext decorate(UserContext context, AuthenticatedUser authenticatedUser, Credentials credentials) throws GuacamoleException {
+        if (context instanceof TemplateUserContext)
+            return context;
+        
+        return new TemplateUserContext(context);
+    }
+    
+}

--- a/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/connection/TemplatedConnection.java
+++ b/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/connection/TemplatedConnection.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.templates.connection;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.form.Form;
+import org.apache.guacamole.net.auth.Connection;
+import org.apache.guacamole.net.auth.DelegatingConnection;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.protocol.GuacamoleConfiguration;
+import org.apache.guacamole.templates.form.ConnectionChooserField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Connection implementation which wraps another Connection object, but also
+ * adds the functionality to link the Connection to another object as a
+ * "template" connection, inheriting parameters and attributes from the
+ * template.
+ */
+public class TemplatedConnection extends DelegatingConnection {
+    
+    /**
+     * The Logger for this class.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(TemplatedConnection.class);
+    
+    /**
+     * The attribute name that provides the connection identifier which should
+     * e the template for this connection, and the parameters and attributes
+     * of which this connection will inherit.
+     */
+    public static final String TEMPLATE_ID_ATTRIBUTE_NAME = "template-connection-id";
+    
+    /**
+     * An array of all of the attributes implemented specifically by this
+     * connection type.
+     */
+    public static final List<String> TEMPLATED_CONNECTION_ATTRIBUTES = Arrays.asList(TEMPLATE_ID_ATTRIBUTE_NAME);
+    
+    /**
+     * The form that provides all of the fields that need to be visible for this
+     * connection implementation in order to provide the template functionality.
+     */
+    public static final Form TEMPLATED_CONNECTION_FORM = new Form(
+                "templated-connection-form",
+                Arrays.asList(new ConnectionChooserField(TEMPLATE_ID_ATTRIBUTE_NAME))
+            );
+    
+    /**
+     * The directory in which this connection exists.
+     */
+    private final Directory<Connection> connectionDirectory;
+    
+    
+    /**
+     * Create a new TemplatedConnection, wrapping the given Connection object
+     * and delegating functionality to that underlying object, after providing
+     * the template capability.
+     * 
+     * @param connection 
+     *     The original connection to wrap.
+     * 
+     * @param directory
+     *     The Connection Directory in which this connection exists, provided
+     *     for the purpose of retrieving the template connection.
+     */
+    public TemplatedConnection(Connection connection, Directory<Connection> directory) {
+        super(connection);
+        this.connectionDirectory = directory;
+    }
+    
+    /**
+     * Retrieve the original connection that this object wraps.
+     * 
+     * @return 
+     *     The original connection that this object wraps.
+     */
+    public Connection getWrappedConnection() {
+        return getDelegateConnection();
+    }
+    
+    @Override
+    public Map<String, String> getAttributes() {
+        
+        // Make a mutable copy of the connection attributes
+        Map<String, String> attributes = new HashMap<>(super.getAttributes());
+        
+        // Loop through and add the ones that aren't present so that they are
+        // available on the web page.
+        for (String attribute : TEMPLATED_CONNECTION_ATTRIBUTES) { 
+            String value = attributes.get(attribute);
+            if (value == null || value.isEmpty())
+                attributes.put(attribute, null);
+        }
+        
+        // Return the new Map of attributes.
+        return attributes;
+    }
+    
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+    
+        // Make a mutable copy of connection attributes
+        attributes = new HashMap<>(attributes);
+        
+        // Loop through extension-specific attributes, only sending ones
+        // that are non-null and non-empty to the underlying storage mechanism.
+        for (String attribute : TEMPLATED_CONNECTION_ATTRIBUTES) {
+            String value = attributes.get(attribute);
+            if (value != null && value.isEmpty())
+                attributes.put(attribute, null);
+        }
+
+        // Set the complete attributes
+        super.setAttributes(attributes);
+        
+    }
+    
+    @Override
+    public GuacamoleConfiguration getConfiguration() {
+        
+        // Retrieve the decorated connection's configuration.
+        GuacamoleConfiguration config = super.getConfiguration();
+        
+        // Get the template connection identifier - if its empty, just return this config.
+        String templateId = getTemplateConnectionId();
+        if (templateId == null || templateId.isEmpty())
+            return config;
+        
+        try {
+            // Get the template connection from its identifier.
+            Connection templateConnection = connectionDirectory.get(templateId);
+            
+            // Get the template connection configuration.
+            GuacamoleConfiguration mergedConfig = new GuacamoleConfiguration(templateConnection.getConfiguration());
+            
+            // Loop through values, overriding the template values as required.
+            for (String parameter: config.getParameterNames()) {
+                String value = config.getParameter(parameter);
+                if (value != null && !value.isEmpty()) {
+                    mergedConfig.setParameter(parameter, value);
+                }
+            }
+            
+            // Return the merged configuration
+            return mergedConfig;
+            
+        } catch (GuacamoleException e) {
+            LOGGER.warn("Could not retrieve template connection: {}", templateId);
+            LOGGER.debug("Exception retrieving template connection.", e);
+            return null;
+        }
+        
+    }
+    
+    /**
+     * Return the identifier of the connection that has been set as this
+     * connections template.
+     * 
+     * @return 
+     *     The identifier of the template connection as set in the
+     *     connection attributes.
+     */
+    private String getTemplateConnectionId() {
+        
+        Map<String, String> attributes = getAttributes();
+        String templateId = attributes.get(TEMPLATE_ID_ATTRIBUTE_NAME);
+        if (templateId != null && !templateId.isEmpty())
+            return templateId;
+        return null;
+        
+    }
+    
+    
+    
+}

--- a/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/form/ConnectionChooserField.java
+++ b/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/form/ConnectionChooserField.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.templates.form;
+
+import org.apache.guacamole.form.Field;
+
+/**
+ * A field that allows users to choose from possible existing connections to
+ * which they have access.
+ */
+public class ConnectionChooserField extends Field {
+    
+    /**
+     * The field type, used to load the correct field within the AngularJS
+     * application.
+     */
+    public static String FIELD_TYPE = "GUAC_CONNECTION_CHOOSER";
+    
+    /**
+     * Create a new ConnectionChooserField with the specified name.
+     * 
+     * @param name 
+     *     The name of the field.
+     */
+    public ConnectionChooserField(String name) {
+        super(name, FIELD_TYPE);
+    }
+    
+}

--- a/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/user/TemplateUserContext.java
+++ b/extensions/guacamole-template-ext/src/main/java/org/apache/guacamole/templates/user/TemplateUserContext.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.templates.user;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.form.Form;
+import org.apache.guacamole.net.auth.Connection;
+import org.apache.guacamole.net.auth.DecoratingDirectory;
+import org.apache.guacamole.net.auth.DelegatingUserContext;
+import org.apache.guacamole.net.auth.Directory;
+import org.apache.guacamole.net.auth.UserContext;
+import org.apache.guacamole.templates.connection.TemplatedConnection;
+
+/**
+ * A UserContext which decorates another context, adding the capability for
+ * connections within this context to be linked to other connections in order
+ * to inherit settings from those connections.
+ */
+public class TemplateUserContext extends DelegatingUserContext {
+    
+    /**
+     * Create a new instances of the TemplateUserContext, wrapping the given
+     * UserContext and delegating functionality to that context.
+     * 
+     * @param context 
+     *     The UserContext to wrap.
+     */
+    public TemplateUserContext(UserContext context) {
+        super(context);
+    }
+    
+    @Override
+    public Directory<Connection> getConnectionDirectory() throws GuacamoleException {
+        return new DecoratingDirectory<Connection>(super.getConnectionDirectory()) {
+            
+            @Override
+            protected Connection decorate(Connection object) {
+                if (object instanceof TemplatedConnection)
+                    return object;
+                return new TemplatedConnection(object, this);
+            }
+            
+            @Override
+            protected Connection undecorate(Connection object) {
+                if (object instanceof TemplatedConnection)
+                    return ((TemplatedConnection) object).getWrappedConnection();
+                return object;
+            }
+            
+        };
+    }
+    
+    @Override
+    public Collection<Form> getConnectionAttributes() {
+        Collection<Form> connectionAttrs = new HashSet<>(super.getConnectionAttributes());
+        connectionAttrs.add(TemplatedConnection.TEMPLATED_CONNECTION_FORM);
+        return Collections.unmodifiableCollection(connectionAttrs);
+    }
+    
+}

--- a/extensions/guacamole-template-ext/src/main/resources/config/templateConfig.js
+++ b/extensions/guacamole-template-ext/src/main/resources/config/templateConfig.js
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Config block which registers restrict-specific field types.
+ */
+angular.module('templateExt').config(['formServiceProvider',
+        function templateExtConfig(formServiceProvider) {
+
+    // Define the time restriction field
+    formServiceProvider.registerFieldType('GUAC_CONNECTION_CHOOSER', {
+        module      : 'templateExt',
+        controller  : 'connectionChooserController',
+        templateUrl : 'app/ext/template-ext/templates/templateChooser.html'
+    });
+
+}]);

--- a/extensions/guacamole-template-ext/src/main/resources/controllers/connectionChooserController.js
+++ b/extensions/guacamole-template-ext/src/main/resources/controllers/connectionChooserController.js
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * A controller for choosing a connection from a list of available connections.
+ */
+angular.module('templateExt').controller('connectionChooserController',
+        ['$scope', '$injector', function connectionChooserController($scope, $injector) {
+
+    // Required types
+    var ConnectionGroup          = $injector.get('ConnectionGroup');
+
+    // Required services
+    var $log                     = $injector.get('$log');
+    var $routeParams             = $injector.get('$routeParams');
+    var connectionGroupService   = $injector.get('connectionGroupService');
+
+    /**
+     * Map of unique identifiers to their corresponding connection
+     * groups.
+     *
+     * @type Object.<String, GroupListItem>
+     */
+    var connectionGroups = {};
+    
+    /**
+     * Map of unique identifiers to their correspnoding connections.
+     * 
+     * @type Object.<String, GroupListItem>
+     */
+    var connections = {};
+    
+    /**
+     * The identifier of the connection being edited. If a new
+     * connection is being created, this will not be defined.
+     *
+     * @type String
+     */
+    var identifier = $routeParams.id;
+    
+    /**
+     * The current data source that is being used to edit the connection,
+     * from which other available connections will be retrieved to use
+     * as possible template values.
+     * 
+     * @type String
+     */
+    var dataSource = $routeParams.dataSource;
+
+    /**
+     * Recursively traverses the given connection group and all
+     * children, storing each encountered connection group within the
+     * connectionGroups map by its identifier.
+     *
+     * @param {GroupListItem} group
+     *     The connection group to traverse.
+     */
+    var mapConnectionsAndGroups = function mapConnectionsAndGroups(group) {
+        
+        // Map given group
+        connectionGroups[group.identifier] = group;
+
+        if (group.childConnections)
+            group.childConnections.forEach(connection => {
+                // Skip this connection
+                if (connection.identifier === identifier)
+                    return;
+                connections[connection.identifier] = connection;
+            });
+
+        // Map all child groups
+        if (group.childConnectionGroups)
+            group.childConnectionGroups.forEach(mapConnectionsAndGroups);
+        
+
+    };
+
+    /**
+     * Whether the connection list menu is currently open.
+     * 
+     * @type Boolean
+     */
+    $scope.menuOpen = false;
+
+    /**
+     * The human-readable name of the currently-chosen connection.
+     * 
+     * @type String
+     */
+    $scope.chosenConnectionName = null;
+    
+    /**
+     * The rootGroup for the currently-selected data source.
+     * 
+     * @type ConnectionGroup
+     */
+    $scope.rootGroups = {};
+    
+    /**
+     * Retrive the root connection group for this data source and save it.
+     */
+    connectionGroupService.getConnectionGroupTree($routeParams.dataSource, ConnectionGroup.ROOT_IDENTIFIER)
+            .then(function connectionGroupDataRetrieved(rootGroup) {
+        
+        connections = {}
+        connectionGroups = {};
+        
+        // Map all known groups
+        mapConnectionsAndGroups(rootGroup);
+        
+        // Wrap root group in map
+        $scope.rootGroups = {};
+        $scope.rootGroups[dataSource] = rootGroup;
+        
+        // Find the currently-selected connection.
+        if ($scope.model && $scope.model in connections)
+            $scope.chosenConnectionName = connections[$scope.model].name;
+        else
+            $scope.chosenConnectionName = '--No Template Chosen--';
+
+    });
+
+    /**
+     * Toggle the current state of the menu listing connections.
+     * If the menu is currently open, it will be closed. If currently
+     * closed, it will be opened.
+     */
+    $scope.toggleMenu = function toggleMenu() {
+        $scope.menuOpen = !$scope.menuOpen;
+    };
+
+    // Expose selection function to connection list template
+    $scope.connectionListContext = {
+
+        /**
+         * Selects the given connection item.
+         *
+         * @param {ConnectionListItem} item
+         *     The chosen item.
+         */
+        chooseConnection : function chooseConnection(item) {
+
+            // Connection cannot set itself as the template
+            if (identifier && identifier === item.identifier)
+                return false;
+
+            // Record new parent
+            $scope.model = item.identifier;
+            $scope.chosenConnectionName = item.name;
+
+            // Close menu
+            $scope.menuOpen = false;
+
+        }
+
+    };
+    
+}]);

--- a/extensions/guacamole-template-ext/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-template-ext/src/main/resources/guac-manifest.json
@@ -1,0 +1,30 @@
+{
+
+    "guacamoleVersion" : "1.5.2",
+
+    "name"      : "Connection Template Extension",
+    "namespace" : "template-ext",
+
+    "authProviders" : [
+        "org.apache.guacamole.templates.TemplateAuthenticationProvider"
+    ],
+
+    "translations" : [
+        "translations/en.json"
+    ],
+
+    "js" : [
+        "templateExt.min.js"
+    ],
+
+    "css" : [
+        "templateExt.min.css"
+    ],
+
+    "resources" : {
+        "templates/templateChooser.html" : "text/html",
+        "templates/templateChooserConnection.html" : "text/html",
+        "templates/tempalteChooserConnectionGroup.html" : "text/html"
+    }
+
+}

--- a/extensions/guacamole-template-ext/src/main/resources/license.txt
+++ b/extensions/guacamole-template-ext/src/main/resources/license.txt
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */

--- a/extensions/guacamole-template-ext/src/main/resources/styles/templateChooser.css
+++ b/extensions/guacamole-template-ext/src/main/resources/styles/templateChooser.css
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.template-chooser .dropdown {
+
+    position: absolute;
+    z-index: 2;
+    margin-top: -1px;
+
+    width: 3in;
+    max-height: 2in;
+    overflow: auto;
+
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    background: white;
+
+    font-size: 10pt;
+
+}

--- a/extensions/guacamole-template-ext/src/main/resources/templateExt.js
+++ b/extensions/guacamole-template-ext/src/main/resources/templateExt.js
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Module which provides handling for setting one connection as a template
+ * for another.
+ */
+angular.module('templateExt', [
+    'form'
+]);
+
+// Ensure the templateExt module is loaded along with the rest of the app
+angular.module('index').requires.push('templateExt');

--- a/extensions/guacamole-template-ext/src/main/resources/templates/templateChooser.html
+++ b/extensions/guacamole-template-ext/src/main/resources/templates/templateChooser.html
@@ -1,0 +1,17 @@
+<div class="template-chooser">
+
+    <!-- Chosen group name -->
+    <div ng-click="toggleMenu()" class="location">{{chosenConnectionName}}</div>
+
+    <!-- Dropdown hierarchical menu of groups -->
+    <div ng-show="menuOpen" class="dropdown">
+        <guac-group-list
+            context="connectionListContext"
+            connection-groups="rootGroups"
+            templates="{
+                'connection-group' : 'app/ext/template-ext/templates/templateChooserConnectionGroup.html',
+                'connection' : 'app/ext/template-ext/templates/templateChooserConnection.html'
+            }"></guac-group-list>
+    </div>
+
+</div>

--- a/extensions/guacamole-template-ext/src/main/resources/templates/templateChooserConnection.html
+++ b/extensions/guacamole-template-ext/src/main/resources/templates/templateChooserConnection.html
@@ -1,0 +1,4 @@
+<span class="template-chooser-connection name"
+      ng-click="context.chooseConnection(item.wrappedItem)">
+    {{item.name}}
+</span>

--- a/extensions/guacamole-template-ext/src/main/resources/templates/templateChooserConnectionGroup.html
+++ b/extensions/guacamole-template-ext/src/main/resources/templates/templateChooserConnectionGroup.html
@@ -1,0 +1,3 @@
+<span class="template-chooser-connection-group name">
+    {{item.name}}
+</span>

--- a/extensions/guacamole-template-ext/src/main/resources/translations/en.json
+++ b/extensions/guacamole-template-ext/src/main/resources/translations/en.json
@@ -1,0 +1,15 @@
+{
+
+    "DATA_SOURCE_TEMPLATE_EXT" : {
+        "NAME" : "Connection Template Extension"
+    },
+
+    "CONNECTION_ATTRIBUTES" : {
+        
+        "FIELD_HEADER_TEMPLATE_CONNECTION_ID" : "Template Connection: ",
+        
+        "SECTION_HEADER_TEMPLATED_CONNECTION_FORM" : "Connection Template"
+        
+    }
+
+}

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -52,6 +52,7 @@
 
         <!-- Additional features -->
         <module>guacamole-history-recording-storage</module>
+        <module>guacamole-template-ext</module>
         <module>guacamole-vault</module>
 
         <!-- Utility extensions -->


### PR DESCRIPTION
I've taken (another) run at this, this time using a decorating extension. Before I spend a bunch of time fixing up the myriad issues with this approach, I figured I'd solicit feedback on whether this is even a desirable approach, or if I should pursue some other route...or if it's something worth doing at all.

At present, it _should_:
* Present a selection box that lists the other connections the current user has access to, allowing you to select one of them as a "template".
* Merge the connection parameters from the selected "template" connection, overriding those with any set locally in that configuration, before connecting.
* Prevents you from selecting the connection you're editing as the template.

Among the several issues that need to be resolved, assuming this is a sane/desirable approach:
* Connections are not filtered by protocol, so you could "template" a SSH connection with a RDP connection, for example. Probably not ideal.
* Connection Attributes are not merged, only the `GuacamoleConfiguration` (parameters).
* Style/UX: Selection box isn't a constant size
* Style/UX: Selection box shows the paging at the bottom, rather than being a scrolling list.
* Style/UX: No indication on the page you're editing of parameter values from the template (not sure this is solvable with this particular method).

All that said, I'm putting it in draft mode, for now - I appreciate any thoughts/comments/guidance.