### PR TITLE
GUACAMOLE-2005: FIlter out batches that ended up not having any keystroke events.

### DIFF
--- a/guacamole/src/main/frontend/src/app/player/services/keyEventDisplayService.js
+++ b/guacamole/src/main/frontend/src/app/player/services/keyEventDisplayService.js
@@ -361,8 +361,8 @@ angular.module('player').factory('keyEventDisplayService',
 
         });
 
-        // All processed batches
-        return batches;
+        // All processed batches with events
+        return batches.filter(batch => batch.events.length > 0);
 
     };
 


### PR DESCRIPTION
Timestamps of key events within the “Keystroke Log” UI will sometimes show as “0:00”, even though there are no associated details displayed and such a timestamp would be in the past.

This is caused by batches that get created but end up not having any events completed within the `batchSeparation` time frame.