### PR TITLE
GUACAMOLE-1239: Fix RADIUS extension build.

### DIFF
--- a/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/user/AuthenticatedUser.java
+++ b/extensions/guacamole-auth-radius/src/main/java/org/apache/guacamole/auth/radius/user/AuthenticatedUser.java
@@ -23,8 +23,6 @@ import com.google.inject.Inject;
 import org.apache.guacamole.net.auth.AbstractAuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An RADIUS-specific implementation of AuthenticatedUser, associating a
@@ -33,23 +31,12 @@ import org.slf4j.LoggerFactory;
 public class AuthenticatedUser extends AbstractAuthenticatedUser {
 
     /**
-     * Logger for this class.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticatedUser.class);
-    
-    /**
      * Reference to the authentication provider associated with this
      * authenticated user.
      */
     @Inject
     private AuthenticationProvider authProvider;
     
-    /**
-     * A reference to the configuration service associated with this module.
-     */
-    @Inject
-    private ConfigurationService confService;
-
     /**
      * The credentials provided when this user was authenticated.
      */


### PR DESCRIPTION
There was an outstanding reference to `ConfigurationService` that needed to be removed. This change also removes the unused `Logger`.