### PR TITLE
GUACAMOLE-1932: Add no-arg constructor to fix guice error on guacamole-auth-json extension load.

### DIFF
--- a/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/RequestValidationService.java
+++ b/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/RequestValidationService.java
@@ -42,18 +42,21 @@ public class RequestValidationService {
      * Service for retrieving configuration information regarding the
      * JSONAuthenticationProvider.
      */
+    @Inject
     private ConfigurationService confService;
 
     /**
-     * Create a new instance of the request validation service, with the
-     * provided ConfigurationService object used to retrieve configuration
-     * properties for this extension.
+     * Create a new RequestValidationService instance.
+     */
+    public RequestValidationService() {}
+
+    /**
+     * Constructor that enables passing of an instance of
+     * ConfigurationService. (Only used for unit testing)
      *
      * @param confService
-     *     The instance of ConfigurationService for retrieving configuration
-     *     properties for this extension.
+     *     The (mock) instance of ConfigurationService
      */
-    @Inject
     public RequestValidationService(ConfigurationService confService) {
         this.confService = confService;
     }


### PR DESCRIPTION
This fixes the error detailed in [the ticket](https://issues.apache.org/jira/browse/GUACAMOLE-1932):
```
22:12:18.436 [main] ERROR o.a.g.extension.ProviderFactory - authentication provider extension failed to start: Unable to create injector, see the following errors:

1) [Guice/MissingConstructor]: No injectable constructor for type RequestValidationService.

class RequestValidationService does not have a @Inject annotated constructor or a no-arg constructor.

Requested by:
1  : RequestValidationService.class(RequestValidationService.java:39)
     at JSONAuthenticationProviderModule.configure(JSONAuthenticationProviderModule.java:80)

Learn more:
  https://github.com/google/guice/wiki/MISSING_CONSTRUCTOR

1 error

======================
Full classname legend:
======================
JSONAuthenticationProviderModule: "org.apache.guacamole.auth.json.JSONAuthenticationProviderModule"
RequestValidationService:         "org.apache.guacamole.auth.json.RequestValidationService"
========================
End of classname legend:
========================
```