### PR TITLE
GUACAMOLE-1167: Add client support for choosing RDP gateway type.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -74,6 +74,11 @@
                     "type"  : "NUMERIC"
                 },
                 {
+                    "name"    : "gateway-type",
+                    "type"    : "ENUM",
+                    "options" : [ "", "rpc", "http", "auto" ]
+                },
+                {
                     "name"  : "gateway-username",
                     "type"  : "USERNAME"
                 },

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -610,6 +610,7 @@
         "FIELD_HEADER_GATEWAY_HOSTNAME" : "Hostname:",
         "FIELD_HEADER_GATEWAY_PASSWORD" : "Password:",
         "FIELD_HEADER_GATEWAY_PORT"     : "Port:",
+        "FIELD_HEADER_GATEWAY_TYPE"     : "Type:",
         "FIELD_HEADER_GATEWAY_USERNAME" : "Username:",
         "FIELD_HEADER_HEIGHT"          : "Height:",
         "FIELD_HEADER_HOSTNAME"        : "Hostname:",
@@ -672,6 +673,11 @@
         "FIELD_OPTION_COLOR_DEPTH_8"     : "256 color",
         "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
 
+        "FIELD_OPTION_GATEWAY_TYPE_AUTO"  : "Auto-select type",
+        "FIELD_OPTION_GATEWAY_TYPE_HTTP"  : "HTTP gateway",
+        "FIELD_OPTION_GATEWAY_TYPE_EMPTY" : "",
+        "FIELD_OPTION_GATEWAY_TYPE_RPC"   : "RPC gateway",
+            
         "FIELD_OPTION_RESIZE_METHOD_DISPLAY_UPDATE" : "\"Display Update\" virtual channel (RDP 8.1+)",
         "FIELD_OPTION_RESIZE_METHOD_EMPTY"          : "",
         "FIELD_OPTION_RESIZE_METHOD_RECONNECT"      : "Reconnect",


### PR DESCRIPTION
Client-side settings for apache/guacamole-server#559.