### PR TITLE
Fixed the problem of incorrect remote host IP in connection history a…

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/Credentials.java
@@ -19,6 +19,8 @@
 
 package org.apache.guacamole.net.auth;
 
+import org.apache.guacamole.util.IpUtils;
+
 import java.io.Serializable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -94,7 +96,7 @@ public class Credentials implements Serializable {
         this.request = request;
 
         // Set the remote address
-        this.remoteAddress = request.getRemoteAddr();
+        this.remoteAddress = IpUtils.getRealIp(request);
 
         // Get the remote hostname
         this.remoteHostname = request.getRemoteHost();

--- a/guacamole-ext/src/main/java/org/apache/guacamole/util/IpUtils.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/util/IpUtils.java
@@ -1,0 +1,35 @@
+package org.apache.guacamole.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author LemonZuo
+ * @create 2023-11-01 20:40
+ * Utility class for IP related operations.
+ */
+public class IpUtils {
+
+    /**
+     * Retrieves the real IP address of the client from the request.
+     * This method considers the possibility of the request being passed through proxies or load balancers.
+     *
+     * @param request the HttpServletRequest object.
+     * @return the real IP address of the client.
+     */
+    public static String getRealIp(HttpServletRequest request) {
+        // Check for X-Forwarded-For header, which is set by proxies and load balancers.
+        String ipAddress = request.getHeader("X-Forwarded-For");
+
+        if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+            // If not available, fall back to the remote address from the request.
+            ipAddress = request.getRemoteAddr();
+        } else {
+            // In case multiple IP addresses are returned (in cases where it has passed through multiple proxies or load balancers),
+            // take only the first IP address from the list.
+            ipAddress = ipAddress.split(",")[0];
+        }
+
+        return ipAddress;
+    }
+}
+


### PR DESCRIPTION
Unable to obtain real remote host IP after reverse proxy,If the proxy request header exists, the real IP will be obtained from the request header, otherwise the IP will be obtained through the original method.