### PR TITLE
GUACAMOLE-1979: Allow setting required properties for connecting to MySQL 8.4 and later.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/MySQLAuthenticationProviderModule.java
@@ -76,6 +76,10 @@ public class MySQLAuthenticationProviderModule implements Module {
         myBatisProperties.setProperty("mybatis.pooled.pingEnabled", "true");
         myBatisProperties.setProperty("mybatis.pooled.pingQuery", "SELECT 1");
 
+        // Set whether public key retrieval from the server is allowed
+        driverProperties.setProperty("allowPublicKeyRetrieval",
+            environment.getMYSQLAllowPublicKeyRetrieval() ? "true" : "false");
+
         // Use UTF-8 in database
         driverProperties.setProperty("characterEncoding", "UTF-8");
 
@@ -113,9 +117,21 @@ public class MySQLAuthenticationProviderModule implements Module {
         if (clientPassword != null)
             driverProperties.setProperty("clientCertificateKeyStorePassword",
                     clientPassword);
-        
+
         // Get the MySQL-compatible driver to use.
         mysqlDriver = environment.getMySQLDriver();
+
+        // Set the path to the server public key, if any
+        // Note that the property name casing is slightly different for MySQL
+        // and MariaDB drivers. See
+        // https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-security.html#cj-conn-prop_serverRSAPublicKeyFile
+        // and https://mariadb.com/kb/en/about-mariadb-connector-j/#infrequently-used-parameters
+        String publicKeyFile = environment.getMYSQLServerRSAPublicKeyFile();
+        if (publicKeyFile != null)
+            driverProperties.setProperty(
+                mysqlDriver == MySQLDriver.MYSQL
+                    ? "serverRSAPublicKeyFile" : "serverRsaPublicKeyFile",
+                publicKeyFile);
 
         // If timezone is present, set it.
         TimeZone serverTz = environment.getServerTimeZone();

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLEnvironment.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLEnvironment.java
@@ -442,4 +442,35 @@ public class MySQLEnvironment extends JDBCEnvironment {
                 true);
     }
 
+    /**
+     * Returns the absolute path to the public key for the server being connected to,
+     * if any, or null if the configuration property is unset.
+     *
+     * @return
+     *     The absolute path to the public key for the server being connected to.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs retrieving the configuration value.
+     */
+    public String getMYSQLServerRSAPublicKeyFile() throws GuacamoleException {
+        return getProperty(MySQLGuacamoleProperties.MYSQL_SERVER_RSA_PUBLIC_KEY_FILE);
+    }
+
+    /**
+     * Returns true if the database server public key should be automatically
+     * retrieved from the MySQL server, or false otherwise.
+     *
+     * @return
+     *     Whether the database server public key should be automatically
+     *     retrieved from the MySQL server.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs retrieving the configuration value.
+     */
+    public boolean getMYSQLAllowPublicKeyRetrieval() throws GuacamoleException {
+        return getProperty(
+                MySQLGuacamoleProperties.MYSQL_ALLOW_PUBLIC_KEY_RETRIEVAL,
+                false);
+    }
+
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/src/main/java/org/apache/guacamole/auth/mysql/conf/MySQLGuacamoleProperties.java
@@ -301,6 +301,29 @@ public class MySQLGuacamoleProperties {
         @Override
         public String getName() { return "mysql-batch-size"; }
 
-    };    
-    
+    };
+
+    /**
+     * The absolute path to the public key for the server being connected to, if any.
+     */
+    public static final StringGuacamoleProperty MYSQL_SERVER_RSA_PUBLIC_KEY_FILE =
+            new StringGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "mysql-server-rsa-public-key-file"; }
+
+    };
+
+    /**
+     * Whether or not the server public key should be automatically retreived from
+     * the MySQL server.
+     */
+    public static final BooleanGuacamoleProperty MYSQL_ALLOW_PUBLIC_KEY_RETRIEVAL =
+            new BooleanGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "mysql-allow-public-key-retrieval"; }
+
+    };
+
 }


### PR DESCRIPTION
These properties allow connecting to a MySQL 8.4+ database server. 

Either the public key can be retrieved from the server and set using the `mysql-server-rsa-public-key-file` property, or the public key can be automatically retrieved by setting the `mysql-allow-public-key-retrieval` property.