### PR TITLE
GUACAMOLE-2018: Convert layer to canvas during exportState() only if layer is non-empty.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -194,7 +194,6 @@ Guacamole.Client = function(tunnel) {
 
                 var index = parseInt(key);
                 var layer = layersSnapshot[key];
-                var canvas = layer.toCanvas();
 
                 // Store layer/buffer dimensions
                 var exportLayer = {
@@ -203,8 +202,10 @@ Guacamole.Client = function(tunnel) {
                 };
 
                 // Store layer/buffer image data, if it can be generated
-                if (layer.width && layer.height)
+                if (layer.width && layer.height) {
+                    var canvas = layer.toCanvas();
                     exportLayer.url = canvas.toDataURL('image/png');
+                }
 
                 // Add layer properties if not a buffer nor the default layer
                 if (index > 0) {


### PR DESCRIPTION
A `<canvas>` cannot have a width or height of zero. We _do_ have a check for this, but we're actually still calling `toCanvas()` regardless of that check, breaking playback of session recordings depending on the content of the recording.

This change corrects this by moving the call to `toCanvas()` such that it only occurs if the layer has non-zero width and height.