### PR TITLE
GUACAMOLE-954: Add LDAP support for nested user groups

### DIFF
--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConnectedLDAPConfiguration.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/ConnectedLDAPConfiguration.java
@@ -223,5 +223,10 @@ public class ConnectedLDAPConfiguration implements LDAPConfiguration, AutoClosea
     public MemberAttributeType getMemberAttributeType() throws GuacamoleException {
         return config.getMemberAttributeType();
     }
+    
+    @Override
+    public boolean getNestedGroups() throws GuacamoleException {
+        return config.getNestedGroups();
+    }
 
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/DefaultLDAPConfiguration.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/DefaultLDAPConfiguration.java
@@ -151,4 +151,9 @@ public class DefaultLDAPConfiguration implements LDAPConfiguration {
         return MemberAttributeType.DN;
     }
 
+    @Override
+    public boolean getNestedGroups() {
+        return false;
+    }
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/EnvironmentLDAPConfiguration.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/EnvironmentLDAPConfiguration.java
@@ -234,4 +234,12 @@ public class EnvironmentLDAPConfiguration implements LDAPConfiguration {
         );
     }
 
+    @Override
+    public boolean getNestedGroups() throws GuacamoleException {
+        return environment.getProperty(
+            LDAPGuacamoleProperties.LDAP_NESTED_GROUPS,
+            DEFAULT.getNestedGroups()
+        );
+    }
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/JacksonLDAPConfiguration.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/JacksonLDAPConfiguration.java
@@ -205,6 +205,13 @@ public class JacksonLDAPConfiguration implements LDAPConfiguration {
     private String memberAttributeType;
 
     /**
+     * The raw YAML value of {@link LDAPGuacamoleProperties#LDAP_NESTED_GROUPS}.
+     * If not set within the YAML, this will be null.
+     */
+    @JsonProperty("nested-groups")
+    private Boolean nestedGroups;
+
+    /**
      * The default configuration options for all parameters.
      */
     private LDAPConfiguration defaultConfig = new DefaultLDAPConfiguration();
@@ -432,6 +439,11 @@ public class JacksonLDAPConfiguration implements LDAPConfiguration {
     @Override
     public String getMemberAttribute() throws GuacamoleException {
         return withDefault(memberAttribute, defaultConfig::getMemberAttribute);
+    }
+
+    @Override
+    public boolean getNestedGroups() throws GuacamoleException {
+        return withDefault(nestedGroups, defaultConfig::getNestedGroups);
     }
 
     @Override

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPConfiguration.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPConfiguration.java
@@ -334,4 +334,16 @@ public interface LDAPConfiguration {
      */
     MemberAttributeType getMemberAttributeType() throws GuacamoleException;
 
+    /**
+     * Returns whether nested groups should be included in group membership.
+     *
+     * @return
+     *     Whether to search in nested groups.
+     *
+     * @throws GuacamoleException
+     *     If the configuration information determining whether nested
+     *     groups should be used cannot be retrieved.
+     */
+    boolean getNestedGroups() throws GuacamoleException;
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/conf/LDAPGuacamoleProperties.java
@@ -307,4 +307,15 @@ public class LDAPGuacamoleProperties {
 
     };
 
+    /**
+     * Whether or not to search nested groups.
+     */
+    public static final BooleanGuacamoleProperty LDAP_NESTED_GROUPS = 
+            new BooleanGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "ldap-nested-groups"; }
+        
+    };
+
 }

--- a/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
+++ b/extensions/guacamole-auth-ldap/src/main/java/org/apache/guacamole/auth/ldap/group/UserGroupService.java
@@ -27,10 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.entry.Value;
 import org.apache.directory.api.ldap.model.exception.LdapInvalidAttributeValueException;
 import org.apache.directory.api.ldap.model.filter.AndNode;
 import org.apache.directory.api.ldap.model.filter.EqualityNode;
 import org.apache.directory.api.ldap.model.filter.ExprNode;
+import org.apache.directory.api.ldap.model.filter.ExtensibleNode;
 import org.apache.directory.api.ldap.model.filter.NotNode;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.guacamole.auth.ldap.conf.MemberAttributeType;
@@ -227,14 +229,36 @@ public class UserGroupService {
         groupAttributes.add(memberAttribute);
 
         // Get all groups the user is a member of starting at the groupBaseDN,
-        // excluding guacConfigGroups
+        // excluding guacConfigGroups and evaluating nested groups 
+        // (if enabled).
+
+        ExprNode groupFilter = config.getGroupSearchFilter();
+        String filterValue = userIDorDN;
+
+        if (config.getNestedGroups()) {
+
+            // Add support for nested groups using LDAP_MATCHING_RULE_IN_CHAIN
+            // (memberOf:1.2.840.113556.1.4.1941:=<UserDN>)
+            // Matching rule OID for LDAP_MATCHING_RULE_IN_CHAIN
+            // ** This possibly only supports Active Directory **
+            ExtensibleNode node = new ExtensibleNode("member");
+            filterValue = null;
+
+            // Explicitly set the matching rule ID and dnAttributes
+            node.setMatchingRuleId("1.2.840.113556.1.4.1941");
+            node.setDnAttributes(false);
+            node.setValue(new Value(userIDorDN));
+            groupFilter = new AndNode(
+                    groupFilter, node
+            );
+        }
         return queryService.search(
             config,
             config.getLDAPConnection(),
             groupBaseDN,
-            getGroupSearchFilter(config),
+            groupFilter,
             Collections.singleton(memberAttribute),
-            userIDorDN,
+            filterValue,
             groupAttributes
         );
 


### PR DESCRIPTION
This is the start of a pull request to address GUACAMOLE-954 in a performant way, but unfortunately this feature only works with Active Directory. 

I added a new config boolean due to this called 'nested-groups' to enable/disable the AD-specific query.

It makes use of the LDAP_MATCHING_RULE_IN_CHAIN mentioned in the Jira with a specific OID.

I understand if the team is not keen on merging a feature that is only for a specific vendor's LDAP implementation, but this is performant and very useful for us in our AD environment so I would like to try and get it added for the others who requested it and likely using AD as well.