### PR TITLE
GUACAMOLE-2045: Add ability to force prompting for missing credentials

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -51,6 +51,11 @@
                     "options" : [ "true" ]
                 },
                 {
+                    "name"    : "always-prompt-for-credentials",
+                    "type"    : "BOOLEAN",
+                    "options" : [ "true" ]
+                },
+                {
                     "name"    : "cert-tofu",
                     "type"    : "BOOLEAN",
                     "options" : [ "true" ]

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -624,6 +624,7 @@
         "FIELD_HEADER_HEIGHT"          : "Height:",
         "FIELD_HEADER_HOSTNAME"        : "Hostname:",
         "FIELD_HEADER_IGNORE_CERT"     : "Ignore server certificate:",
+        "FIELD_HEADER_ALWAYS_PROMPT_FOR_CREDENTIALS": "Prompt for credentials in browser form:",
         "FIELD_HEADER_INITIAL_PROGRAM" : "Initial program:",
         "FIELD_HEADER_LOAD_BALANCE_INFO" : "Load balance info/cookie:",
         "FIELD_HEADER_NORMALIZE_CLIPBOARD" : "Line endings:",


### PR DESCRIPTION
Supports the following PR: https://github.com/apache/guacamole-server/pull/580