### PR TITLE
GUACAMOLE-2023: Add Czech keyboard layout to client

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -104,6 +104,7 @@
                     "type"    : "ENUM",
                     "options" : [
                         "",
+                        "cs-cz-qwertz",
                         "de-ch-qwertz",
                         "de-de-qwertz",
                         "en-gb-qwerty",

--- a/guacamole/src/main/frontend/src/translations/ca.json
+++ b/guacamole/src/main/frontend/src/translations/ca.json
@@ -581,6 +581,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "TLS encryption",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Txec (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Danès (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Suís alemany (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Alemany (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/cs.json
+++ b/guacamole/src/main/frontend/src/translations/cs.json
@@ -662,6 +662,7 @@
         "FIELD_OPTION_SECURITY_TLS"       : "Šifrování TLS",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Čeština (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Dánština (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Švícarská Němčina (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Němčina (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/de.json
+++ b/guacamole/src/main/frontend/src/translations/de.json
@@ -653,6 +653,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "TLS Verschlüsselung",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Tschechisch (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Dänisch (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Deutsch (Schweiz) (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Deutsch (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -686,6 +686,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "TLS encryption",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Czech (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Danish (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Swiss German (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "German (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/es.json
+++ b/guacamole/src/main/frontend/src/translations/es.json
@@ -551,6 +551,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "Encriptación TLS",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ"    : "Checo (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY"    : "Danés (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ"    : "Alemán Suizo (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ"    : "Alemán (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/fr.json
+++ b/guacamole/src/main/frontend/src/translations/fr.json
@@ -681,6 +681,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "Chiffrement TLS",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Tchèque (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Danois (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Suisse Allemand (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Allemand (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/ko.json
+++ b/guacamole/src/main/frontend/src/translations/ko.json
@@ -541,6 +541,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "TLS 암호화",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Czech (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Danish (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Swiss German (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "German (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/pl.json
+++ b/guacamole/src/main/frontend/src/translations/pl.json
@@ -579,6 +579,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "szyfrowanie TLS",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Czeski (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Duński (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Szwajcarski Niemiecki (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Niemiecki (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/pt.json
+++ b/guacamole/src/main/frontend/src/translations/pt.json
@@ -549,6 +549,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "Encriptação TLS",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Tcheco (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Dinamarquês (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Alemão-Suiço (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "Alemão (Qwertz)",

--- a/guacamole/src/main/frontend/src/translations/zh.json
+++ b/guacamole/src/main/frontend/src/translations/zh.json
@@ -659,6 +659,7 @@
         "FIELD_OPTION_SECURITY_TLS"   : "TLS 加密",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
 
+        "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Czech (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Danish (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_CH_QWERTZ" : "Swiss German (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DE_DE_QWERTZ" : "German (Qwertz)",


### PR DESCRIPTION
Add Czech keyboard layout to client connected to https://issues.apache.org/jira/browse/GUACAMOLE-1708