### PR TITLE
GUACAMOLE-1844 : OIDC JWT claims as user token

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/java/org/apache/guacamole/auth/openid/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/java/org/apache/guacamole/auth/openid/AuthenticationProviderService.java
@@ -25,6 +25,7 @@ import com.google.inject.Singleton;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.UriBuilder;
@@ -84,6 +85,7 @@ public class AuthenticationProviderService implements SSOAuthenticationProviderS
 
         String username = null;
         Set<String> groups = null;
+        Map<String,String> tokens = Collections.emptyMap();
 
         // Validate OpenID token in request, if present, and derive username
         HttpServletRequest request = credentials.getRequest();
@@ -94,6 +96,7 @@ public class AuthenticationProviderService implements SSOAuthenticationProviderS
                 if (claims != null) {
                     username = tokenService.processUsername(claims);
                     groups = tokenService.processGroups(claims);
+                    tokens = tokenService.processAttributes(claims);
                 }
             }
         }
@@ -104,7 +107,7 @@ public class AuthenticationProviderService implements SSOAuthenticationProviderS
 
             // Create corresponding authenticated user
             SSOAuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
-            authenticatedUser.init(username, credentials, groups, Collections.emptyMap());
+            authenticatedUser.init(username, credentials, groups, tokens);
             return authenticatedUser;
 
         }

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/java/org/apache/guacamole/auth/openid/conf/ConfigurationService.java
@@ -21,10 +21,13 @@ package org.apache.guacamole.auth.openid.conf;
 
 import com.google.inject.Inject;
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.environment.Environment;
 import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
+import org.apache.guacamole.properties.StringListProperty;
 import org.apache.guacamole.properties.URIGuacamoleProperty;
 
 /**
@@ -44,6 +47,11 @@ public class ConfigurationService {
      * groups.
      */
     private static final String DEFAULT_GROUPS_CLAIM_TYPE = "groups";
+
+    /**
+     * The default JWT claims list to map to tokens.
+     */
+    private static final List<String> DEFAULT_ATTRIBUTES_CLAIM_TYPE = Collections.emptyList();
 
     /**
      * The default space-separated list of OpenID scopes to request.
@@ -125,6 +133,16 @@ public class ConfigurationService {
         public String getName() { return "openid-groups-claim-type"; }
 
     };
+
+    /**
+     * The claims within any valid JWT that should be mapped to
+     * the authenticated user's tokens, as configured with guacamole.properties.
+     */
+    private static final StringListProperty OPENID_ATTRIBUTES_CLAIM_TYPE =
+            new StringListProperty() {
+                @Override
+                public String getName() { return "openid-attributes-claim-type"; }
+            };
 
     /**
      * The space-separated list of OpenID scopes to request.
@@ -324,6 +342,22 @@ public class ConfigurationService {
      */
     public String getGroupsClaimType() throws GuacamoleException {
         return environment.getProperty(OPENID_GROUPS_CLAIM_TYPE, DEFAULT_GROUPS_CLAIM_TYPE);
+    }
+
+    /**
+     * Returns the claims list within any valid JWT that should be mapped to
+     * the authenticated user's tokens, as configured with guacamole.properties.
+     * Empty by default.
+     *
+     * @return
+     *     The claims list within any valid JWT that should be mapped to
+     *     the authenticated user's tokens, as configured with guacamole.properties.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public List<String> getAttributesClaimType() throws GuacamoleException {
+        return environment.getProperty(OPENID_ATTRIBUTES_CLAIM_TYPE, DEFAULT_ATTRIBUTES_CLAIM_TYPE);
     }
 
     /**


### PR DESCRIPTION
GUACAMOLE-1844 : OIDC JWT claims as user token

This patch allows IDP to send JWT claims that can be mapped to user tokens, prefixed with OIDC_. Same case transormation apply than LDAP_ and CAS_.

Define openid-attributes-claim-type with a comma-separated list of claims that should be mapped.

Multivalued JWT claims are not unrolled.