### PR TITLE
GUACAMOLE-2036: Reuse buffers received by parser when converting instructions back to character arrays.

### DIFF
--- a/guacamole-common/src/main/java/org/apache/guacamole/io/ReaderGuacamoleReader.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/io/ReaderGuacamoleReader.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.Reader;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.util.Arrays;
 import org.apache.guacamole.GuacamoleConnectionClosedException;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
@@ -92,7 +91,7 @@ public class ReaderGuacamoleReader implements GuacamoleReader {
         if (instruction == null)
             return null;
 
-        return instruction.toString().toCharArray();
+        return instruction.toCharArray();
     }
 
     @Override

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleParser.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleParser.java
@@ -109,6 +109,18 @@ public class GuacamoleParser implements Iterator<GuacamoleInstruction> {
     private final String elements[] = new String[INSTRUCTION_MAX_ELEMENTS];
 
     /**
+     * A copy of the raw protocol data that has been parsed for the current
+     * instruction. This value is maintained by {@link #append(char[], int, int)}.
+     */
+    private final char rawInstruction[] = new char[INSTRUCTION_MAX_LENGTH];
+
+    /**
+     * The offset within {@link #rawInstruction} that new data should be
+     * appended. This value is maintained by {@link #append(char[], int, int)}.
+     */
+    private int rawInstructionOffset = 0;
+
+    /**
      * Appends data from the given buffer to the current instruction.
      * 
      * @param chunk
@@ -129,6 +141,71 @@ public class GuacamoleParser implements Iterator<GuacamoleInstruction> {
      *     If an error occurs while parsing the new data.
      */
     public int append(char chunk[], int offset, int length) throws GuacamoleException {
+
+        int originalOffset = offset;
+        int originalLength = length;
+
+        // Process as much of the received chunk as possible
+        while (length > 0) {
+
+            int appended = processElement(chunk, offset, length);
+            if (appended == 0)
+                break;
+
+            length -= appended;
+            offset += appended;
+        }
+
+        // Update the raw copy of the received instruction with whatever data
+        // has now been processed
+        int charsParsed = originalLength - length;
+        if (charsParsed > 0) {
+
+            System.arraycopy(chunk, originalOffset, rawInstruction, rawInstructionOffset, charsParsed);
+            rawInstructionOffset += charsParsed;
+
+            // If the instruction is now complete, we're good to store the
+            // parsed instruction for future retrieval via next()
+            if (state == State.COMPLETE) {
+                parsedInstruction = new GuacamoleInstruction(elements[0], Arrays.asList(elements).subList(1, elementCount),
+                        Arrays.copyOf(rawInstruction, rawInstructionOffset));
+                rawInstructionOffset = 0;
+            }
+
+        }
+
+        return charsParsed;
+
+    }
+
+    /**
+     * Processes additional data from the given buffer, potentially adding
+     * another element to the current instruction being parsed. This function
+     * will need to be invoked multiple times per instruction until all data
+     * for that instruction is ready.
+     * <p>
+     * This function DOES NOT update {@link #parsedInstruction}. The caller
+     * ({@link #append(char[], int, int)}) must update this as necessary when
+     * the parser {@link #state} indicates the instruction is complete.
+     *
+     * @param chunk
+     *     The buffer containing the data to append.
+     *
+     * @param offset
+     *     The offset within the buffer where the data begins.
+     *
+     * @param length
+     *     The length of the data to append.
+     *
+     * @return
+     *     The number of characters appended, or 0 if complete instructions
+     *     have already been parsed and must be read via next() before more
+     *     data can be appended.
+     *
+     * @throws GuacamoleException
+     *     If an error occurs while parsing the new data.
+     */
+    private int processElement(char chunk[], int offset, int length) throws GuacamoleException {
 
         int charsParsed = 0;
 
@@ -215,8 +292,6 @@ public class GuacamoleParser implements Iterator<GuacamoleInstruction> {
                 // If semicolon, store end-of-instruction
                 case ';':
                     state = State.COMPLETE;
-                    parsedInstruction = new GuacamoleInstruction(elements[0],
-                            Arrays.asList(elements).subList(1, elementCount));
                     break;
 
                 // If comma, move on to next element


### PR DESCRIPTION
This change builds on the changes from @aleitner via #1057, optimizing for the common case where a parsed `GuacamoleInstruction` must be converted back into Guacamole protocol and re-sent. With these changes, performance of both `read()` and `readInstruction()` are identical, and both exceed the performance of past releases.

For benchmarks and further context, see [the final review comment on PR #1057](https://github.com/apache/guacamole-client/pull/1057#pullrequestreview-2642357246).