### PR TITLE
GUACAMOLE-2210: Add support for AAD authentication to RDP protocol.

### DIFF
--- a/doc/licenses/qrcode-generator/LICENSE
+++ b/doc/licenses/qrcode-generator/LICENSE
@@ -1,0 +1,25 @@
+# Name:    qrcode-generator
+# URL:     https://github.com/kazuhikoarase/qrcode-generator
+# From:    'Kazuhiko Arase'
+# License: MIT
+#
+# --- BEGIN LICENSE FILE [2.0.4] ---
+Copyright (c) 2009 Kazuhiko Arase
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/doc/licenses/qrcode-generator/dep-coordinates.txt
+++ b/doc/licenses/qrcode-generator/dep-coordinates.txt
@@ -1,0 +1,1 @@
+qrcode-generator:*

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -38,7 +38,19 @@
                 {
                     "name"    : "security",
                     "type"    : "ENUM",
-                    "options" : [ "", "any", "nla", "rdp", "tls", "vmconnect" ]
+                    "options" : [ "", "any", "nla", "rdp", "tls", "vmconnect", "aad" ]
+                },
+                {
+                    "name"  : "aad-client-id",
+                    "type"  : "TEXT"
+                },
+                {
+                    "name"  : "aad-scope",
+                    "type"  : "TEXT"
+                },
+                {
+                    "name"  : "aad-tenant-id",
+                    "type"  : "TEXT"
                 },
                 {
                     "name"    : "disable-auth",

--- a/guacamole/src/main/frontend/package-lock.json
+++ b/guacamole/src/main/frontend/package-lock.json
@@ -23,6 +23,7 @@
                 "jquery": "^3.7.1",
                 "jstz": "^2.1.1",
                 "lodash": "^4.18.1",
+                "qrcode-generator": "^2.0.4",
                 "yaml": "^2.9.0"
             },
             "devDependencies": {
@@ -3834,6 +3835,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/qrcode-generator": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+            "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
+            "license": "MIT"
         },
         "node_modules/randombytes": {
             "version": "2.1.0",

--- a/guacamole/src/main/frontend/package.json
+++ b/guacamole/src/main/frontend/package.json
@@ -21,6 +21,7 @@
         "jquery": "^3.7.1",
         "jstz": "^2.1.1",
         "lodash": "^4.18.1",
+        "qrcode-generator": "^2.0.4",
         "yaml": "^2.9.0"
     },
     "devDependencies": {

--- a/guacamole/src/main/frontend/src/app/client/directives/guacAadSignin.js
+++ b/guacamole/src/main/frontend/src/app/client/directives/guacAadSignin.js
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Directive which displays the Azure AD device code sign-in prompt for a
+ * connection. When the server requests sign-in, a QR code of the Microsoft
+ * verification URI is shown alongside the user code; the user scans it and
+ * completes sign-in on a separate device. The prompt is dismissed automatically
+ * once the server reports the flow has completed.
+ */
+angular.module('client').directive('guacAadSignin', [function guacAadSignin() {
+
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+
+            /**
+             * The ManagedClient whose Azure AD sign-in should be displayed.
+             *
+             * @type ManagedClient
+             */
+            client: '='
+
+        },
+        templateUrl: 'app/client/templates/guacAadSignin.html',
+        controller: ['$scope', function controller($scope) {
+
+            /**
+             * Cancels sign-in by disconnecting the connection awaiting it.
+             */
+            $scope.cancel = function cancel() {
+                if ($scope.client && $scope.client.client)
+                    $scope.client.client.disconnect();
+            };
+
+        }]
+    };
+
+}]);

