### PR TITLE
GUACAMOLE-1904: Enhanced client menu field functionality

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -468,7 +468,20 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         else if (menuShownPreviousState)
             $scope.applyParameterChanges($scope.focusedClient);
 
+        /* Broadcast changes to the menu display state */
+        $scope.$broadcast('guacMenuShown', menuShown);
+
     });
+
+    // Toggle the menu when the guacClientToggleMenu event is received
+    $scope.$on('guacToggleMenu',
+            () => $scope.menu.shown = !$scope.menu.shown);
+
+    // Show the menu when the guacClientShowMenu event is received
+    $scope.$on('guacShowMenu', () => $scope.menu.shown = true);
+
+    // Hide the menu when the guacClientHideMenu event is received
+    $scope.$on('guacHideMenu', () => $scope.menu.shown = false);
 
     // Automatically track and cache the currently-focused client
     $scope.$on('guacClientFocused', function focusedClientChanged(event, newFocusedClient) {

--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -498,16 +498,33 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         $scope.menu.connectionParameters = newFocusedClient ?
             ManagedClient.getArgumentModel(newFocusedClient) : {};
 
+        // Re-broadcast the updated client
+        $scope.$broadcast('guacClientChanged', newFocusedClient);
+
+    });
+
+    // Track when the protocol changes for the current client - generally
+    // this will be when the protocol is first set for the client
+    $scope.$on('guacClientProtocolUpdated', function protocolChanged(event, focusedClient) {
+
+        // Ignore any updated protocol not for the current focused client
+        if ($scope.focusedClient && $scope.focusedClient === focusedClient)
+
+            // Re-broadcast the updated protocol
+            $scope.$broadcast('guacClientProtocolChanged', focusedClient);
     });
 
     // Automatically update connection parameters that have been modified
     // for the current focused client
-    $scope.$on('guacClientArgumentsUpdated', function focusedClientChanged(event, focusedClient) {
+    $scope.$on('guacClientArgumentsUpdated', function argumentsChanged(event, focusedClient) {
 
-        // Update available connection parameters, if the updated arguments are
-        // for the current focused client - otherwise ignore them
-        if ($scope.focusedClient && $scope.focusedClient === focusedClient)
+        // Ignore any updated arguments not for the current focused client
+        if ($scope.focusedClient && $scope.focusedClient === focusedClient) {
             $scope.menu.connectionParameters = ManagedClient.getArgumentModel(focusedClient);
+
+            // Re-broadcast the updated arguments
+            $scope.$broadcast('guacClientArgumentsChanged', focusedClient);
+        }
 
     });
 

--- a/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
+++ b/guacamole/src/main/frontend/src/app/client/controllers/clientController.js
@@ -498,20 +498,6 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
         $scope.menu.connectionParameters = newFocusedClient ?
             ManagedClient.getArgumentModel(newFocusedClient) : {};
 
-        // Re-broadcast the updated client
-        $scope.$broadcast('guacClientChanged', newFocusedClient);
-
-    });
-
-    // Track when the protocol changes for the current client - generally
-    // this will be when the protocol is first set for the client
-    $scope.$on('guacClientProtocolUpdated', function protocolChanged(event, focusedClient) {
-
-        // Ignore any updated protocol not for the current focused client
-        if ($scope.focusedClient && $scope.focusedClient === focusedClient)
-
-            // Re-broadcast the updated protocol
-            $scope.$broadcast('guacClientProtocolChanged', focusedClient);
     });
 
     // Automatically update connection parameters that have been modified
