### PR TITLE
GUACAMOLE-2020: Allow hiding the display statistics bar.

### DIFF
--- a/extensions/guacamole-display-statistics/src/main/resources/directives/guacClientStatistics.js
+++ b/extensions/guacamole-display-statistics/src/main/resources/directives/guacClientStatistics.js
@@ -101,6 +101,9 @@ angular.module('client').directive('guacClientStatistics', [function guacClientS
                 $scope.client.managedDisplay.display.onstatistics = null;
         });
 
+        // Display statistics by default
+        $scope.isVisible = true;
+
     }];
 
     return directive;

--- a/extensions/guacamole-display-statistics/src/main/resources/styles/clientStatistics.css
+++ b/extensions/guacamole-display-statistics/src/main/resources/styles/clientStatistics.css
@@ -23,6 +23,39 @@ guac-client-statistics {
     background: #111;
 }
 
+guac-client-statistics div.buttons-statistics {
+    content: '';
+    cursor: pointer;
+    display: block;
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: center center;
+    height: 15px;
+    position: absolute;
+}
+
+guac-client-statistics div.hide-statistics {
+    background-image: url('images/x.svg');
+    bottom: 10px;
+    right: 20px;
+    width: 15px;
+}
+
+guac-client-statistics div.show-statistics {
+    background-color: #888;
+    background-image: url('images/arrows/up.svg');
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    bottom: 0;
+    left: 50%;
+    margin-left: -15px;
+    opacity: .5;
+    width: 30px;
+}
+
+guac-client-statistics div.show-statistics:hover {
+    background-color: #FFF;
+}
+
 guac-client-statistics dl.client-statistics {
     display: table;
     margin: 0;

--- a/extensions/guacamole-display-statistics/src/main/resources/templates/guacClientStatistics.html
+++ b/extensions/guacamole-display-statistics/src/main/resources/templates/guacClientStatistics.html
@@ -1,4 +1,4 @@
-<dl class="client-statistics">
+<dl class="client-statistics" ng-show="isVisible">
 
     <dt class="client-statistic desktop-fps">
         {{ 'CLIENT.FIELD_HEADER_DESKTOP_FRAMERATE' | translate }}
@@ -37,3 +37,8 @@
     </dd>
 
 </dl>
+
+<div class="buttons-statistics"
+     ng-click="isVisible = !isVisible"
+     ng-class="{ 'hide-statistics' : isVisible, 'show-statistics' : !isVisible }">
+</div>


### PR DESCRIPTION
Add a close button:
![image](https://github.com/user-attachments/assets/68fb294e-da39-43d0-a703-34a6658c0fe4)

Show statistics bar again:
![image](https://github.com/user-attachments/assets/90357204-4eeb-482e-b89e-8b8c9b8ad52e)
