### PR TITLE
Add Russian keyboard support for RDP

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -121,7 +121,8 @@
                         "ro-ro-qwerty",
                         "sv-se-qwerty",
                         "da-dk-qwerty",
-                        "tr-tr-qwerty"
+                        "tr-tr-qwerty",
+                        "ru-ru-qwerty"
                     ]
                 },
                 {

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -699,6 +699,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_RO_RO_QWERTY" : "Romanian (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Swedish (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_TR_TR_QWERTY" : "Turkish-Q (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_RU_RU_QWERTY" : "Russian (Qwerty)"
 
         "NAME" : "RDP",
 


### PR DESCRIPTION
Add Russian keyboard support for RDP.
Request change to guacamole-server. 
See [guacamole-server 507](https://github.com/apache/guacamole-server/pull/507) for details.