### PR TITLE
GUACAMOLE-839: Force usage of non-dynamic version of Bouncy Castle FIPS.

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/pom.xml
@@ -124,6 +124,25 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
             <version>1.0.7</version>
+
+            <!-- Force usage of known version of bc-fips, rather than a future
+            unknown version (bcpkix-fips references bc-fips using a version
+            range, resulting in newer versions getting pulled in automatically,
+            breaking the automated license check) -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bc-fips</artifactId>
+                </exclusion>
+            </exclusions>
+
+        </dependency>
+
+        <!-- Force usage of known version of bc-fips (see bcpkix-fips above) -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bc-fips</artifactId>
+            <version>1.0.2.4</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
[As noted on GUACAMOLE-839](https://issues.apache.org/jira/browse/GUACAMOLE-839?focusedCommentId=17770213&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17770213), the `bcpkix-fips` library depends on `bc-fips` using a version range. This leads to an unpredictable build and breakage of the license check whenever a new version of `bc-fips` is released.

These changes override the `bc-fips` dependency, instead explicitly selecting what is currently the latest version.