### PR TITLE
extensions: auth-sso-saml: Add option to get username from attribute

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/conf/ConfigurationService.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/conf/ConfigurationService.java
@@ -152,6 +152,18 @@ public class ConfigurationService {
     };
 
     /**
+     * The property that defines what attribute the SAML provider will return
+     * that contains login name for the authenticated user.
+     */
+    private static final StringGuacamoleProperty SAML_USER_ATTRIBUTE =
+            new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "saml-user-attribute"; }
+
+    };
+
+    /**
      * The maximum amount of time to allow for an in-progress SAML
      * authentication attempt to be completed, in minutes. A user that takes
      * longer than this amount of time to complete authentication with their
@@ -338,6 +350,20 @@ public class ConfigurationService {
      */
     public String getGroupAttribute() throws GuacamoleException {
         return environment.getProperty(SAML_GROUP_ATTRIBUTE, "groups");
+    }
+
+    /**
+     * Return the name of the attribute that will be supplied by the identity
+     * provider that contains the username.
+     *
+     * @return
+     *     The name of the attribute that contains the username.
+     *
+     * @throws GuacamoleException
+     *     If guacamole.properties cannot be parsed.
+     */
+    public String getUserAttribute() throws GuacamoleException {
+        return environment.getProperty(SAML_USER_ATTRIBUTE, null);
     }
 
     /**

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/user/SAMLAuthenticatedUser.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/user/SAMLAuthenticatedUser.java
@@ -104,6 +104,23 @@ public class SAMLAuthenticatedUser extends SSOAuthenticatedUser {
 
     }
 
+    private String getUser(AssertedIdentity identity)
+            throws GuacamoleException {
+
+        String samlUserAttribute = confService.getUserAttribute();
+        List<String> samlUser = null;
+
+        if (samlUserAttribute == null || samlUserAttribute.isEmpty())
+            return identity.getUsername();
+
+        samlUser = identity.getAttributes().get(samlUserAttribute);
+        if (samlUser == null || samlUser.isEmpty())
+            return identity.getUsername();
+
+        return samlUser.get(0);
+
+    }
+
     /**
      * Initializes this AuthenticatedUser using the given
      * {@link AssertedIdentity} and credentials.
@@ -121,7 +138,7 @@ public class SAMLAuthenticatedUser extends SSOAuthenticatedUser {
      */
     public void init(AssertedIdentity identity, Credentials credentials)
             throws GuacamoleException {
-        super.init(identity.getUsername(), credentials, getGroups(identity), getTokens(identity));
+        super.init(getUser(identity), credentials, getGroups(identity), getTokens(identity));
     }
     
 }


### PR DESCRIPTION
The auth-sso-saml plugin always uses NameID as username.
Some SAML providers like simplesamlphp use NameID format "urn:oasis:names:tc:SAML:2.0:nameid-format:transient", this is a temporary ID associated with the user.
I added the option "saml-user-attribute" which allows to get the username from one of the attributes.

For example if simplesamlphp uses Active Directory LDAP as backend you can add one of this lines to guacamole.properties:
saml-user-attribute: mail
saml-user-attribute: sAMAccountName
saml-user-attribute: userPrincipalName

If saml-user-attribute is not set or empty the NameID wil be used.