### PR TITLE
GUACAMOLE-1849: Fix a bug in Parser.js where receive would reparse instructions multiple times.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Parser.js
+++ b/guacamole-common-js/src/main/webapp/modules/Parser.js
@@ -208,7 +208,7 @@ Guacamole.Parser = function Parser() {
                     // Immediately truncate buffer if its contents have been
                     // completely parsed, so that the next call to receive()
                     // need not append to the buffer unnecessarily
-                    if (elementEnd + 1 === buffer.length) {
+                    if (!isBuffer && elementEnd + 1 === buffer.length) {
                         elementEnd = -1;
                         buffer = '';
                     }


### PR DESCRIPTION
This fixes instruction buffers from xhr-based tunnels being processed multiple times in some cases due to the `startIndex` getting reset in the parser.