### PR TITLE
GUACAMOLE-1374: Updating base Docker image for building on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,11 @@
 # Use args for Tomcat image label to allow image builder to choose alternatives
 # such as `--build-arg TOMCAT_JRE=jre8-alpine`
 #
-ARG TOMCAT_VERSION=8.5
-ARG TOMCAT_JRE=jdk8
+ARG TOMCAT_VERSION=9
+ARG TOMCAT_JRE=jdk21
 
 # Use official maven image for the build
-FROM maven:3-eclipse-temurin-8-focal AS builder
+FROM maven:3-eclipse-temurin-21 AS builder
 
 # Use Mozilla's Firefox PPA (newer Ubuntu lacks a "firefox-esr" package and
 # provides only a transitional "firefox" package that actually requires Snap


### PR DESCRIPTION
Pull request based on discussion [here](https://lists.apache.org/thread/yoqfy9s6bfvcsgccc33kylgyk9h7pwko) and followup to `guacamole-server` pull request [here](https://github.com/apache/guacamole-server/pull/499).

I have tested that it works on macOS (arch: amd64) and a Raspberry Pi 4 (arch: aarch64), open to hearing how it works on other architectures!