### PR TITLE
GUACAMOLE-926: Reorder "Import" button to end to avoid fighting muscle memory.

### DIFF
--- a/guacamole/src/main/frontend/src/app/settings/templates/settingsConnections.html
+++ b/guacamole/src/main/frontend/src/app/settings/templates/settingsConnections.html
@@ -9,10 +9,6 @@
         <!-- Form action buttons -->
         <div class="action-buttons">
 
-            <a class="import-connections button"
-                ng-show="canAdminister()"
-                href="#/import/{{dataSource | escape}}/connection/">{{'SETTINGS_CONNECTIONS.ACTION_IMPORT' | translate}}</a>
-
             <a class="add-connection button"
                ng-show="canCreateConnections()"
                href="#/manage/{{dataSource | escape}}/connections/">{{'SETTINGS_CONNECTIONS.ACTION_NEW_CONNECTION' | translate}}</a>
@@ -20,6 +16,10 @@
             <a class="add-connection-group button"
                ng-show="canCreateConnectionGroups()"
                href="#/manage/{{dataSource | escape}}/connectionGroups/">{{'SETTINGS_CONNECTIONS.ACTION_NEW_CONNECTION_GROUP' | translate}}</a>
+
+            <a class="import-connections button"
+                ng-show="canAdminister()"
+                href="#/import/{{dataSource | escape}}/connection/">{{'SETTINGS_CONNECTIONS.ACTION_IMPORT' | translate}}</a>
 
         </div>
 


### PR DESCRIPTION
Users that are used to the established Guacamole UI will be used to clicking the leftmost button when attempting to create a new connection, but the leftmost button has changed from "New Connection" to "Import".

This change restores that original button order, with "New Connection" being on the far left.