### PR TITLE
GUACAMOLE-2036: Refactor away public constructor accepting internal char array.

### DIFF
--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleInstruction.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleInstruction.java
@@ -94,34 +94,6 @@ public class GuacamoleInstruction {
     }
 
     /**
-     * Creates a new GuacamoleInstruction having the given opcode, list of
-     * argument values, and underlying protocol representation. The list given
-     * will be used to back the internal list of arguments and the list
-     * returned by {@link #getArgs()}. The provided protocol representation
-     * will be used to back the internal protocol representation and values
-     * returned by {@link #toCharArray()} and {@link #toString()}.
-     * <p>
-     * Neither the provided argument list nor the provided protocol
-     * representation may be modified in any way after being provided to this
-     * constructor. Doing otherwise will result in undefined behavior.
-     *
-     * @param opcode
-     *     The opcode of the instruction to create.
-     *
-     * @param args
-     *     The list of argument values to provide in the new instruction, if
-     *     any.
-     *
-     * @param raw
-     *     The underlying representation of this instruction as would be sent
-     *     over the network via the Guacamole protocol.
-     */
-    public GuacamoleInstruction(String opcode, List<String> args, char[] raw) {
-        this(opcode, args);
-        this.rawChars = raw;
-    }
-
-    /**
      * Returns the opcode associated with this GuacamoleInstruction.
      *
      * @return

--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleParser.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleParser.java
@@ -21,6 +21,7 @@ package org.apache.guacamole.protocol;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 
@@ -121,6 +122,62 @@ public class GuacamoleParser implements Iterator<GuacamoleInstruction> {
     private int rawInstructionOffset = 0;
 
     /**
+     * GuacamoleInstruction that efficiently exposes the originally parsed
+     * character buffer for calls to {@link #toString()} and {@link #toCharArray()}
+     * rather than regenerate the buffer from scratch.
+     */
+    private static class ParsedGuacamoleInstruction extends GuacamoleInstruction {
+
+        /**
+         * The original data parsed to produce this GuacamoleInstruction.
+         */
+        private final char[] rawChars;
+
+        /**
+         * A String containing the original data parsed to produce this
+         * GuacamoleInstruction.
+         */
+        private String rawString = null;
+
+        /**
+         * Creates a new GuacamoleInstruction that efficiently exposes the
+         * originally parsed character buffer rather than regenerating that
+         * buffer from scratch for {@link #toString()} and {@link #toCharArray()}.
+         *
+         * @param opcode
+         *     The opcode of the instruction to create.
+         *
+         * @param args
+         *     The list of argument values to provide in the new instruction, if
+         *     any.
+         *
+         * @param raw
+         *     The underlying representation of this instruction as would be sent
+         *     over the network via the Guacamole protocol.
+         */
+        public ParsedGuacamoleInstruction(String opcode, List<String> args, char[] raw) {
+            super(opcode, args);
+            this.rawChars = raw;
+        }
+
+        @Override
+        public String toString() {
+
+            if (rawString == null)
+                rawString = new String(rawChars);
+
+            return rawString;
+
+        }
+
+        @Override
+        public char[] toCharArray() {
+            return rawChars;
+        }
+
+    }
+
+    /**
      * Appends data from the given buffer to the current instruction.
      * 
      * @param chunk
@@ -167,7 +224,8 @@ public class GuacamoleParser implements Iterator<GuacamoleInstruction> {
             // If the instruction is now complete, we're good to store the
             // parsed instruction for future retrieval via next()
             if (state == State.COMPLETE) {
-                parsedInstruction = new GuacamoleInstruction(elements[0], Arrays.asList(elements).subList(1, elementCount),
+                parsedInstruction = new ParsedGuacamoleInstruction(elements[0],
+                        Arrays.asList(elements).subList(1, elementCount),
                         Arrays.copyOf(rawInstruction, rawInstructionOffset));
                 rawInstructionOffset = 0;
             }


### PR DESCRIPTION
This change improves on #1063 a bit, removing the need to alter the public API to support the internals of `GuacamoleParser`.