### PR TITLE
Adding Dvorak ES keyboard layout

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -109,6 +109,7 @@
                         "en-gb-qwerty",
                         "en-us-qwerty",
                         "es-es-qwerty",
+                        "es-es-dvorak",
                         "es-latam-qwerty",
                         "failsafe",
                         "fr-be-azerty",

--- a/guacamole/src/main/frontend/src/translations/ca.json
+++ b/guacamole/src/main/frontend/src/translations/ca.json
@@ -584,6 +584,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "Anglès del Regne Unit (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "Anglès dels Estats Units (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Espanyol (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Espanyol (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latino Americano (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Francès de Bèlgica (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/cs.json
+++ b/guacamole/src/main/frontend/src/translations/cs.json
@@ -666,6 +666,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "UK Angličtina (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US Angličtina (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Španělština (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Španělština (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Standardní Angličtina (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Belgická Francouzština (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/de.json
+++ b/guacamole/src/main/frontend/src/translations/de.json
@@ -657,6 +657,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "Englisch (GB) (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "Englisch (US) (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Spanisch (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Spanisch (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latein-Amerikanisch (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Französisch (Belgien) (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -690,6 +690,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "UK English (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US English (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Spanish (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Spanish (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latin American (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Belgian French (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/es.json
+++ b/guacamole/src/main/frontend/src/translations/es.json
@@ -555,6 +555,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY"    : "Inglés UK (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY"    : "Inglés US (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY"    : "Español (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK"    : "Español (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latin American (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"        : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY"    : "Francés Belga (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/fr.json
+++ b/guacamole/src/main/frontend/src/translations/fr.json
@@ -685,6 +685,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "Anglais UK (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "Anglais US (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Enspagnol (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Enspagnol (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latino-Américain (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Français Belge (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/ko.json
+++ b/guacamole/src/main/frontend/src/translations/ko.json
@@ -544,6 +544,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "UK English (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US English (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Spanish (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Spanish (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latin American (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Belgian French (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/pl.json
+++ b/guacamole/src/main/frontend/src/translations/pl.json
@@ -583,6 +583,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "UK Angielski (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US Angielski (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Hiszpański (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Hiszpański (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latynoamerykański (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Belgijski Francuski (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/pt.json
+++ b/guacamole/src/main/frontend/src/translations/pt.json
@@ -553,6 +553,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "Inglês UK (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "Inglês US (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Espanhol (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Espanhol (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "América Latina (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Francês Belga (Azerty)",

--- a/guacamole/src/main/frontend/src/translations/zh.json
+++ b/guacamole/src/main/frontend/src/translations/zh.json
@@ -663,6 +663,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_EN_GB_QWERTY" : "UK English (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_EN_US_QWERTY" : "US English (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_ES_QWERTY" : "Spanish (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_ES_ES_DVORAK" : "Spanish (Dvorak)",
         "FIELD_OPTION_SERVER_LAYOUT_ES_LATAM_QWERTY" : "Latin American (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_FAILSAFE"     : "Unicode",
         "FIELD_OPTION_SERVER_LAYOUT_FR_BE_AZERTY" : "Belgian French (Azerty)",


### PR DESCRIPTION
Adding support for Spanish Dvorak keyboard layout included in Ubuntu distributions.