### PR TITLE
GUACAMOLE-377: Revert to synchronous flush (asynchronous is slower).

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Display.js
+++ b/guacamole-common-js/src/main/webapp/modules/Display.js
@@ -186,19 +186,6 @@ Guacamole.Display = function() {
     var frames = [];
 
     /**
-     * The ID of the animation frame request returned by the last call to
-     * requestAnimationFrame(). This value will only be set if the browser
-     * supports requestAnimationFrame(), if a frame render is currently
-     * pending, and if the current browser tab is currently focused (likely to
-     * handle requests for animation frames). In all other cases, this will be
-     * null.
-     *
-     * @private
-     * @type {number}
-     */
-    var inProgressFrame = null;
-
-    /**
      * Flushes all pending frames synchronously. This function will block until
      * all pending frames have rendered. If a frame is currently blocked by an
      * asynchronous operation like an image load, this function will return
@@ -236,45 +223,6 @@ Guacamole.Display = function() {
 
         if (rendered_frames)
             notifyFlushed(localTimestamp, remoteTimestamp, renderedLogicalFrames);
-
-    };
-
-    /**
-     * Flushes all pending frames asynchronously. This function returns
-     * immediately, relying on requestAnimationFrame() to dictate when each
-     * frame should be flushed.
-     *
-     * @private
-     */
-    var asyncFlush = function asyncFlush() {
-
-        var continueFlush = function continueFlush() {
-
-            // We're no longer waiting to render a frame
-            inProgressFrame = null;
-
-            // Nothing to do if there are no frames remaining
-            if (!frames.length)
-                return;
-
-            // Flush the next frame only if it is ready (not awaiting
-            // completion of some asynchronous operation like an image load)
-            if (frames[0].isReady()) {
-                var frame = frames.shift();
-                frame.flush();
-                notifyFlushed(frame.localTimestamp, frame.remoteTimestamp, frame.logicalFrames);
-            }
-
-            // Request yet another animation frame if frames remain to be
-            // flushed
-            if (frames.length)
-                inProgressFrame = window.requestAnimationFrame(continueFlush);
-
-        };
-
-        // Begin flushing frames if not already waiting to render a frame
-        if (!inProgressFrame)
-            inProgressFrame = window.requestAnimationFrame(continueFlush);
 
     };
 
@@ -373,33 +321,12 @@ Guacamole.Display = function() {
 
     };
 
-    // Switch from asynchronous frame handling to synchronous frame handling if
-    // requestAnimationFrame() is unlikely to be usable (browsers may not
-    // invoke the animation frame callback if the relevant tab is not focused)
-    window.addEventListener('blur', function switchToSyncFlush() {
-        if (inProgressFrame && !document.hasFocus()) {
-
-            // Cancel pending asynchronous processing of frame ...
-            window.cancelAnimationFrame(inProgressFrame);
-            inProgressFrame = null;
-
-            // ... and instead process it synchronously
-            syncFlush();
-
-        }
-    }, true);
-
     /**
      * Flushes all pending frames.
      * @private
      */
     function __flush_frames() {
-
-        if (window.requestAnimationFrame && document.hasFocus())
-            asyncFlush();
-        else
-            syncFlush();
-
+        syncFlush();
     }
 
     /**


### PR DESCRIPTION
This partly reverts the changes introduced by d6db8fac7ea01d8a6a4a8c2b8bc84b66be4fb471 (#681), restoring the previous client-side frame handling.

The new asynchronous flush mechanism leveraging `requestAnimationFrame()` does not perform as well as the old synchronous flush. This appears to be due to delays in when the browser actually allows the frame to proceed, which cause the client to lag behind.

A future change that could improve things further might be to process graphical changes in a WebWorker when available.