### PR TITLE
GUACAMOLE-1239: Configurable username letter case

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/environment/Environment.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/environment/Environment.java
@@ -68,6 +68,13 @@ public interface Environment {
 
     };
 
+    public static final StringGuacamoleProperty USERNAME_LETTER_CASE = new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "username-letter-case"; }
+
+    };
+
     /**
      * Returns the Guacamole home directory as determined when this Environment
      * object was created. The Guacamole home directory is found by checking, in


### PR DESCRIPTION
This is [another option](/apache/guacamole-client/pull/902) to make guacamole case-insensitive.

More specific, it can be configured, whether usernames shall be treated as uppercase, lowercase or mixed-case.

If that seems reasonable, but needs more work, don't hesitate to ask.

[1239]: https://issues.apache.org/jira/browse/GUACAMOLE-1239