--- a/guacamole/src/main/frontend/src/app/client/styles/aad-signin.css
+++ b/guacamole/src/main/frontend/src/app/client/styles/aad-signin.css
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.aad-signin {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 20;
+}
+
+.aad-signin .aad-signin-dialog {
+    background: white;
+    color: black;
+    padding: 2em;
+    border-radius: 0.25em;
+    max-width: 24em;
+    text-align: center;
+    box-shadow: 0 0.25em 1em rgba(0, 0, 0, 0.5);
+}
+
+.aad-signin .aad-signin-text {
+    margin: 0 0 1.5em;
+}
+
+.aad-signin .aad-signin-qr {
+    display: block;
+    width: 12em;
+    height: 12em;
+    margin: 0 auto 1em;
+    image-rendering: pixelated;
+}
+
+.aad-signin .aad-signin-instructions {
+    margin: 0 0 0.5em;
+    word-break: break-all;
+}
+
+.aad-signin .aad-signin-code {
+    margin: 0 0 1.5em;
+}
+
+.aad-signin .aad-signin-user-code {
+    display: block;
+    margin-top: 0.25em;
+    font-family: monospace;
+    font-size: 1.5em;
+    font-weight: bold;
+    letter-spacing: 0.1em;
+}
+
+.aad-signin .buttons {
+    display: flex;
+    justify-content: center;
+    gap: 0.5em;
+}

--- a/guacamole/src/main/frontend/src/app/client/templates/client.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/client.html
@@ -15,6 +15,10 @@
                     emulate-absolute-mouse="menu.emulateAbsoluteMouse">
                 </guac-tiled-clients>
 
+                <!-- Azure AD sign-in prompt -->
+                <guac-aad-signin ng-if="focusedClient.managedAAD"
+                    client="focusedClient"></guac-aad-signin>
+
             </div>
 
             <!-- Bottom portion of view -->

