### PR TITLE
GUACAMOLE-1239: Remove Environment binding from SSO base class.

### DIFF
--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/java/org/apache/guacamole/auth/sso/SSOAuthenticationProvider.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/java/org/apache/guacamole/auth/sso/SSOAuthenticationProvider.java
@@ -112,7 +112,6 @@ public abstract class SSOAuthenticationProvider extends AbstractAuthenticationPr
             protected void configure() {
 
                 bind(AuthenticationProvider.class).toInstance(SSOAuthenticationProvider.this);
-                bind(Environment.class).toInstance(LocalEnvironment.getInstance());
                 bind(SSOAuthenticationProviderService.class).to(authService);
 
                 // Bind custom SSOResource implementation if different from


### PR DESCRIPTION
Fixes an issue with duplicate bindings for the `Environment` class(es) in the SSO modules.