### PR TITLE
GUACAMOLE-61: Strings for token names should be static.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/AbstractGuacamoleTunnelService.java
@@ -80,57 +80,57 @@ public abstract class AbstractGuacamoleTunnelService implements GuacamoleTunnelS
     /**
      * Logger for this class.
      */
-    private final Logger logger = LoggerFactory.getLogger(AbstractGuacamoleTunnelService.class);
+    private static final Logger logger = LoggerFactory.getLogger(AbstractGuacamoleTunnelService.class);
 
     /**
      * The prefix that will be used to generate JDBC tokens.
      */
-    private final String JDBC_TOKEN_PREFIX = "JDBC_";
+    private static final String JDBC_TOKEN_PREFIX = "JDBC_";
 
     /**
      * The token that contains the date the connection was started.
      */
-    private final String JDBC_DATE_TOKEN = JDBC_TOKEN_PREFIX + "STARTDATE";
+    private static final String JDBC_DATE_TOKEN = JDBC_TOKEN_PREFIX + "STARTDATE";
     
     /**
      * The format of the date in the date token.
      */
-    private final String JDBC_DATE_TOKEN_FORMAT = "yyyyMMdd";
+    private static final String JDBC_DATE_TOKEN_FORMAT = "yyyyMMdd";
     
     /**
      * The token that contains the start time of the connection.
      */
-    private final String JDBC_TIME_TOKEN = JDBC_TOKEN_PREFIX + "STARTTIME";
+    private static final String JDBC_TIME_TOKEN = JDBC_TOKEN_PREFIX + "STARTTIME";
     
     /**
      * The format of the time in the time token.
      */
-    private final String JDBC_TIME_TOKEN_FORMAT = "HHmmss";
+    private static final String JDBC_TIME_TOKEN_FORMAT = "HHmmss";
     
     /**
      * The token that contains the connection name.
      */
-    private final String JDBC_CONNECTION_NAME_TOKEN = JDBC_TOKEN_PREFIX + "CONNECTION_NAME";
+    private static final String JDBC_CONNECTION_NAME_TOKEN = JDBC_TOKEN_PREFIX + "CONNECTION_NAME";
     
     /**
      * The token that contains the connection identifier.
      */
-    private final String JDBC_CONNECTION_ID_TOKEN = JDBC_TOKEN_PREFIX + "CONNECTION_ID";
+    private static final String JDBC_CONNECTION_ID_TOKEN = JDBC_TOKEN_PREFIX + "CONNECTION_ID";
     
     /**
      * The token that contains the hostname configured in the connection parameters.
      */
-    private final String JDBC_CONNECTION_HOSTNAME_TOKEN = JDBC_TOKEN_PREFIX + "HOSTNAME";
+    private static final String JDBC_CONNECTION_HOSTNAME_TOKEN = JDBC_TOKEN_PREFIX + "HOSTNAME";
     
     /**
      * The name of the parameter containing the hostname in the configuration.
      */
-    private final String JDBC_CONNECTION_HOSTNAME_TOKEN_PARAMETER = "hostname";
+    private static final String JDBC_CONNECTION_HOSTNAME_TOKEN_PARAMETER = "hostname";
     
     /**
      * The token containing the protocol configured in the connection.
      */
-    private final String JDBC_CONNECTION_PROTOCOL_TOKEN = JDBC_TOKEN_PREFIX + "PROTOCOL";
+    private static final String JDBC_CONNECTION_PROTOCOL_TOKEN = JDBC_TOKEN_PREFIX + "PROTOCOL";
     
     /**
      * Mapper for accessing connections.


### PR DESCRIPTION
Coverity caught that I had failed to make the strings for defining the JDBC tokens `static`, so here's a quick fix for that.