### PR TITLE
GUACAMOLE-1855: Allow MFA modules to be configured to bypass or enforce for specific hosts.

### DIFF
--- a/extensions/guacamole-auth-duo/pom.xml
+++ b/extensions/guacamole-auth-duo/pom.xml
@@ -130,6 +130,14 @@
             <version>${kotlin.version}</version>
         </dependency>
 
+        <!-- Library for unified IPv4/6 parsing and validation -->
+        <dependency>
+            <groupId>com.github.seancfoley</groupId>
+            <artifactId>ipaddress</artifactId>
+            <version>5.5.0</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-duo/src/main/java/org/apache/guacamole/auth/duo/conf/ConfigurationService.java
@@ -20,10 +20,14 @@
 package org.apache.guacamole.auth.duo.conf;
 
 import com.google.inject.Inject;
+import inet.ipaddr.IPAddress;
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
+import org.apache.guacamole.properties.IPAddressListProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
 import org.apache.guacamole.properties.URIGuacamoleProperty;
 
@@ -103,6 +107,40 @@ public class ConfigurationService {
                 
         @Override
         public String getName() { return "duo-auth-timeout"; }
+                
+    };
+    
+    /**
+     * The optional property that contains a comma-separated list of IP addresses
+     * or CIDRs for which the MFA requirement should be bypassed. If the Duo
+     * extension is installed, any/all users authenticating from clients that
+     * match this list will be able to successfully log in without fulfilling
+     * the MFA requirement. If this option is omitted or is empty, and the
+     * Duo module is installed, all users from all hosts will have Duo MFA
+     * enforced.
+     */
+    private static final IPAddressListProperty DUO_BYPASS_HOSTS =
+            new IPAddressListProperty() {
+    
+        @Override
+        public String getName() { return "duo-bypass-hosts"; }
+                
+    };
+        
+    /**
+     * The optional property that contains a comma-separated list of IP addresses
+     * or CIDRs for which the MFA requirement should be explicitly enforced. If
+     * the Duo module is enabled and this property is specified, users that log
+     * in from hosts that match the items in this list will have Duo MFA required,
+     * and all users from hosts that do not match this list will be able to log
+     * in without the MFA requirement. If this option is missing or empty and
+     * the Duo module is installed, MFA will be enforced for all users.
+     */
+    private static final IPAddressListProperty DUO_ENFORCE_HOSTS =
+            new IPAddressListProperty() {
+    
+        @Override
+        public String getName() { return "duo-enforce-hosts"; }
                 
     };
 
@@ -188,5 +226,43 @@ public class ConfigurationService {
     public int getAuthenticationTimeout() throws GuacamoleException {
         return environment.getProperty(DUO_AUTH_TIMEOUT, 5);
     }
+    
+    /**
+     * Returns the list of IP addresses and subnets defined in guacamole.properties
+     * for which Duo MFA should _not_ be enforced. Users logging in from hosts
+     * contained in this list will be logged in without the MFA requirement.
+     * 
+     * @return
+     *     A list of IP addresses and subnets for which Duo MFA should not be
+     *     enforced.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed, or if an invalid IP address
+     *     or subnet is specified.
+     */
+    public List<IPAddress> getBypassHosts() throws GuacamoleException {
+        return environment.getProperty(DUO_BYPASS_HOSTS, Collections.emptyList());
+    }
+    
+    /**
+     * Returns the list of IP addresses and subnets defined in guacamole.properties
+     * for which Duo MFA should explicitly be enforced, while logins from all
+     * other hosts should not enforce MFA. Users logging in from hosts
+     * contained in this list will be required to complete the Duo MFA authentication,
+     * while users from all other hosts will be logged in without the MFA requirement.
+     * 
+     * @return
+     *     A list of IP addresses and subnets for which Duo MFA should be
+     *     explicitly enforced.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed, or if an invalid IP address
+     *     or subnet is specified.
+     */
+    public List<IPAddress> getEnforceHosts() throws GuacamoleException {
+        return environment.getProperty(DUO_ENFORCE_HOSTS, Collections.emptyList());
+    }
+    
+    
 
 }

--- a/extensions/guacamole-auth-json/pom.xml
+++ b/extensions/guacamole-auth-json/pom.xml
@@ -78,6 +78,7 @@
             <groupId>com.github.seancfoley</groupId>
             <artifactId>ipaddress</artifactId>
             <version>5.5.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- JUnit -->

--- a/extensions/guacamole-auth-totp/pom.xml
+++ b/extensions/guacamole-auth-totp/pom.xml
@@ -177,6 +177,14 @@
             <version>2.1.1</version>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- Library for unified IPv4/6 parsing and validation -->
+        <dependency>
+            <groupId>com.github.seancfoley</groupId>
+            <artifactId>ipaddress</artifactId>
+            <version>5.5.0</version>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/conf/ConfigurationService.java
@@ -20,10 +20,14 @@
 package org.apache.guacamole.auth.totp.conf;
 
 import com.google.inject.Inject;
