### PR TITLE
GUAC-1967: Remove duplicate wheel handler registrations.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Mouse.js
+++ b/guacamole-common-js/src/main/webapp/modules/Mouse.js
@@ -258,9 +258,16 @@ Guacamole.Mouse = function Mouse(element) {
 
     }
 
-    element.addEventListener('DOMMouseScroll', mousewheel_handler, false);
-    element.addEventListener('mousewheel',     mousewheel_handler, false);
-    element.addEventListener('wheel',          mousewheel_handler, false);
+    if (window.WheelEvent) {
+        // All modern browsers support wheel events.
+        element.addEventListener('wheel', mousewheel_handler, false);
+    }
+    else {
+        // Legacy FireFox wheel events.
+        element.addEventListener('DOMMouseScroll', mousewheel_handler, false);
+        // Legacy Chrome/IE/other wheel events.
+        element.addEventListener('mousewheel', mousewheel_handler, false);
+    }
 
     /**
      * Whether the browser supports CSS3 cursor styling, including hotspot


### PR DESCRIPTION
Modern-day browsers abide the standardized `wheel` event (typed `WheelEvent`), however to support older browsers the legacy `DOMMouseScroll` (FireFox) and `mousewheel` (all others) events are also being registered.

However modern browsers support both the `wheel` event as well as the legacy, which results in the wheel handler being registered multiple times. This results in the wheel handler firing twice instead of once, causing excessive scrolling.

This change separates the event registration such that either the modern or the legacy events are registered, and not both.