### PR TITLE
GUACAMOLE-2021: Fix session recording playback heatmap for short videos.

### DIFF
--- a/guacamole/src/main/frontend/src/app/player/services/playerHeatmapService.js
+++ b/guacamole/src/main/frontend/src/app/player/services/playerHeatmapService.js
@@ -218,7 +218,7 @@ angular.module('player').factory('playerHeatmapService', [() => {
         const bucketDuration = duration / NUM_BUCKETS;
 
         // The rate-limited maximum number of events that any bucket can have,
-        const maxPossibleBucketValue = Math.floor(bucketDuration * maxRate);
+        const maxPossibleBucketValue = Math.max(Math.floor(bucketDuration * maxRate), 1);
 
         // If the duration is invalid, return the still-empty array
         if (duration <= 0)


### PR DESCRIPTION
I believe we can simply limit minimum `maxPossibleBucketValue` to 1 instead of having variable `NUM_BUCKETS`.