### PR TITLE
GUACAMOLE-839: Ensure all SSO and related mechanisms set Credentials username.

### DIFF
--- a/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-header/src/main/java/org/apache/guacamole/auth/header/AuthenticationProviderService.java
@@ -66,9 +66,15 @@ public class AuthenticationProviderService {
         // Get the username from the header configured in guacamole.properties
         String username = credentials.getHeader(confService.getHttpAuthHeader());
         if (username != null) {
+
+            // Update credentials with username provided via header for sake of
+            // ${GUAC_USERNAME} token
+            credentials.setUsername(username);
+
             AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
             authenticatedUser.init(username, credentials);
             return authenticatedUser;
+
         }
 
         // Authentication not provided via header, yet, so we request it.

--- a/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-json/src/main/java/org/apache/guacamole/auth/json/AuthenticationProviderService.java
@@ -76,6 +76,10 @@ public class AuthenticationProviderService {
         if (userData == null)
             throw new GuacamoleInvalidCredentialsException("Permission denied.", CredentialsInfo.EMPTY);
 
+        // Update credentials with username provided via JSON for sake of
+        // ${GUAC_USERNAME} token
+        credentials.setUsername(userData.getUsername());
+
         // Produce AuthenticatedUser associated with derived UserData
         AuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
         authenticatedUser.init(credentials, userData);

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/java/org/apache/guacamole/auth/sso/user/SSOAuthenticatedUser.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-base/src/main/java/org/apache/guacamole/auth/sso/user/SSOAuthenticatedUser.java
@@ -60,14 +60,17 @@ public class SSOAuthenticatedUser extends AbstractAuthenticatedUser {
 
     /**
      * Initializes this SSOAuthenticatedUser, associating it with the given
-     * username, credentials, groups, and parameter tokens. This function must
-     * be invoked for every SSOAuthenticatedUser created.
+     * username, credentials, groups, and parameter tokens. The contents of the
+     * given credentials are automatically updated to match the provided
+     * username. This function must be invoked for every SSOAuthenticatedUser
+     * created.
      *
      * @param username
      *     The username of the user that was authenticated.
      *
      * @param credentials
-     *     The credentials provided when this user was authenticated.
+     *     The credentials provided when this user was authenticated. These
+     *     credentials will be updated to match the provided username.
      *
      * @param effectiveGroups
      *     The groups that the authenticated user belongs to.
@@ -78,10 +81,16 @@ public class SSOAuthenticatedUser extends AbstractAuthenticatedUser {
      */
     public void init(String username, Credentials credentials,
             Set<String> effectiveGroups, Map<String, String> tokens) {
+
         this.credentials = credentials;
         this.effectiveGroups = Collections.unmodifiableSet(effectiveGroups);
         this.tokens = Collections.unmodifiableMap(tokens);
         setIdentifier(username);
+
+        // Update credentials with username provided via SSO for sake of
+        // ${GUAC_USERNAME} token
+        credentials.setUsername(username);
+
     }
 
     /**

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-cas/src/main/java/org/apache/guacamole/auth/cas/ticket/TicketValidationService.java
@@ -163,10 +163,6 @@ public class TicketValidationService {
         // Canonicalize username as lowercase
         username = username.toLowerCase();
 
-        // Update credentials with username provided by CAS for sake of
-        // ${GUAC_USERNAME} token
-        credentials.setUsername(username);
-
         // Retrieve password, attempt decryption, and set credentials.
         Object credObj = ticketAttrs.remove("credential");
         if (credObj != null) {

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-saml/src/main/java/org/apache/guacamole/auth/saml/AuthenticationProviderService.java
@@ -96,15 +96,9 @@ public class AuthenticationProviderService implements SSOAuthenticationProviderS
                 getSessionIdentifier(credentials));
 
         if (identity != null) {
-
-            // Back-port the username to the credentials
-            credentials.setUsername(identity.getUsername());
-
-            // Configure the AuthenticatedUser and return it
             SAMLAuthenticatedUser authenticatedUser = authenticatedUserProvider.get();
             authenticatedUser.init(identity, credentials);
             return authenticatedUser;
-
         }
 
         // Redirect to SAML IdP if no SAML identity is associated with the


### PR DESCRIPTION
This was missing from the SSL SSO and is necessary to ensure the `${GUAC_USERNAME}` token is properly substituted in cases where SSO and SSO-like auth methods are used.