+import inet.ipaddr.IPAddress;
+import java.util.Collections;
+import java.util.List;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.properties.EnumGuacamoleProperty;
+import org.apache.guacamole.properties.IPAddressListProperty;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
 import org.apache.guacamole.totp.TOTPGenerator;
@@ -87,6 +91,36 @@ public class ConfigurationService {
         @Override
         public String getName() { return "totp-mode"; }
 
+    };
+    
+    /**
+     * A property that contains a list of IP addresses and/or subnets for which
+     * MFA via the TOTP module should be bypassed. Users logging in from addresses
+     * contained in this list will not be prompted for a second authentication
+     * factor. If this property is empty or not defined, and the TOTP module
+     * is installed, all users will be prompted for MFA.
+     */
+    private static final IPAddressListProperty TOTP_BYPASS_HOSTS =
+            new IPAddressListProperty() {
+                
+        @Override
+        public String getName() { return "totp-bypass-hosts"; }
+                
+    };
+    
+    /**
+     * A property that contains a list of IP addresses and/or subnets for which
+     * MFA via the TOTP module should explicitly be enabled. If this property is defined,
+     * and the TOTP module is installed, users logging in from hosts contained
+     * in this list will be prompted for MFA, and users logging in from all
+     * other hosts will not be prompted for MFA.
+     */
+    private static final IPAddressListProperty TOTP_ENFORCE_HOSTS =
+            new IPAddressListProperty() {
+    
+        @Override
+        public String getName() { return "totp-enforce-hosts"; }
+                
     };
 
     /**
@@ -157,6 +191,40 @@ public class ConfigurationService {
      */
     public TOTPGenerator.Mode getMode() throws GuacamoleException {
         return environment.getProperty(TOTP_MODE, TOTPGenerator.Mode.SHA1);
+    }
+    
+    /**
+     * Return the list of IP addresses and/or subnets for which MFA authentication via the
+     * TOTP module should be bypassed, allowing users from those addresses to log in
+     * without the MFA requirement.
+     * 
+     * @return
+     *     A list of IP addresses and/or subnets for which MFA authentication
+     *     should be bypassed.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed, or an invalid IP address
+     *     or subnet is specified.
+     */
+    public List<IPAddress> getBypassHosts() throws GuacamoleException {
+        return environment.getProperty(TOTP_BYPASS_HOSTS, Collections.emptyList());
+    }
+    
+    /**
+     * Return the list of IP addresses and/or subnets for which MFA authentication via the TOTP
+     * module should be explicitly enabled, requiring users logging in from hosts specified in
+     * the list to complete MFA.
+     * 
+     * @return
+     *     A list of IP addresses and/or subnets for which MFA authentication
+     *     should be explicitly enabled.
+     * 
+     * @throws GuacamoleException 
+     *     If guacamole.properties cannot be parsed, or an invalid IP address
+     *     or subnet is specified.
+     */
+    public List<IPAddress> getEnforceHosts() throws GuacamoleException {
+        return environment.getProperty(TOTP_ENFORCE_HOSTS, Collections.emptyList());
     }
 
 }

--- a/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/UserVerificationService.java
+++ b/extensions/guacamole-auth-totp/src/main/java/org/apache/guacamole/auth/totp/user/UserVerificationService.java
@@ -22,9 +22,12 @@ package org.apache.guacamole.auth.totp.user;
 import com.google.common.io.BaseEncoding;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 import java.security.InvalidKeyException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
