### PR TITLE
GUACAMOLE-1905: Revert to Java-8-compatible Logback 1.3.14.

### DIFF
--- a/doc/licenses/logback-1.3.14/LICENSE.txt
+++ b/doc/licenses/logback-1.3.14/LICENSE.txt
@@ -1,0 +1,17 @@
+Logback LICENSE
+---------------
+
+Logback: the reliable, generic, fast and flexible logging framework.
+Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+
+This program and the accompanying materials are dual-licensed under
+either the terms of the Eclipse Public License v1.0 as published by
+the Eclipse Foundation
+ 
+  or (per the licensee's choosing)
+ 
+under the terms of the GNU Lesser General Public License version 2.1
+as published by the Free Software Foundation.
+
+** ECLIPSE PUBLIC LICENSE v1.0 CHOSEN. **
+

--- a/doc/licenses/logback-1.3.14/README
+++ b/doc/licenses/logback-1.3.14/README
@@ -1,0 +1,8 @@
+Logback (http://logback.qos.ch/)
+--------------------------------
+
+    Version: 1.3.14
+    From: 'QOS.ch Sàrl' (http://qos.ch/)
+    License(s):
+        EPL v1.0 (bundled/logback-1.3.14/LICENSE.txt)
+

--- a/doc/licenses/logback-1.3.14/dep-coordinates.txt
+++ b/doc/licenses/logback-1.3.14/dep-coordinates.txt
@@ -1,0 +1,2 @@
+ch.qos.logback:logback-classic:jar:1.3.14
+ch.qos.logback:logback-core:jar:1.3.14

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <jersey.version>2.41</jersey.version>
         <junit.version>5.10.2</junit.version>
         <junit4.version>4.13.2</junit4.version>
-        <logback.version>1.5.2</logback.version>
+        <logback.version>1.3.14</logback.version>
         <slf4j.version>2.0.12</slf4j.version>
 
         <!-- The directory that should receive all generated dependency lists


### PR DESCRIPTION
As discussed in https://github.com/apache/guacamole-client/pull/954, this is the latest Java 8 compatible version of Logback.