### PR TITLE
GUACAMOLE-1906: Bump guac-manifest versions and add 1.5.5 to the extension loader.

### DIFF
--- a/extensions/guacamole-auth-duo/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-duo/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "Duo TFA Authentication Backend",
     "namespace" : "duo",

--- a/extensions/guacamole-auth-header/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-header/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "HTTP Header Authentication Extension",
     "namespace" : "header",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "MySQL Authentication",
     "namespace" : "mysql",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "PostgreSQL Authentication",
     "namespace" : "postgresql",

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "SQLServer Authentication",
     "namespace" : "sqlserver",

--- a/extensions/guacamole-auth-json/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-json/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "Encrypted JSON Authentication",
     "namespace" : "json",

--- a/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-ldap/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "LDAP Authentication",
     "namespace" : "ldap",

--- a/extensions/guacamole-auth-quickconnect/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-quickconnect/src/main/resources/guac-manifest.json
@@ -1,5 +1,5 @@
 {
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"             : "Adhoc Guacamole Connections",
     "namespace"        : "quickconnect",

--- a/extensions/guacamole-auth-radius/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-radius/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "RADIUS Authentication Backend",
     "namespace" : "radius",

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "CAS Authentication Extension",
     "namespace" : "cas",

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "OpenID Authentication Extension",
     "namespace" : "openid",

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "SAML Authentication Extension",
     "namespace" : "saml",

--- a/extensions/guacamole-auth-totp/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-auth-totp/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "TOTP TFA Authentication Backend",
     "namespace" : "totp",

--- a/extensions/guacamole-history-recording-storage/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-history-recording-storage/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "Session Recording Storage",
     "namespace" : "recording-storage",

--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/resources/guac-manifest.json
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/resources/guac-manifest.json
@@ -1,6 +1,6 @@
 {
 
-    "guacamoleVersion" : "1.5.4",
+    "guacamoleVersion" : "1.5.5",
 
     "name"      : "Keeper Secrets Manager",
     "namespace" : "keeper-secrets-manager",

--- a/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
+++ b/guacamole/src/main/java/org/apache/guacamole/extension/ExtensionModule.java
@@ -72,7 +72,8 @@ public class ExtensionModule extends ServletModule {
             "1.5.1",
             "1.5.2",
             "1.5.3",
-            "1.5.4"
+            "1.5.4",
+            "1.5.5"
         ));
 
     /**


### PR DESCRIPTION
Got all the pom.xml files in the last pull request, but forgot the extension loader and the guac-manifest files.