@@ -311,6 +314,65 @@ public class UserVerificationService {
     public void verifyIdentity(UserContext context,
             AuthenticatedUser authenticatedUser) throws GuacamoleException {
 
+        // Pull the original HTTP request used to authenticate
+        Credentials credentials = authenticatedUser.getCredentials();
+        HttpServletRequest request = credentials.getRequest();
+        
+        // Get the current client address
+        IPAddressString clientAddr = new IPAddressString(request.getRemoteAddr());
+
+        // Ignore anonymous users
+        if (authenticatedUser.getIdentifier().equals(AuthenticatedUser.ANONYMOUS_IDENTIFIER))
+            return;
+        
+        // We enforce by default
+        boolean enforceHost = true;
+        
+        // Check for a list of addresses that should be bypassed and iterate
+        List<IPAddress> bypassAddresses = confService.getBypassHosts();
+        for (IPAddress bypassAddr : bypassAddresses) {
+            // If the address contains current client address, flip enforce flag
+            // and break out
+            if (clientAddr != null && clientAddr.isIPAddress()
+                    && bypassAddr.getIPVersion().equals(clientAddr.getIPVersion())
+                    && bypassAddr.contains(clientAddr.getAddress())) {
+                enforceHost = false;
+                break;
+            }
+        }
+        
+        // Check for a list of addresses that should be enforced and iterate
+        List<IPAddress> enforceAddresses = confService.getEnforceHosts();
+        
+        // Only continue processing if the list is not empty
+        if (!enforceAddresses.isEmpty()) {
+            
+            if (clientAddr == null || !clientAddr.isIPAddress()) {
+                logger.warn("Client address is not valid, "
+                + "MFA will be enforced.");
+                enforceHost = true;
+            }
+            
+            else {
+                // With addresses set, this default changes to false.
+                enforceHost = false;
+
+                for (IPAddress enforceAddr : enforceAddresses) {
+
+                    // If there's a match, flip the enforce flag and break out of the loop
+                    if (enforceAddr.getIPVersion().equals(clientAddr.getIPVersion())
+                            && enforceAddr.contains(clientAddr.getAddress())) {
+                        enforceHost = true;
+                        break;
+                    }
+                }
+            }
+        }
+            
+        // If the enforce flag has been changed, exit, bypassing TOTP MFA.
+        if (!enforceHost)
+            return;
+        
         // Ignore anonymous users
         String username = authenticatedUser.getIdentifier();
         if (username.equals(AuthenticatedUser.ANONYMOUS_IDENTIFIER))
@@ -324,10 +386,6 @@ public class UserVerificationService {
         UserTOTPKey key = getKey(context, username);
         if (key == null)
             return;
-
-        // Pull the original HTTP request used to authenticate
-        Credentials credentials = authenticatedUser.getCredentials();
-        HttpServletRequest request = credentials.getRequest();
 
         // Retrieve TOTP from request
         String code = request.getParameter(AuthenticationCodeField.PARAMETER_NAME);

--- a/guacamole-ext/pom.xml
+++ b/guacamole-ext/pom.xml
@@ -110,6 +110,13 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <!-- Library for unified IPv4/6 parsing and validation -->
+        <dependency>
+            <groupId>com.github.seancfoley</groupId>
+            <artifactId>ipaddress</artifactId>
+            <version>5.5.0</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/IPAddressListProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/IPAddressListProperty.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.guacamole.properties;
+
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.GuacamoleServerException;
+
+/**
+ * A GuacamoleProperty implementation that parses a String for a comma-separated
+ * list of IP addresses and/or IP subnets, both IPv4 and IPv6, and returns the
+ * list of those valid IP addresses/subnets.
+ */
+public abstract class IPAddressListProperty implements GuacamoleProperty<List<IPAddress>> {
+    
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently simply a comma and any following whitespace. Parts of the
+     * input string which match this pattern will not be included in the parsed
+     * result.
+     */
+    private static final Pattern DELIMITER_PATTERN = Pattern.compile(",\\s*");
+    
+    @Override
+    public List<IPAddress> parseValue(String values) throws GuacamoleException {
+        
+        // Null for null
+        if (values == null)
+            return null;
+        
+        // Not null, just empty
+        if (values.isEmpty())
+            return Collections.emptyList();
+        
+        // Split the string into an array
+        List<String> addrStrings = Arrays.asList(DELIMITER_PATTERN.split(values));
+        List<IPAddress> ipAddresses = new ArrayList<>();
+        
+        // Loop through each string
+        for (String addrString : addrStrings) {
+            
+            // Convert the string to an IPAddressString for validation
+            IPAddressString ipString = new IPAddressString(addrString);
+            
+            // If this isn't a valid address, subnet, etc., throw an exception
+            if (!ipString.isIPAddress())
+                throw new GuacamoleServerException("Invalid IP address specified: " + addrString);
+            
+            // Add the address to the list.
+            ipAddresses.add(ipString.getAddress());
+        }
+        
+        // Return our list of valid IP addresses and/or subnets
+        return ipAddresses;
+        
+    }
+    
+    /**
+     * Return true if the provided address list contains the client address,
+     * or false if no match is found.
+     * 
+     * @param addrList
+     *     The address list to check for matches.
+     * 
+     * @param ipAddr
+     *     The client address to look for in the list.
+     * 
+     * @return 
+     *     True if the client address is in the provided list, otherwise
+     *     false.
+     */
+    public static boolean addressListContains(List<IPAddress> addrList, IPAddress ipAddr) {
+        
+        // If either is null, return false
+        if (ipAddr == null || addrList == null)
+            return false;
+        
+        for (IPAddress ipEntry : addrList)
+                    
+            // If version matches and entry contains it, return true
+            if (ipEntry.getIPVersion().equals(ipAddr.getIPVersion())
+                    && ipEntry.contains(ipAddr))
+                return true;
+        
+        // No match, so return false
+        return false;
+        
+    }
+    
+}


### PR DESCRIPTION
This pull request implements the feature proposed in Jira for GUACAMOLE-1855 - the Duo and TOTP modules can be configured to either be bypassed for users logging in from specific hosts, or can be configured to be explicitly required for users logging in from specific hosts, while other hosts are bypassed.

This allows situations where users connecting from the Internet ought to be required to complete MFA, but users logging in from behind a VPN or on a corporate network may not need to perform the extra authentication step.