--- a/guacamole/src/main/frontend/src/app/client/templates/guacAadSignin.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/guacAadSignin.html
@@ -1,0 +1,45 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<div class="aad-signin" ng-show="client.managedAAD.prompt">
+    <div class="aad-signin-dialog">
+
+        <p class="aad-signin-text">{{'CLIENT.HELP_AAD_SIGN_IN' | translate}}</p>
+
+        <img class="aad-signin-qr" ng-src="{{client.managedAAD.prompt.qrCode}}"
+            alt="{{'CLIENT.HELP_AAD_SIGN_IN' | translate}}"/>
+
+        <p class="aad-signin-instructions">
+            {{'CLIENT.INFO_AAD_SIGN_IN_INSTRUCTIONS' | translate}}
+            <a ng-href="{{client.managedAAD.prompt.verificationUri}}"
+                target="_blank" rel="noopener noreferrer">{{client.managedAAD.prompt.verificationUri}}</a>
+        </p>
+
+        <p class="aad-signin-code">
+            {{'CLIENT.INFO_AAD_SIGN_IN_CODE' | translate}}
+            <span class="aad-signin-user-code">{{client.managedAAD.prompt.userCode}}</span>
+        </p>
+
+        <div class="buttons">
+            <button ng-click="cancel()">
+                {{'APP.ACTION_CANCEL' | translate}}
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedAAD.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedAAD.js
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import qrcode from 'qrcode-generator';
+
+/**
+ * Provides the ManagedAAD class used by ManagedClient to display an Azure AD
+ * device code sign-in prompt for an RDP connection. The server obtains a device
+ * code from Azure and opens an inbound pipe stream carrying the user code and
+ * verification URI; the browser shows these as a QR code the user scans to sign
+ * in on a separate device (a phone). The browser sends nothing back: the server
+ * polls Azure for completion and closes the stream when the flow finishes,
+ * which dismisses the prompt.
+ */
+angular.module('client').factory('ManagedAAD', ['$rootScope',
+    function defineManagedAAD($rootScope) {
+
+
+    /**
+     * Runs the given mutation inside an Angular digest. Prompt handling runs
+     * outside Angular (via Guacamole's tunnel dispatch), so state the sign-in
+     * prompt watches needs an explicit $apply.
+     *
+     * @private
+     * @param {!Function} updateFn
+     *     The mutation to apply.
+     */
+    function applyStateChange(updateFn) {
+        if ($rootScope.$$phase)
+            updateFn();
+        else
+            $rootScope.$apply(updateFn);
+    }
+
+    /**
+     * Renders the given text as a QR code, returning a data URI suitable for the
+     * src of an <img>.
+     *
+     * @private
+     * @param {!String} text
+     *     The text to encode.
+     *
+     * @returns {!String}
+     *     A data URI of the rendered QR code.
+     */
+    function renderQRCode(text) {
+        const qr = qrcode(0, 'M');
+        qr.addData(text);
+        qr.make();
+        return qr.createDataURL(6, 8);
+    }
+
+    /**
+     * Object which tracks Azure AD device code sign-in for a single
+     * ManagedClient.
+     *
+     * @constructor
+     * @param {ManagedAAD|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     ManagedAAD.
+     */
+    const ManagedAAD = function ManagedAAD(template) {
+
+        template = template || {};
+
+        /**
+         * The ManagedClient that owns this sign-in relay.
+         *
+         * @type ManagedClient
+         */
+        this.client = template.client;
+
+        /**
+         * The sign-in prompt currently being displayed, or null if none. When
+         * set, the QR overlay is shown. Contains the user code, the
+         * verification URI (with and without the code embedded), and the QR
+         * code data URI.
+         *
+         * @type {Object}
+         */
+        this.prompt = template.prompt || null;
+
+    };
+
+    /**
+     * Creates a new ManagedAAD instance bound to the given client.
+     *
+     * @param {ManagedClient} client
+     *     The client this ManagedAAD should be associated with.
+     *
+     * @returns {ManagedAAD}
+     *     The newly-created ManagedAAD.
+     */
+    ManagedAAD.getInstance = function getInstance(client) {
+        return new ManagedAAD({ client });
+    };
+
+    /**
+     * The name of the pipe stream that carries the device code prompt. Matches
+     * the name used by the server (guacd) when opening the stream.
+     *
+     * @constant
+     * @type {!String}
+     */
+    ManagedAAD.PIPE_NAME = 'aad-device-code';
+
+    /**
+     * Handles a single inbound Azure AD device code prompt. Reads the JSON
+     * prompt off the pipe stream and displays it as a QR code. The stream is
+     * left open by the server for the duration of the sign-in; when the server
+     * closes it (on success, failure, or expiry) the prompt is dismissed.
+     *
+     * @param {!ManagedAAD} managedAAD
+     *     The ManagedAAD that should display the prompt.
+     *
+     * @param {!Guacamole.InputStream} stream
+     *     The pipe stream carrying the prompt body.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the prompt body.
+     *
+     * @param {!String} name
+     *     The name of the pipe stream.
+     */
+    ManagedAAD.handlePrompt = function handlePrompt(managedAAD, stream,
+            mimetype, name) {
+
+        let payload = '';
+        let shown = false;
+
+        const reader = new Guacamole.StringReader(stream);
+        reader.ontext = function promptChunk(text) {
+
+            payload += text;
+            if (shown)
+                return;
+
+            // The prompt arrives as a single JSON object; wait for enough blobs
+            // to form valid JSON before displaying it
+            let prompt;
+            try {
+                prompt = JSON.parse(payload);
+            }
+            catch (e) {
+                return;
+            }
+
+            shown = true;
+            applyStateChange(function showPrompt() {
+                const link = prompt.verification_uri_complete
+                        || prompt.verification_uri;
+                managedAAD.prompt = {
+                    userCode                : prompt.user_code,
+                    verificationUri         : prompt.verification_uri,
+                    verificationUriComplete : link,
+                    qrCode                  : renderQRCode(link)
+                };
+            });
+
+        };
+
+        // The server closes the stream once the device code flow completes,
+        // whatever the outcome; dismiss the prompt
+        reader.onend = function signInComplete() {
+            ManagedAAD.clear(managedAAD);
+        };
+
+    };
+
+    /**
+     * Dismisses the currently-displayed sign-in prompt, if any. Called when the
+     * server closes the prompt stream and when the connection drops.
+     *
+     * @param {!ManagedAAD} managedAAD
+     *     The ManagedAAD whose prompt should be cleared.
+     */
+    ManagedAAD.clear = function clear(managedAAD) {
+        applyStateChange(function clearPrompt() {
+            managedAAD.prompt = null;
+        });
+    };
+
+    return ManagedAAD;
+
+}]);

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedAAD.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedAAD.js
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import qrcode from 'qrcode-generator';
+
+/**
+ * Provides the ManagedAAD class used by ManagedClient to display an Azure AD
+ * device code sign-in prompt for an RDP connection. The server obtains a device
+ * code from Azure and opens an inbound pipe stream carrying the user code and
+ * verification URI; the browser shows these as a QR code the user scans to sign
+ * in on a separate device (a phone). The browser sends nothing back: the server
+ * polls Azure for completion while the prompt stays displayed. The prompt is
+ * dismissed once the connection completes or drops, not when the pipe stream
+ * ends.
+ */
+angular.module('client').factory('ManagedAAD', ['$rootScope',
+    function defineManagedAAD($rootScope) {
+
+
+    /**
+     * Runs the given mutation inside an Angular digest. Prompt handling runs
+     * outside Angular (via Guacamole's tunnel dispatch), so state the sign-in
+     * prompt watches needs an explicit $apply.
+     *
+     * @private
+     * @param {!Function} updateFn
+     *     The mutation to apply.
+     */
+    function applyStateChange(updateFn) {
+        if ($rootScope.$$phase)
+            updateFn();
+        else
+            $rootScope.$apply(updateFn);
+    }
+
+    /**
+     * Renders the given text as a QR code, returning a data URI suitable for the
+     * src of an <img>.
+     *
+     * @private
+     * @param {!String} text
+     *     The text to encode.
+     *
+     * @returns {!String}
+     *     A data URI of the rendered QR code.
+     */
+    function renderQRCode(text) {
+        const qr = qrcode(0, 'M');
+        qr.addData(text);
+        qr.make();
+        return qr.createDataURL(6, 8);
+    }
+
+    /**
+     * Object which tracks Azure AD device code sign-in for a single
+     * ManagedClient.
+     *
+     * @constructor
+     * @param {ManagedAAD|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     ManagedAAD.
+     */
+    const ManagedAAD = function ManagedAAD(template) {
+
+        template = template || {};
+
+        /**
+         * The ManagedClient that owns this sign-in relay.
+         *
+         * @type ManagedClient
+         */
+        this.client = template.client;
+
+        /**
+         * The sign-in prompt currently being displayed, or null if none. When
+         * set, the QR overlay is shown. Contains the user code, the
+         * verification URI (with and without the code embedded), and the QR
+         * code data URI.
+         *
+         * @type {Object}
+         */
+        this.prompt = template.prompt || null;
+
+    };
+
+    /**
+     * Creates a new ManagedAAD instance bound to the given client.
+     *
+     * @param {ManagedClient} client
+     *     The client this ManagedAAD should be associated with.
+     *
+     * @returns {ManagedAAD}
+     *     The newly-created ManagedAAD.
+     */
+    ManagedAAD.getInstance = function getInstance(client) {
+        return new ManagedAAD({ client });
+    };
+
+    /**
+     * The name of the pipe stream that carries the device code prompt. Matches
+     * the name used by the server (guacd) when opening the stream.
+     *
+     * @constant
+     * @type {!String}
+     */
+    ManagedAAD.PIPE_NAME = 'aad-device-code';
+
+    /**
+     * Handles a single inbound Azure AD device code prompt. Reads the JSON
+     * prompt off the pipe stream and displays it as a QR code. The stream is a
+     * complete pipe (open, blob, end); the prompt stays displayed until the
+     * connection completes or drops, not when this stream ends.
+     *
+     * @param {!ManagedAAD} managedAAD
+     *     The ManagedAAD that should display the prompt.
+     *
+     * @param {!Guacamole.InputStream} stream
+     *     The pipe stream carrying the prompt body.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the prompt body.
+     *
+     * @param {!String} name
+     *     The name of the pipe stream.
+     */
+    ManagedAAD.handlePrompt = function handlePrompt(managedAAD, stream,
+            mimetype, name) {
+
+        let payload = '';
+        let shown = false;
+
+        const reader = new Guacamole.StringReader(stream);
+        reader.ontext = function promptChunk(text) {
+
+            payload += text;
+            if (shown)
+                return;
+
+            // The prompt arrives as a single JSON object; wait for enough blobs
+            // to form valid JSON before displaying it
+            let prompt;
+            try {
+                prompt = JSON.parse(payload);
+            }
+            catch (e) {
+                return;
+            }
+
+            shown = true;
+            applyStateChange(function showPrompt() {
+                const link = prompt.verification_uri_complete
+                        || prompt.verification_uri;
+                managedAAD.prompt = {
+                    userCode                : prompt.user_code,
+                    verificationUri         : prompt.verification_uri,
+                    verificationUriComplete : link,
+                    qrCode                  : renderQRCode(link)
+                };
+            });
+
+        };
+
+        // The stream is a complete pipe (open, blob, end); the client frees it
+        // on end. The prompt is not dismissed here, but when the connection
+        // completes or drops.
+
+    };
+
+    /**
+     * Dismisses the currently-displayed sign-in prompt, if any. Called when the
+     * server closes the prompt stream and when the connection drops.
+     *
+     * @param {!ManagedAAD} managedAAD
+     *     The ManagedAAD whose prompt should be cleared.
+     */
+    ManagedAAD.clear = function clear(managedAAD) {
+        applyStateChange(function clearPrompt() {
+            managedAAD.prompt = null;
+        });
+    };
+
+    return ManagedAAD;
+
+}]);

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -36,6 +36,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     const ManagedFilesystem      = $injector.get('ManagedFilesystem');
     const ManagedFileUpload      = $injector.get('ManagedFileUpload');
     const ManagedShareLink       = $injector.get('ManagedShareLink');
