### PR TITLE
GUACAMOLE-925: Add Russian keymap support "ru-ru-qwerty"

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -123,6 +123,7 @@
                         "pt-br-qwerty",
                         "pt-pt-qwerty",
                         "ro-ro-qwerty",
+                        "ru-ru-qwerty",
                         "sv-se-qwerty",
                         "da-dk-qwerty",
                         "tr-tr-qwerty"

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -704,6 +704,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_PT_BR_QWERTY" : "Portuguese Brazilian (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_PT_PT_QWERTY" : "Portuguese (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_RO_RO_QWERTY" : "Romanian (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_RU_RU_QWERTY" : "Russian (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Swedish (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_TR_TR_QWERTY" : "Turkish-Q (Qwerty)",
 

--- a/guacamole/src/main/frontend/src/translations/ru.json
+++ b/guacamole/src/main/frontend/src/translations/ru.json
@@ -43,7 +43,7 @@
         "INFO_ACTIVE_USER_COUNT" : "Сейчас в системе {USERS} {USERS, plural, one{пользователь} few{пользователя} many{пользователей} other{пользователя}}.",
 
         "TEXT_ANONYMOUS_USER"   : "Аноним",
-        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{секунда} few{секуны} many{секунд} other{секуны}}} minute{{VALUE, plural, one{минута} few{минуты} many{минут} other{минуты}}} hour{{VALUE, plural, one{час} few{часа} many{часов} other{часа}}} day{{VALUE, plural, one{день} few{дня} many{дней} other{дня}}} other{}}"
+        "TEXT_HISTORY_DURATION" : "{VALUE} {UNIT, select, second{{VALUE, plural, one{секунда} few{секунды} many{секунд} other{секунды}}} minute{{VALUE, plural, one{минута} few{минуты} many{минут} other{минуты}}} hour{{VALUE, plural, one{час} few{часа} many{часов} other{часа}}} day{{VALUE, plural, one{день} few{дня} many{дней} other{дня}}} other{}}"
 
     },
 


### PR DESCRIPTION
The parameter "ru-ru-qwerty" has been added to the "guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json" file to support the Russian keyboard layout.
The parameter "FIELD_OPTION_SERVER_LAYOUT_RU_RU_QWERTY" : "Russian (Qwerty)" has been added to the "guacamole/src/main/frontend/src/translations/en.json" file to support the Russian keyboard layout.

I added the "Ё" character to support the Russian keyboard layout and corrected the missing comma in the configuration file. Everything is working correctly in the current build of the application.