@@ -519,12 +505,8 @@ angular.module('client').controller('clientController', ['$scope', '$routeParams
     $scope.$on('guacClientArgumentsUpdated', function argumentsChanged(event, focusedClient) {
 
         // Ignore any updated arguments not for the current focused client
-        if ($scope.focusedClient && $scope.focusedClient === focusedClient) {
+        if ($scope.focusedClient && $scope.focusedClient === focusedClient)
             $scope.menu.connectionParameters = ManagedClient.getArgumentModel(focusedClient);
-
-            // Re-broadcast the updated arguments
-            $scope.$broadcast('guacClientArgumentsChanged', focusedClient);
-        }
 
     });
 

--- a/guacamole/src/main/frontend/src/app/client/directives/guacTiledClients.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacTiledClients.js
@@ -62,6 +62,9 @@ angular.module('client').directive('guacTiledClients', [function guacTiledClient
     directive.controller = ['$scope', '$injector', '$element',
             function guacTiledClientsController($scope, $injector, $element) {
 
+        // Required services
+        const $rootScope = $injector.get('$rootScope');
+
         // Required types
         const ManagedClient      = $injector.get('ManagedClient');
         const ManagedClientGroup = $injector.get('ManagedClientGroup');
@@ -89,17 +92,17 @@ angular.module('client').directive('guacTiledClients', [function guacTiledClient
 
         // Notify whenever identify of currently-focused client changes
         $scope.$watch('getFocusedClient()', function focusedClientChanged(focusedClient) {
-            $scope.$emit('guacClientFocused', focusedClient);
+            $rootScope.$broadcast('guacClientFocused', focusedClient);
         });
 
         // Notify whenever arguments of currently-focused client changes
         $scope.$watch('getFocusedClient().arguments', function focusedClientParametersChanged() {
-            $scope.$emit('guacClientArgumentsUpdated', $scope.getFocusedClient());
+            $rootScope.$broadcast('guacClientArgumentsUpdated', $scope.getFocusedClient());
         }, true);
 
         // Notify whenever protocol of currently-focused client changes
         $scope.$watch('getFocusedClient().protocol', function focusedClientParametersChanged() {
-            $scope.$emit('guacClientProtocolUpdated', $scope.getFocusedClient());
+            $rootScope.$broadcast('guacClientProtocolUpdated', $scope.getFocusedClient());
         }, true);
 
         /**

--- a/guacamole/src/main/frontend/src/app/client/directives/guacTiledClients.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacTiledClients.js
@@ -97,6 +97,11 @@ angular.module('client').directive('guacTiledClients', [function guacTiledClient
             $scope.$emit('guacClientArgumentsUpdated', $scope.getFocusedClient());
         }, true);
 
+        // Notify whenever protocol of currently-focused client changes
+        $scope.$watch('getFocusedClient().protocol', function focusedClientParametersChanged() {
+            $scope.$emit('guacClientProtocolUpdated', $scope.getFocusedClient());
+        }, true);
+
         /**
          * Returns a callback for guacClick that assigns or updates keyboard
          * focus to the given client, allowing that client to receive and

--- a/guacamole/src/main/frontend/src/app/client/styles/menu.css
+++ b/guacamole/src/main/frontend/src/app/client/styles/menu.css
@@ -27,11 +27,11 @@
     background: #EEE;
     box-shadow: inset -1px 0 2px white, 1px 0 2px black;
     z-index: 100;
-    -webkit-transition: left 0.125s;
-    -moz-transition: left 0.125s;
-    -ms-transition: left 0.125s;
-    -o-transition: left 0.125s;
-    transition: left 0.125s;
+    -webkit-transition: left 0.125s, opacity 0.125s;
+    -moz-transition: left 0.125s, opacity 0.125s;
+    -ms-transition: left 0.125s, opacity 0.125s;
+    -o-transition: left 0.125s, opacity 0.125s;
+    transition: left 0.125s, opacity 0.125s;
 }
 
 .menu-content {
@@ -137,10 +137,10 @@
 .menu,
 .menu.closed {
     left: -480px;
-    visibility: hidden;
+    opacity: 0;
 }
 
 .menu.open {
     left: 0px;
-    visibility: visible;
+    opacity: 1;
 }

--- a/guacamole/src/main/frontend/src/app/client/styles/menu.css
+++ b/guacamole/src/main/frontend/src/app/client/styles/menu.css
@@ -27,11 +27,11 @@
     background: #EEE;
     box-shadow: inset -1px 0 2px white, 1px 0 2px black;
     z-index: 100;
-    -webkit-transition: left 0.125s, opacity 0.125s;
-    -moz-transition: left 0.125s, opacity 0.125s;
-    -ms-transition: left 0.125s, opacity 0.125s;
-    -o-transition: left 0.125s, opacity 0.125s;
-    transition: left 0.125s, opacity 0.125s;
+    -webkit-transition: left 0.125s;
+    -moz-transition: left 0.125s;
+    -ms-transition: left 0.125s;
+    -o-transition: left 0.125s;
+    transition: left 0.125s;
 }
 
 .menu-content {
@@ -137,10 +137,10 @@
 .menu,
 .menu.closed {
     left: -480px;
-    opacity: 0;
+    visibility: hidden;
 }
 
 .menu.open {
     left: 0px;
-    opacity: 1;
+    visibility: visible;
 }

--- a/guacamole/src/main/frontend/src/app/client/templates/client.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/client.html
@@ -124,6 +124,7 @@
                     <guac-form namespace="getProtocolNamespace(focusedClient.protocol)"
                                content="focusedClient.forms"
                                model="menu.connectionParameters"
+                               client="focusedClient"
                                model-only="true"></guac-form>
                 </div>
 

--- a/guacamole/src/main/frontend/src/app/client/templates/client.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/client.html
@@ -47,7 +47,7 @@
     
     <!-- Menu -->
     <div class="menu" ng-class="{open: menu.shown}" id="guac-menu">
-        <div class="menu-content" ng-if="menu.shown" guac-touch-drag="menuDrag">
+        <div class="menu-content" guac-touch-drag="menuDrag">
 
             <!-- Stationary header -->
             <div class="header">

--- a/guacamole/src/main/frontend/src/app/client/templates/client.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/client.html
@@ -47,7 +47,7 @@
     
     <!-- Menu -->
     <div class="menu" ng-class="{open: menu.shown}" id="guac-menu">
-        <div class="menu-content" guac-touch-drag="menuDrag">
+        <div class="menu-content" ng-if="menu.shown" guac-touch-drag="menuDrag">
 
             <!-- Stationary header -->
             <div class="header">

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -836,8 +836,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
      */
     ManagedClient.setArgument = function setArgument(managedClient, name, value) {
         var managedArgument = managedClient.arguments[name];
-        if (managedArgument && ManagedArgument.setValue(managedArgument, value))
-            delete managedClient.arguments[name];
+        managedArgument && ManagedArgument.setValue(managedArgument, value);
     };
 
     /**

--- a/guacamole/src/main/frontend/src/app/form/directives/form.js
+++ b/guacamole/src/main/frontend/src/app/form/directives/form.js
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+/* global _ */
 
 /**
  * A directive that allows editing of a collection of fields.
@@ -83,6 +84,11 @@ angular.module('form').directive('guacForm', [function form() {
 
             /**
              * The client associated with this form, if any.
+             *
+             * NOTE: If the provided client has any managed arguments in the
+             * pending state, any fields with the same name rendered by this
+             * form will be disabled. The fields will be re-enabled when guacd
+             * sends an updated argument with a the same name.
              *
              * @type ManagedClient
              */
@@ -245,6 +251,28 @@ angular.module('form').directive('guacForm', [function form() {
                 // within the model
                 return field && (field.name in $scope.values);
 
+            };
+
+
+            /**
+             * Returns whether the given field should be disabled (read-only)
+             * when presented to the current user.
+             *
+             * @param {Field} field
+             *     The field to check.
+             *
+             * @returns {Boolean}
+             *     true if the given field should be disabled, false otherwise.
+             */
+            $scope.isDisabled = function isDisabled(field) {
+
+                /*
+                 * The field is disabled if either the form as a whole is disabled,
+                 * or if a client is provided to the directive, and the field is
+                 * marked as pending.
+                 */
+                return $scope.disabled ||
+                        _.get($scope.client, ['arguments', field.name, 'pending']);
             };
 
             /**

--- a/guacamole/src/main/frontend/src/app/form/directives/form.js
+++ b/guacamole/src/main/frontend/src/app/form/directives/form.js
@@ -79,7 +79,14 @@ angular.module('form').directive('guacForm', [function form() {
              *
              * @type String
              */
-            focused : '='
+            focused : '=',
+
+            /**
+             * The client associated with this form, if any.
+             *
+             * @type ManagedClient
+             */
+            client: '='
 
         },
         templateUrl: 'app/form/templates/form.html',

--- a/guacamole/src/main/frontend/src/app/form/directives/formField.js
+++ b/guacamole/src/main/frontend/src/app/form/directives/formField.js
@@ -68,7 +68,14 @@ angular.module('form').directive('guacFormField', [function formField() {
              *
              * @type Boolean
              */
-            focused : '='
+            focused : '=',
+
+            /**
+             * The client associated with this form field, if any.
+             *
+             * @type ManagedClient
+             */
+            client: '='
 
         },
         templateUrl: 'app/form/templates/formField.html',

--- a/guacamole/src/main/frontend/src/app/form/templates/form.html
+++ b/guacamole/src/main/frontend/src/app/form/templates/form.html
@@ -10,7 +10,7 @@
         <div class="fields">
             <guac-form-field ng-repeat="field in form.fields" namespace="namespace"
                              ng-if="isVisible(field)"
-                             data-disabled="disabled"
+                             data-disabled="isDisabled(field)"
                              focused="isFocused(field)"
                              field="field"
                              client="client"

--- a/guacamole/src/main/frontend/src/app/form/templates/form.html
+++ b/guacamole/src/main/frontend/src/app/form/templates/form.html
@@ -13,6 +13,7 @@
                              data-disabled="disabled"
                              focused="isFocused(field)"
                              field="field"
+                             client="client"
                              model="values[field.name]"></guac-form-field>
         </div>
 


### PR DESCRIPTION
This change allows extensions to define custom fields that have a few new capabilities, namely:

* Request the showing or hiding of the menu
* Save their own values without having to close the menu
* Receive events when the client, arguments, or protocol changes


