### PR TITLE
GUACAMOLE-1948: Provide a comprehensive error message for input exceeding database column.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/resources/translations/en.json
@@ -108,6 +108,10 @@
 
         "SECTION_HEADER_RESTRICTIONS" : "Group Restrictions"
 
-    }
+    },
+
+    "CONNECTION_PARAMETERS": {
+        "DATABASE_PARAMETER_VALUE_TOO_LONG": "The value provided for connection parameter {PARAMETER_NAME} exceeds the maximum allowed length of {MAX_SIZE} {MAX_SIZE, plural, one{character} other{characters}}."
+    } 
 
 }


### PR DESCRIPTION
### Problem
We identified an issue where users were facing a generic error when attempting to save Guacamole connection parameters that exceeded the maximum allowed length (4096 characters). The error message was not clear and did not provide useful feedback regarding the input size constraint on the database column for connection parameters.

### Solution
To enhance the user experience and provide a more informative error message, I have implemented the following changes:

- Added a new method `validateParameters` within the `ConnectionService` class. This method checks each connection parameter's value against the known maximum size limit before a connection is created or updated. If a parameter value exceeds the maximum allowed length, the method throws a `TranslatableGuacamoleClientOverrunException` with a clear and specific message.

-  Added new error key `CONNECTION_PARAMETERS.DATABASE_PARAMETER_VALUE_TOO_LONG` to the JSON file of translatable messages.

![Screenshot_20240502_232540](https://github.com/apache/guacamole-client/assets/7276007/b7f3ccdd-f6c7-4671-ac79-23f8c5c573fd)

