### PR TITLE
GUACAMOLE-2036: Increase the number of max elements to match guacamole server.

### DIFF
--- a/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleParser.java
+++ b/guacamole-common/src/main/java/org/apache/guacamole/protocol/GuacamoleParser.java
@@ -44,7 +44,7 @@ public class GuacamoleParser implements Iterator<GuacamoleInstruction> {
     /**
      * The maximum number of elements per instruction, including the opcode.
      */
-    public static final int INSTRUCTION_MAX_ELEMENTS = 64;
+    public static final int INSTRUCTION_MAX_ELEMENTS = 128;
 
     /**
      * All possible states of the instruction parser.


### PR DESCRIPTION
In guacamole-server `GUAC_INSTRUCTION_MAX_ELEMENTS` is defined as 128. In guacamole-client, `INSTRUCTION_MAX_ELEMENTS` is still 64. 