+    const ManagedAAD             = $injector.get('ManagedAAD');
 
     // Required services
     const $document               = $injector.get('$document');
@@ -278,7 +279,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         this.arguments = template.arguments || {};
 
         /**
-         * Any received pipe streams that have not been consumed by an onpipe
+ * Any received pipe streams that have not been consumed by an onpipe
          * handler or registered pipe handler, indexed by pipe stream name.
          *
          * @type {Object.<String, Object>}
@@ -292,6 +293,16 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
          * @type {Object.<String, Function>}
          */
         this.deferredPipeStreamHandlers = template.deferredPipeStreamHandlers || {};
+
+        /**
+         * State tracking Azure AD sign-in for this client. The device code
+         * prompt arrives as an inbound pipe stream with the Azure AD mimetype
+         * and is shown as a QR code; sign-in itself completes out of band (on
+         * the user's phone) while the server polls Azure.
+         *
+         * @type ManagedAAD
+         */
+        this.managedAAD = template.managedAAD || null;
 
     };
 
@@ -443,6 +454,17 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             tunnel : tunnel
         });
 
+        // Set up Azure AD sign-in. The device-code prompt is delivered as a
+        // named pipe stream; register a handler for it with the deferred pipe
+        // stream framework rather than overriding the default onpipe handler.
+        managedClient.managedAAD = ManagedAAD.getInstance(managedClient);
+
+        ManagedClient.registerDeferredPipeHandler(managedClient,
+                ManagedAAD.PIPE_NAME,
+                function aadPromptReceived(stream, mimetype, name) {
+            ManagedAAD.handlePrompt(managedClient.managedAAD, stream, mimetype, name);
+        });
+
         // Fire events for tunnel errors
         tunnel.onerror = function tunnelError(status) {
             $rootScope.$apply(function handleTunnelError() {
@@ -458,6 +480,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             tunnelService.getProtocol(uuid).then(function protocolRetrieved(protocol) {
                 managedClient.protocol = protocol.name;
                 managedClient.forms = protocol.connectionForms;
+                $rootScope.$broadcast('guacClientProtocolAssigned', managedClient);
             }, requestService.WARN);
         };
 
@@ -485,6 +508,10 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
 
                     // Connection has closed
                     case Guacamole.Tunnel.State.CLOSED:
+                        // Dismiss any sign-in prompt left stranded by the tunnel
+                        // dropping mid-flow
+                        if (managedClient.managedAAD)
+                            ManagedAAD.clear(managedClient.managedAAD);
                         ManagedClientState.setConnectionState(managedClient.clientState,
                             ManagedClientState.ConnectionState.DISCONNECTED);
                         break;

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -36,6 +36,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     const ManagedFilesystem      = $injector.get('ManagedFilesystem');
     const ManagedFileUpload      = $injector.get('ManagedFileUpload');
     const ManagedShareLink       = $injector.get('ManagedShareLink');
+    const ManagedAAD             = $injector.get('ManagedAAD');
 
     // Required services
     const $document               = $injector.get('$document');
@@ -278,7 +279,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         this.arguments = template.arguments || {};
 
         /**
-         * Any received pipe streams that have not been consumed by an onpipe
+ * Any received pipe streams that have not been consumed by an onpipe
          * handler or registered pipe handler, indexed by pipe stream name.
          *
          * @type {Object.<String, Object>}
@@ -292,6 +293,16 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
          * @type {Object.<String, Function>}
          */
         this.deferredPipeStreamHandlers = template.deferredPipeStreamHandlers || {};
+
+        /**
+         * State tracking Azure AD sign-in for this client. The device code
+         * prompt arrives as an inbound pipe stream with the Azure AD mimetype
+         * and is shown as a QR code; sign-in itself completes out of band (on
+         * the user's phone) while the server polls Azure.
+         *
+         * @type ManagedAAD
+         */
+        this.managedAAD = template.managedAAD || null;
 
     };
 
@@ -443,6 +454,17 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             tunnel : tunnel
         });
 
