### PR TITLE
GUACAMOLE-577: guacConfigProxyHostname should be single-valued.

### DIFF
--- a/extensions/guacamole-auth-ldap/schema/guacConfigGroup.ldif
+++ b/extensions/guacamole-auth-ldap/schema/guacConfigGroup.ldif
@@ -26,6 +26,7 @@ olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.1 NAME 'guacConfigProtocol'
 olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.2 NAME 'guacConfigParameter'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.3 NAME 'guacConfigProxyHostname'
+  SINGLE-VALUE
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 olcAttributeTypes: ( 1.3.6.1.4.1.38971.1.1.4 NAME 'guacConfigProxyPort'
   SINGLE-VALUE

--- a/extensions/guacamole-auth-ldap/schema/guacConfigGroup.schema
+++ b/extensions/guacamole-auth-ldap/schema/guacConfigGroup.schema
@@ -24,6 +24,7 @@ attributetype ( 1.3.6.1.4.1.38971.1.1.2 NAME 'guacConfigParameter'
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
 attributetype ( 1.3.6.1.4.1.38971.1.1.3 NAME 'guacConfigProxyHostname'
+    SINGLE-VALUE
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
 attributetype ( 1.3.6.1.4.1.38971.1.1.4 NAME 'guacConfigProxyPort'

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/connection/ConnectionService.java
@@ -87,7 +87,7 @@ public class ConnectionService {
     public static final String LDAP_ATTRIBUTE_PROXY_PORT = "guacConfigProxyPort";
     
     /**
-     * The name of the LDAP attribute that stores guacd proxy hostname.
+     * The name of the LDAP attribute that stores guacd proxy encryption method.
      */
     public static final String LDAP_ATTRIBUTE_PROXY_ENCRYPTION = "guacConfigProxyEncryption";
 


### PR DESCRIPTION
Slight correction to the schema files - the proxy hostname attribute should be single-valued, similar to port and encryption method.

...and one comment that I caught that was incorrect...