### PR TITLE
GUACAMOLE-1905: Revert to java-saml-compatible version of woodstox.

### DIFF
--- a/doc/licenses/woodstox-core-5.4.0/README
+++ b/doc/licenses/woodstox-core-5.4.0/README
@@ -1,7 +1,7 @@
 Woodstox Core (https://github.com/FasterXML/woodstox)
 ------------------------------------------------------
 
-    Version: 6.5.0
+    Version: 5.4.0
     From: 'FasterXML, LLC' (http://fasterxml.com/)
     License(s):
         Apache v2.0

--- a/doc/licenses/woodstox-core-5.4.0/dep-coordinates.txt
+++ b/doc/licenses/woodstox-core-5.4.0/dep-coordinates.txt
@@ -1,0 +1,1 @@
+com.fasterxml.woodstox:woodstox-core:jar:5.4.0

--- a/doc/licenses/woodstox-core-6.5.0/dep-coordinates.txt
+++ b/doc/licenses/woodstox-core-6.5.0/dep-coordinates.txt
@@ -1,1 +1,0 @@
-com.fasterxml.woodstox:woodstox-core:jar:6.5.0

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
-            <version>6.5.0</version>
+            <version>5.4.0</version>
         </dependency>
 
         <!-- Apache XML Security for Java (see exclusions for java-saml) -->


### PR DESCRIPTION
In https://github.com/apache/guacamole-client/pull/954, the version of woodstox was bumped from `5.4.0` to `6.5.0`, but `6.5.0` is a major version bump past the `5.2.1` version that java-saml expects. }

This change restores the old `5.4.0` version of woodstox, which should remain in place until a newer `5.*` version of woodstox is released, or `java-saml` has a new release that uses a `6.*` version of woodstox.