### PR TITLE
GUACAMOLE-1887: Bump versions numbers of projects outside 1.5.4 scope.

### DIFF
--- a/extensions/guacamole-auth-ban/pom.xml
+++ b/extensions/guacamole-auth-ban/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-ban</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <name>guacamole-auth-ban</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.4</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.4</version>
             <scope>provided</scope>
 
             <!-- Exclude transitive dependencies that will be overridden by

--- a/extensions/guacamole-auth-ban/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-ban/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.3",
+    "guacamoleVersion" : "1.5.4",
 
     "name"      : "Brute-force Authentication Detection/Prevention",
     "namespace" : "ban",

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-dist/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-dist/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-auth-sso-ssl</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.4</version>
         </dependency>
 
     </dependencies>

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-auth-sso-ssl</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <name>guacamole-auth-sso-ssl</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>guacamole-auth-sso</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.4</version>
         <relativePath>../../</relativePath>
     </parent>
 

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-ssl/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.3",
+    "guacamoleVersion" : "1.5.4",
 
     "name"      : "SSL Authentication Extension",
     "namespace" : "ssl",

--- a/extensions/guacamole-display-statistics/pom.xml
+++ b/extensions/guacamole-display-statistics/pom.xml
@@ -26,14 +26,14 @@
     <groupId>org.apache.guacamole</groupId>
     <artifactId>guacamole-display-statistics</artifactId>
     <packaging>jar</packaging>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <name>guacamole-display-statistics</name>
     <url>http://guacamole.apache.org/</url>
 
     <parent>
         <groupId>org.apache.guacamole</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.4</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/extensions/guacamole-display-statistics/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-display-statistics/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.3",
+    "guacamoleVersion" : "1.5.4",
 
     "name"      : "Display Statistic Toolbar",
     "namespace" : "display-stats",


### PR DESCRIPTION
This addresses the build failures on `master` as of the merge of #934.