### PR TITLE
GUACAMOLE-2051: Allow Guacamole properties to be either comma or semi-colon or comma delimited.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/FileGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/FileGuacamoleProperty.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.guacamole.GuacamoleException;
 
 /**
@@ -30,6 +31,14 @@ import org.apache.guacamole.GuacamoleException;
  */
 public abstract class FileGuacamoleProperty implements GuacamoleProperty<File> {
 
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently either a comma or a semicolon and any following whitespace.
+     * Parts of the input string which match this pattern will not be included
+     * in the parsed result.
+     */
+    static final Pattern DELIMITER_PATTERN = Pattern.compile("[,;]\\s*");
+    
     @Override
     public File parseValue(String value) throws GuacamoleException {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/GuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/GuacamoleProperty.java
@@ -21,7 +21,6 @@ package org.apache.guacamole.properties;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.regex.Pattern;
 import org.apache.guacamole.GuacamoleException;
 
 /**
@@ -32,14 +31,6 @@ import org.apache.guacamole.GuacamoleException;
  *     The type this GuacamoleProperty will parse into.
  */
 public interface GuacamoleProperty<Type> {
-
-    /**
-     * A pattern which matches against the delimiters between values. This is
-     * currently simply a semicolon and any following whitespace. Parts of the
-     * input string which match this pattern will not be included in the parsed
-     * result.
-     */
-    static final Pattern DELIMITER_PATTERN = Pattern.compile(";\\s*");
     
     /**
      * Returns the name of the property in guacamole.properties that this

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/IntegerGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/IntegerGuacamoleProperty.java
@@ -22,6 +22,7 @@ package org.apache.guacamole.properties;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 
@@ -30,6 +31,14 @@ import org.apache.guacamole.GuacamoleServerException;
  */
 public abstract class IntegerGuacamoleProperty implements GuacamoleProperty<Integer> {
 
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently either a comma or a semicolon and any following whitespace.
+     * Parts of the input string which match this pattern will not be included
+     * in the parsed result.
+     */
+    static final Pattern DELIMITER_PATTERN = Pattern.compile("[,;]\\s*");
+    
     @Override
     public Integer parseValue(String value) throws GuacamoleException {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/LongGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/LongGuacamoleProperty.java
@@ -22,6 +22,7 @@ package org.apache.guacamole.properties;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 
@@ -30,6 +31,14 @@ import org.apache.guacamole.GuacamoleServerException;
  */
 public abstract class LongGuacamoleProperty implements GuacamoleProperty<Long> {
 
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently either a comma or a semicolon and any following whitespace.
+     * Parts of the input string which match this pattern will not be included
+     * in the parsed result.
+     */
+    static final Pattern DELIMITER_PATTERN = Pattern.compile("[,;]\\s*");
+    
     @Override
     public Long parseValue(String value) throws GuacamoleException {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/StringGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/StringGuacamoleProperty.java
@@ -21,6 +21,7 @@ package org.apache.guacamole.properties;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.guacamole.GuacamoleException;
 
 /**
@@ -28,6 +29,14 @@ import org.apache.guacamole.GuacamoleException;
  */
 public abstract class StringGuacamoleProperty implements GuacamoleProperty<String> {
 
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently either a comma or a semicolon and any following whitespace.
+     * Parts of the input string which match this pattern will not be included
+     * in the parsed result.
+     */
+    static final Pattern DELIMITER_PATTERN = Pattern.compile("[,;]\\s*");
+    
     @Override
     public String parseValue(String value) throws GuacamoleException {
         return value;

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/StringListProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/StringListProperty.java
@@ -39,6 +39,14 @@ import org.apache.guacamole.GuacamoleException;
 @Deprecated
 public abstract class StringListProperty implements GuacamoleProperty<List<String>> {
 
+    /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently either a comma or a semicolon and any following whitespace.
+     * Parts of the input string which match this pattern will not be included
+     * in the parsed result.
+     */
+    static final Pattern DELIMITER_PATTERN = Pattern.compile("[,;]\\s*");
+    
     @Override
     public List<String> parseValue(String values) throws GuacamoleException {
 

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/TimeZoneGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/TimeZoneGuacamoleProperty.java
@@ -34,6 +34,14 @@ public abstract class TimeZoneGuacamoleProperty
         implements GuacamoleProperty<TimeZone> {
     
     /**
+     * A pattern which matches against the delimiters between values. This is
+     * currently either a comma or a semicolon and any following whitespace.
+     * Parts of the input string which match this pattern will not be included
+     * in the parsed result.
+     */
+    static final Pattern DELIMITER_PATTERN = Pattern.compile("[,;]\\s*");
+    
+    /**
      * A regex that matches valid variants of GMT timezones.
      */
     public static final Pattern GMT_REGEX =

--- a/guacamole-ext/src/main/java/org/apache/guacamole/properties/URIGuacamoleProperty.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/properties/URIGuacamoleProperty.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.GuacamoleServerException;
 
@@ -31,6 +32,13 @@ import org.apache.guacamole.GuacamoleServerException;
  * A GuacamoleProperty whose value is a URI.
  */
 public abstract class URIGuacamoleProperty implements GuacamoleProperty<URI> {
+    
+    /**
+     * A pattern which matches against the delimiters between values. For the
+     * URIGuacamoleProperty, this is set to one or more spaces, as commas and
+     * semicolons are valid in URIs while white space is not.
+     */
+    static final Pattern DELIMITER_PATTERN = Pattern.compile("\\s+");
     
     @Override
     public URI parseValue(String value) throws GuacamoleException {


### PR DESCRIPTION
Took a quick stab at fixing this issue with adding the comma back in as a delimiter. Not tested, yet, but I think the RegEx is sound.