### PR TITLE
GUACAMOLE-1746: Docker Allow usage of custom keystore and custom certificat and GUACAMOLE-1524: Importing LDAPS certificate into docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,10 +96,12 @@ RUN useradd --system --create-home --shell /usr/sbin/nologin --uid $UID --gid $G
 # Run with user guacamole
 USER guacamole
 
-# Environment variable defaults
+# Environment variable defaults (JAVA_KEYSTORE_FILE is relative to guacamole home )
 ENV BAN_ENABLED=true \
     ENABLE_FILE_ENVIRONMENT_PROPERTIES=true \
-    GUACAMOLE_HOME=/etc/guacamole
+    GUACAMOLE_HOME=/etc/guacamole \
+    JAVA_KEYSTORE_FILE=cacert \
+    JAVA_KEYSTORE_PASS=changeit
 
 # Start Guacamole under Tomcat, listening on 0.0.0.0:8080
 EXPOSE 8080

--- a/guacamole-docker/entrypoint.d/100-generate-guacamole-home.sh
+++ b/guacamole-docker/entrypoint.d/100-generate-guacamole-home.sh
@@ -99,7 +99,7 @@ fi
 #
 export JAVA_KEYSTORE_FILE=$GUACAMOLE_HOME/$JAVA_KEYSTORE_FILE
 keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore $JAVA_KEYSTORE_FILE -deststorepass $JAVA_KEYSTORE_PASS -noprompt
-export JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${JAVA_KEYSTORE_FILE}"
+export JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${JAVA_KEYSTORE_FILE} -Djavax.net.ssl.trustStorePassword=${JAVA_KEYSTORE_PASS}"
 
 # Enable reading of properties directly from environment variables unless
 # overridden

--- a/guacamole-docker/entrypoint.d/100-generate-guacamole-home.sh
+++ b/guacamole-docker/entrypoint.d/100-generate-guacamole-home.sh
@@ -94,6 +94,13 @@ if [ -e "$GUACAMOLE_HOME_TEMPLATE" ]; then
 
 fi
 
+#
+# Create JVM keystore by copying the default in JAVA_HOME
+#
+export JAVA_KEYSTORE_FILE=$GUACAMOLE_HOME/$JAVA_KEYSTORE_FILE
+keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore $JAVA_KEYSTORE_FILE -deststorepass $JAVA_KEYSTORE_PASS -noprompt
+export JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${JAVA_KEYSTORE_FILE}"
+
 # Enable reading of properties directly from environment variables unless
 # overridden
 if ! is_property_set "enable-environment-properties"; then

--- a/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
+++ b/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
@@ -32,5 +32,5 @@
 CERT_PATH="EXTRA_CACERT_$(echo "searchPath" | sed 's/\([a-z]\)\([A-Z]\)/\1_\2/g' | tr 'a-z' 'A-Z')"
 
 for cert_fn in `find ${!CERT_PATH} -name "*.crt"`; do
-    keytool -importcert -file $cert_fn -alias $(basename $cert_fn) -storepass changeit -noprompt -keystore $JAVA_HOME/lib/security/cacerts || true
+    keytool -importcert -file $cert_fn -alias $(basename $cert_fn) -keystore $JAVA_KEYSTORE_FILE -storepass $JAVA_KEYSTORE_PASS -noprompt || true
 done

--- a/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
+++ b/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+##
+## @fn EXTRA_CACERT_/configure.sh
+##
+## Configures Tomcat to import additional CA certificates if
+## the EXTRA_CACERT_ENABLED environment variable is set to "true".
+##
+
+##
+## Search pach for additional CA certificates MUST be specified in
+## EXTRA_CACERT_SEARCH_PATH environment variables. 
+## CA certificates MUST have an extension of .crt
+##
+CERT_PATH="EXTRA_CACERT_$(echo "searchPath" | sed 's/\([a-z]\)\([A-Z]\)/\1_\2/g' | tr 'a-z' 'A-Z')"
+
+for cert_fn in `find $CERT_PATH -name "*.crt"`; do
+    keytool -importcert -file $cert_fn -alias $(basename $cert_fn) -storepass changeit -noprompt -keystore $JAVA_HOME/jre/lib/security/cacerts || true
+done

--- a/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
+++ b/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
@@ -32,5 +32,5 @@
 CERT_PATH="EXTRA_CACERT_$(echo "searchPath" | sed 's/\([a-z]\)\([A-Z]\)/\1_\2/g' | tr 'a-z' 'A-Z')"
 
 for cert_fn in `find $CERT_PATH -name "*.crt"`; do
-    keytool -importcert -file $cert_fn -alias $(basename $cert_fn) -storepass changeit -noprompt -keystore $JAVA_HOME/jre/lib/security/cacerts || true
+    keytool -importcert -file $cert_fn -alias $(basename $cert_fn) -storepass changeit -noprompt -keystore $JAVA_HOME/lib/security/cacerts || true
 done

--- a/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
+++ b/guacamole-docker/environment/EXTRA_CACERT_/configure.sh
@@ -31,6 +31,6 @@
 ##
 CERT_PATH="EXTRA_CACERT_$(echo "searchPath" | sed 's/\([a-z]\)\([A-Z]\)/\1_\2/g' | tr 'a-z' 'A-Z')"
 
-for cert_fn in `find $CERT_PATH -name "*.crt"`; do
+for cert_fn in `find ${!CERT_PATH} -name "*.crt"`; do
     keytool -importcert -file $cert_fn -alias $(basename $cert_fn) -storepass changeit -noprompt -keystore $JAVA_HOME/lib/security/cacerts || true
 done


### PR DESCRIPTION
This PR takes over 
- https://github.com/apache/guacamole-client/pull/694
- https://github.com/apache/guacamole-client/pull/805