### PR TITLE
GUACAMOLE-1838: Downgrade SQL Server JDBC driver to latest 9.4.x.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y firefox
 ARG MAVEN_ARGUMENTS="-DskipTests=false"
 
 # Versions of JDBC drivers to bundle within image
-ARG MSSQL_JDBC_VERSION=12.2.0
+ARG MSSQL_JDBC_VERSION=9.4.1
 ARG MYSQL_JDBC_VERSION=8.0.33
 ARG PGSQL_JDBC_VERSION=42.6.0
 


### PR DESCRIPTION
The 12.2.0 version breaks compatibility in terms of SSL/TLS behavior, causing database connection failures that did not previously occur.