### PR TITLE
GUACAMOLE-2030: Fix KSM static token mapping for per-user config.

### DIFF
--- a/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
+++ b/extensions/guacamole-vault/modules/guacamole-vault-ksm/src/main/java/org/apache/guacamole/vault/ksm/secret/KsmClient.java
@@ -651,25 +651,19 @@ public class KsmClient {
 
         }
 
-        // Unfortunately, the notation parser within the Keeper SDK throws
-        // plain Errors for retrieval failures ...
-        catch (Error e) {
-            logger.warn("Record \"{}\" does not exist.", notation);
+        // Unfortunately, the notation parser within the Keeper SDK
+        // only throws plain Errors and Exceptions.
+        // There is no way to differentiate if an error is caused by
+        // a non-existing record or a pure parse failure.
+        catch (Error | Exception e) {
+            logger.warn("Keeper notation \"{}\" could not be resolved "
+                    + "to a record: {}", notation, e.getMessage());
             logger.debug("Retrieval of record by Keeper notation failed.", e);
 
             // If the secret is not found, invoke the fallback function
             if (fallbackFunction != null)
                 return fallbackFunction.get();
 
-            return CompletableFuture.completedFuture(null);
-        }
-
-        // ... and plain Exceptions for parse failures (no subclasses)
-        catch (Exception e) {
-            logger.warn("\"{}\" is not valid Keeper notation. Please check "
-                    + "the documentation at {} for valid formatting.",
-                    notation, KEEPER_NOTATION_DOC_URL);
-            logger.debug("Provided Keeper notation could not be parsed.", e);
             return CompletableFuture.completedFuture(null);
         }
         finally {


### PR DESCRIPTION
Fixes the issue plus changes log messages for this case:
`16:52:41.850 [http-nio-8080-exec-10] WARN  o.a.g.vault.ksm.secret.KsmClient - "keeper://XXX/field/login" could not be resolved: Record 'XXX' not found`
`16:52:42.442 [http-nio-8080-exec-10] WARN  o.a.g.vault.ksm.secret.KsmClient - "keeper://XXX/field/password" could not be resolved: Record 'XXX' not found`