### PR TITLE
GUACAMOLE-1872: Hide session recording playback controls even when paused.

### DIFF
--- a/guacamole/src/main/frontend/src/app/settings/styles/history-player.css
+++ b/guacamole/src/main/frontend/src/app/settings/styles/history-player.css
@@ -96,7 +96,7 @@
     background: rgba(0, 0, 0, 0.5);
 }
 
-.settings.connectionHistoryPlayer .guac-player-controls.playing {
+.settings.connectionHistoryPlayer .guac-player-controls {
     opacity: 0;
     -webkit-transition: opacity 0.25s linear 0.25s;
     -moz-transition: opacity 0.25s linear 0.25s;
@@ -104,15 +104,7 @@
     transition: opacity 0.25s linear 0.25s;
 }
 
-.settings.connectionHistoryPlayer .guac-player-controls.paused,
-.settings.connectionHistoryPlayer .guac-player-controls.playing:hover {
-    opacity: 1;
-    -webkit-transition-delay: 0s;
-    -moz-transition-delay: 0s;
-    -o-transition-delay: 0s;
-    transition-delay: 0s;
-}
-
-.settings.connectionHistoryPlayer guac-player.recent-mouse-movement .guac-player-controls.playing {
+.settings.connectionHistoryPlayer .guac-player-controls:hover,
+.settings.connectionHistoryPlayer guac-player.recent-mouse-movement .guac-player-controls {
     opacity: 1;
 }


### PR DESCRIPTION
This change ensures that the session recording player controls can be hidden, even when the playback is paused. The controls will always be shown when the control bar is hovered over.

This is to allow admins to look at the bottom of the screen (which can contain import things like a task bar) when the recording is paused.