### PR TITLE
GUACAMOLE-1905: Revert Apache Santuario version for compatibility with reverted Woodstox version.

### DIFF
--- a/doc/licenses/apache-santuario-2.2.6/NOTICE
+++ b/doc/licenses/apache-santuario-2.2.6/NOTICE
@@ -1,5 +1,5 @@
 Apache Santuario - XML Security for Java
-Copyright 1999-2024 The Apache Software Foundation
+Copyright 1999-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/doc/licenses/apache-santuario-2.2.6/README
+++ b/doc/licenses/apache-santuario-2.2.6/README
@@ -1,7 +1,7 @@
 Apache Santuario (https://santuario.apache.org/)
 -------------------------------------------------
 
-    Version: 2.3.4
+    Version: 2.2.6
     From: 'Apache Software Foundation' (https://www.apache.org/)
     License(s):
         Apache v2.0

--- a/doc/licenses/apache-santuario-2.2.6/dep-coordinates.txt
+++ b/doc/licenses/apache-santuario-2.2.6/dep-coordinates.txt
@@ -1,0 +1,1 @@
+org.apache.santuario:xmlsec:jar:2.2.6

--- a/doc/licenses/apache-santuario-2.3.4/dep-coordinates.txt
+++ b/doc/licenses/apache-santuario-2.3.4/dep-coordinates.txt
@@ -1,1 +1,0 @@
-org.apache.santuario:xmlsec:jar:2.3.4

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/pom.xml
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
-            <version>2.3.4</version>
+            <version>2.2.6</version>
             <exclusions>
 
                 <!--


### PR DESCRIPTION
Oops, missed this in https://github.com/apache/guacamole-client/pull/957. The latest version of Apache Santuario that's compliant with the now-reverted version of Woodstox is 2.2.6, what we had before https://github.com/apache/guacamole-client/pull/954.