### PR TITLE
GUACAMOLE-1823: Fix capslock on macos chrome

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -355,6 +355,14 @@ Guacamole.Keyboard = function Keyboard(element) {
         // We extend KeyEvent
         KeyEvent.call(this, orig);
 
+        // If unreliable caps lock was pressed and event was not marked, then
+        // we need to pretend that this is a keydown event because we obviously
+        // did not receive it (issue on macos with chrome)
+        if (this.keyCode == 20 && quirks.capsLockKeyupUnreliable) {
+          eventLog.push(new KeydownEvent(this));
+          return;
+        }
+
         // If key is known from keyCode or DOM3 alone, use that (keyCode is
         // still more reliable for keyup when dead keys are in use)
         this.keysym =  keysym_from_keycode(this.keyCode, this.location)

--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -109,12 +109,12 @@ Guacamole.Keyboard = function Keyboard(element) {
         altIsTypableOnly: false,
 
         /**
-         * Whether we can rely on receiving a keyup event for the Caps Lock
-         * key.
+         * Whether we can rely on receiving a keyup or keydown event for the
+         * Caps Lock key.
          *
          * @type {!boolean}
          */
-        capsLockKeyupUnreliable: false
+        capsLockKeyEventUnreliable: false
 
     };
 
@@ -127,10 +127,11 @@ Guacamole.Keyboard = function Keyboard(element) {
             quirks.keyupUnreliable = true;
 
         // The Alt key on Mac is never used for keyboard shortcuts, and the
-        // Caps Lock key never dispatches keyup events
+        // Caps Lock key never dispatches keyup events in firefox, and it
+        // dispatches either keydown or keyup events in chrome, but never both
         else if (navigator.platform.match(/^mac/i)) {
             quirks.altIsTypableOnly = true;
-            quirks.capsLockKeyupUnreliable = true;
+            quirks.capsLockKeyEventUnreliable = true;
         }
 
     }
@@ -289,7 +290,7 @@ Guacamole.Keyboard = function Keyboard(element) {
             this.keyupReliable = false;
 
         // We cannot rely on receiving keyup for Caps Lock on certain platforms
-        else if (this.keysym === 0xFFE5 && quirks.capsLockKeyupUnreliable)
+        else if (this.keysym === 0xFFE5 && quirks.capsLockKeyEventUnreliable)
             this.keyupReliable = false;
 
         // Determine whether default action for Alt+combinations must be prevented
@@ -358,7 +359,7 @@ Guacamole.Keyboard = function Keyboard(element) {
         // If unreliable caps lock was pressed and event was not marked, then
         // we need to pretend that this is a keydown event because we obviously
         // did not receive it (issue on macos with chrome)
-        if (this.keyCode == 20 && quirks.capsLockKeyupUnreliable) {
+        if (this.keyCode == 20 && quirks.capsLockKeyEventUnreliable) {
           eventLog.push(new KeydownEvent(this));
           return;
         }


### PR DESCRIPTION
Chrome on MacOS sends only a single `keydown` event when turning on caps-lock, and only a single `keyup` event when turning off caps-lock.

Firefox on MacOS sends always only a single `keydown` that is properly handled in quirks as `capsLockKeyupUnreliable`.

# Steps to reproduce:

In my tests I always clicked CapsLock twice, while initial state was not activated. So I activated and deactivated caps lock in Firefox and Chrome on MacOS while watching how [guacamole keybaord behaves](https://guacamole.apache.org/pub/tests/guac/keyboard-test.html) and also what [events](https://dvcs.w3.org/hg/d4e/raw-file/tip/key-event-test.html) are actually fired:

## Firefox MacOS:

![image](https://github.com/apache/guacamole-client/assets/7534274/d702aada-5ea7-4dad-85a4-cc6f97470c5a)
![image](https://github.com/apache/guacamole-client/assets/7534274/ff169602-79a7-490a-8636-506ff67526e2)

## Chrome MacOS:

![image](https://github.com/apache/guacamole-client/assets/7534274/3fab3c74-9eb6-43bb-822d-bcd609e98fe2)
![image](https://github.com/apache/guacamole-client/assets/7534274/a386a6ba-0094-4b8e-93d7-e5817f60e147)

# Solution
When quirk `capsLockKeyupUnreliable` is active, we are never handling any keyup event because we don't expect it to happen. I extended the code to handle a case, when we only get a single `keyup` event, and we convert it to `keydown` event. This evenutally changes meaning of `capsLockKeyupUnreliable` to `capsLockKeyUnreliable` (because its either `up` or `down`).