### PR TITLE
GUACAMOLE-1851: Add Inject notation to RequestValidationService constructor to fix Guice loading.

### DIFF
--- a/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/RequestValidationService.java
+++ b/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/RequestValidationService.java
@@ -42,16 +42,18 @@ public class RequestValidationService {
      * Service for retrieving configuration information regarding the
      * JSONAuthenticationProvider.
      */
-    @Inject
     private ConfigurationService confService;
 
     /**
-     * Constructor that enables passing of an instance of
-     * ConfigurationService. (Only used for unit testing)
+     * Create a new instance of the request validation service, with the
+     * provided ConfigurationService object used to retrieve configuration
+     * properties for this extension.
      *
      * @param confService
-     *     The (mock) instance of ConfigurationService
+     *     The instance of ConfigurationService for retrieving configuration
+     *     properties for this extension.
      */
+    @Inject
     public RequestValidationService(ConfigurationService confService) {
         this.confService = confService;
     }


### PR DESCRIPTION
Adds the `@Inject` notation to the constructor in `RequestValidationService` class so that it loads correctly with Guice, correcting an issue introduced by the addition of the parameterized construction from GUACAMOLE-1809.