### PR TITLE
GUACAMOLE-1856: Correct CREATE_USER vs. CREATE_USER_GROUP check in creation of groups.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/usergroup/UserGroupService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/usergroup/UserGroupService.java
@@ -121,7 +121,7 @@ public class UserGroupService extends ModeledDirectoryObjectService<ModeledUserG
 
         // Return whether user has explicit user group creation permission
         SystemPermissionSet permissionSet = user.getUser().getEffectivePermissions().getSystemPermissions();
-        return permissionSet.hasPermission(SystemPermission.Type.CREATE_USER);
+        return permissionSet.hasPermission(SystemPermission.Type.CREATE_USER_GROUP);
 
     }
 


### PR DESCRIPTION
This change corrects a typo in database user group management, properly separating permission enforcement of _user_ creation from _user group_ creation.

As noted on [GUACAMOLE-1856](https://issues.apache.org/jira/browse/GUACAMOLE-1856), this happily does _not_ have security implications:

>
> ... A user with permission to create other users and the unintentional permission to create user groups would not be able to leverage that access to gain or grant any additional privileges:
>
> * A user cannot add users to a group unless they already have sufficient privileges to grant permissions to those users directly.
> * A user cannot grant any permissions to a group that they cannot already grant to a user.
>

It's the enforcement of other permissions that dictate whether anything can actually be done with a created object, as well as what that object is permitted to affect, and those permissions are correctly enforced regardless of whether the object is a group or a user.