+        // Set up Azure AD sign-in. The device-code prompt is delivered as a
+        // named pipe stream; register a handler for it with the deferred pipe
+        // stream framework rather than overriding the default onpipe handler.
+        managedClient.managedAAD = ManagedAAD.getInstance(managedClient);
+
+        ManagedClient.registerDeferredPipeHandler(managedClient,
+                ManagedAAD.PIPE_NAME,
+                function aadPromptReceived(stream, mimetype, name) {
+            ManagedAAD.handlePrompt(managedClient.managedAAD, stream, mimetype, name);
+        });
+
         // Fire events for tunnel errors
         tunnel.onerror = function tunnelError(status) {
             $rootScope.$apply(function handleTunnelError() {
@@ -458,6 +480,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             tunnelService.getProtocol(uuid).then(function protocolRetrieved(protocol) {
                 managedClient.protocol = protocol.name;
                 managedClient.forms = protocol.connectionForms;
+                $rootScope.$broadcast('guacClientProtocolAssigned', managedClient);
             }, requestService.WARN);
         };
 
@@ -485,6 +508,10 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
 
                     // Connection has closed
                     case Guacamole.Tunnel.State.CLOSED:
+                        // Dismiss any sign-in prompt left stranded by the tunnel
+                        // dropping mid-flow
+                        if (managedClient.managedAAD)
+                            ManagedAAD.clear(managedClient.managedAAD);
                         ManagedClientState.setConnectionState(managedClient.clientState,
                             ManagedClientState.ConnectionState.DISCONNECTED);
                         break;
@@ -522,6 +549,11 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
                     case Guacamole.Client.State.CONNECTED:
                         ManagedClientState.setConnectionState(managedClient.clientState,
                             ManagedClientState.ConnectionState.CONNECTED);
+
+                        // Dismiss any Azure AD sign-in prompt now that sign-in
+                        // has completed and the desktop is connected
+                        if (managedClient.managedAAD)
+                            ManagedAAD.clear(managedClient.managedAAD);
 
                         // Sync current clipboard data
                         clipboardService.getClipboard().then((data) => {

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -125,6 +125,7 @@
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
+        "HELP_AAD_SIGN_IN"         : "This connection requires you to sign in with Azure AD. Scan the QR code with your phone to continue.",
         "HELP_CLIPBOARD"           : "Text copied/cut within Guacamole will appear here. Changes to the text below will affect the remote clipboard.",
         "HELP_INPUT_METHOD_NONE"   : "No input method is used. Keyboard input is accepted from a connected, physical keyboard.",
         "HELP_INPUT_METHOD_OSK"    : "Display and accept input from the built-in Guacamole on-screen keyboard. The on-screen keyboard allows typing of key combinations that may otherwise be impossible (such as Ctrl-Alt-Del).",
@@ -134,6 +135,8 @@
         "HELP_MOUSE_MODE_RELATIVE" : "Drag to move the mouse pointer and tap to click. The click occurs at the location of the pointer.",
         "HELP_SHARE_LINK"          : "The current connection is being shared, and can be accessed by anyone with the following {LINKS, plural, one{link} other{links}}:",
 
+        "INFO_AAD_SIGN_IN_CODE"         : "Then enter the code:",
+        "INFO_AAD_SIGN_IN_INSTRUCTIONS" : "Or, on another device, go to:",
         "INFO_ANONYMOUS_USER_COUNT" : "Anonymous{COUNT, plural, one{} other{ (#)}}",
         "INFO_CONNECTION_SHARED"    : "This connection is now shared.",
         "INFO_NO_FILE_TRANSFERS"    : "No file transfers.",
@@ -601,6 +604,9 @@
 
     "PROTOCOL_RDP" : {
 
+        "FIELD_HEADER_AAD_CLIENT_ID"         : "Azure AD application (client) ID (optional):",
+        "FIELD_HEADER_AAD_SCOPE"             : "Azure AD scope (optional):",
+        "FIELD_HEADER_AAD_TENANT_ID"         : "Azure AD tenant (directory) ID (optional):",
         "FIELD_HEADER_CERT_TOFU"             : "Trust host certificate on first use:",
         "FIELD_HEADER_CERT_FINGERPRINTS"     : "Fingerprints of trusted host certificates:",
         "FIELD_HEADER_CLIENT_NAME"           : "Client name:",
@@ -719,6 +725,7 @@
         "FIELD_OPTION_SECURITY_RDP"   : "RDP encryption",
         "FIELD_OPTION_SECURITY_TLS"   : "TLS encryption",
         "FIELD_OPTION_SECURITY_VMCONNECT" : "Hyper-V / VMConnect",
+        "FIELD_OPTION_SECURITY_AAD"   : "Azure AD (AAD)",
 
         "FIELD_OPTION_SERVER_LAYOUT_CS_CZ_QWERTZ" : "Czech (Qwertz)",
         "FIELD_OPTION_SERVER_LAYOUT_DA_DK_QWERTY" : "Danish (Qwerty)",


### PR DESCRIPTION
Client-side support for the Azure AD (Entra ID) device code sign-in flow used by RDP connections. Paired with apache/guacamole-server#633.

## What it does

When an RDP connection uses `security=aad`, guacd sends a device code prompt (user code and verification URI) to the browser over a pipe stream. This change:

1. Renders that prompt as a QR code the user scans to sign in on a separate device, alongside the user code and a link fallback.
2. Registers a handler for the device code pipe stream by name.
3. Dismisses the prompt automatically when guacd closes the stream (on success, failure, or expiry) or the connection drops.

## Configuration

Adds `aad-client-id`, `aad-scope`, and `aad-tenant-id` fields to the RDP connection form (the `security` option already offered `aad`), with matching field labels and prompt strings.

## Dependencies

Adds `qrcode-generator` (MIT) for QR rendering, with its license registered under `doc/licenses/`.

Paired with [apache/guacamole-server#633](https://github.com/apache/guacamole-server/pull/633)
