### PR TITLE
GUACAMOLE-2138: Add connection-timeout parameter

### DIFF
--- a/guacamole/src/main/java/org/apache/guacamole/rest/auth/HashTokenSessionMap.java
+++ b/guacamole/src/main/java/org/apache/guacamole/rest/auth/HashTokenSessionMap.java
@@ -67,6 +67,18 @@ public class HashTokenSessionMap implements TokenSessionMap {
     };
 
     /**
+     * The connection timeout for individual Guacamole connections, in minutes.
+     * If 0, connections will not be automatically terminated based on age.
+     */
+    private final IntegerGuacamoleProperty CONNECTION_TIMEOUT =
+            new IntegerGuacamoleProperty() {
+
+        @Override
+        public String getName() { return "connection-timeout"; }
+
+    };
+
+    /**
      * Create a new HashTokenSessionMap configured using the given environment.
      *
      * @param environment
@@ -75,6 +87,7 @@ public class HashTokenSessionMap implements TokenSessionMap {
     public HashTokenSessionMap(Environment environment) {
         
         int sessionTimeoutValue;
+        int connectionTimeoutValue;
 
         // Read session timeout from guacamole.properties
         try {
@@ -85,10 +98,25 @@ public class HashTokenSessionMap implements TokenSessionMap {
             logger.debug("Error while reading session timeout value.", e);
             sessionTimeoutValue = 60;
         }
+
+        // Read connection timeout from guacamole.properties
+        try {
+            connectionTimeoutValue = environment.getProperty(CONNECTION_TIMEOUT, 0); // Disabled by default
+        }
+        catch (GuacamoleException e) {
+            logger.error("Unable to read guacamole.properties: {}", e.getMessage());
+            logger.debug("Error while reading connection timeout value.", e);
+            connectionTimeoutValue = 0;  
+        }
         
         // Check for expired sessions every minute
         logger.info("Sessions will expire after {} minutes of inactivity.", sessionTimeoutValue);
-        executor.scheduleAtFixedRate(new SessionEvictionTask(sessionTimeoutValue * 60000l), 1, 1, TimeUnit.MINUTES);
+        if (connectionTimeoutValue > 0) {
+            logger.info("Connections will be terminated after {} minutes regardless of activity.", connectionTimeoutValue);
+        } else {
+            logger.info("Connection timeout disabled (set to 0).");
+        }
+        executor.scheduleAtFixedRate(new SessionEvictionTask(sessionTimeoutValue * 60000l, connectionTimeoutValue * 60000l), 1, 1, TimeUnit.MINUTES);
         
     }
 
@@ -105,15 +133,25 @@ public class HashTokenSessionMap implements TokenSessionMap {
         private final long sessionTimeout;
 
         /**
+         * The maximum allowed age of any connection, in milliseconds.
+         * If 0, connections will not be terminated based on age.
+         */
+        private final long connectionTimeout;
+
+        /**
          * Creates a new task which automatically evicts sessions which are
          * older than the specified timeout, or are marked as invalid by an
          * extension.
          * 
          * @param sessionTimeout The maximum age of any session, in
          *                       milliseconds.
+         * @param connectionTimeout The maximum age of any connection, in
+         *                         milliseconds. If 0, connections will not be
+         *                         terminated based on age.
          */
-        public SessionEvictionTask(long sessionTimeout) {
+        public SessionEvictionTask(long sessionTimeout, long connectionTimeout) {
             this.sessionTimeout = sessionTimeout;
+            this.connectionTimeout = connectionTimeout;
         }
 
         /**
@@ -145,6 +183,16 @@ public class HashTokenSessionMap implements TokenSessionMap {
                                 entry.getKey());
                         entries.remove();
                         session.invalidate();
+                        continue;
+                    }
+
+                    // Close any connections that have exceeded the connection timeout
+                    if (connectionTimeout > 0) {
+                        int closedConnections = session.closeExpiredTunnels(connectionTimeout);
+                        if (closedConnections > 0) {
+                            logger.debug("Closed {} expired connection(s) in session \"{}\".", 
+                                    closedConnections, entry.getKey());
+                        }
                     }
 
                     // Do not expire sessions which are active


### PR DESCRIPTION
# Summary

In my company's business use case for Guacamole, for security and auditing purposes, we need to be able to ensure that any idle user is disconnected and logged off within a set period of time of idleness. 

In an *ideal* version of such a system, we would do the following. 

1.  Check if the user has interacted with the connection in the last X minutes, or if an active SFTP transfer is happening on the connection.
2. If not, terminate the user connection after X minutes of inactivity. 
3. If they remain idle, the Guacamole idle timer will log them out after the pre-configured login idle timeout.

This requires a lot of conditionals and would be more difficult to implement and maintain in an ongoing project like Guacamole. 

A *more practical*, yet sufficient, version is:
 1. The Administrator sets a maximum duration for any connection, specified in minutes. 
 2. Any connection that exceeds that duration, regardless of activity, is terminated while the user remains logged in.  They are free to reconnect if the user is still active. 
 3. The login idle timeout starts when the connection ends. 

This second option meets our business needs, and we would like to share it with others. 

# Features

* Add parameter `connection-timeout` in `guacamole.properties`, disconnecting users after `connection-timeout` minutes. Defaults to 0, disabling the feature. 
* Implement the connection timeout using a Map that stores the creation time of the connection.
* Integrate the connection timeout check into the existing idle timeout function. 