### PR TITLE
GUACAMOLE-2224: Fix effective user group expansion for SAML/SSO groups

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledPermissions.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledPermissions.java
@@ -20,6 +20,7 @@
 package org.apache.guacamole.auth.jdbc.base;
 
 import com.google.inject.Inject;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.guacamole.auth.jdbc.permission.SystemPermissionService;
@@ -210,6 +211,26 @@ public abstract class ModeledPermissions<ModelType extends EntityModel>
     public Set<String> getEffectiveUserGroups() {
         return entityService.retrieveEffectiveGroups(this,
                 Collections.<String>emptySet());
+    }
+
+    /**
+     * Returns the identifiers of all user groups that apply to this entity,
+     * including groups defined within the database (inherited through
+     * membership) and any additional groups provided externally (such as from
+     * an SSO provider like SAML or LDAP). The external groups are used as
+     * additional seeds for recursive DB group expansion, so any parent groups
+     * of external groups in the database are also included in the result.
+     *
+     * @param externalEffectiveGroups
+     *     The identifiers of any externally-asserted group memberships (e.g.
+     *     SAML claims) that should be used as seeds for DB group expansion.
+     *
+     * @return
+     *     The identifiers of all user groups that apply to this entity,
+     *     including DB-inherited parent groups of the external groups.
+     */
+    public Set<String> expandEffectiveGroups(Collection<String> externalEffectiveGroups) {
+        return entityService.retrieveEffectiveGroups(this, externalEffectiveGroups);
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledPermissions.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/base/ModeledPermissions.java
@@ -20,7 +20,6 @@
 package org.apache.guacamole.auth.jdbc.base;
 
 import com.google.inject.Inject;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.guacamole.auth.jdbc.permission.SystemPermissionService;
@@ -211,26 +210,6 @@ public abstract class ModeledPermissions<ModelType extends EntityModel>
     public Set<String> getEffectiveUserGroups() {
         return entityService.retrieveEffectiveGroups(this,
                 Collections.<String>emptySet());
-    }
-
-    /**
-     * Returns the identifiers of all user groups that apply to this entity,
-     * including groups defined within the database (inherited through
-     * membership) and any additional groups provided externally (such as from
-     * an SSO provider like SAML or LDAP). The external groups are used as
-     * additional seeds for recursive DB group expansion, so any parent groups
-     * of external groups in the database are also included in the result.
-     *
-     * @param externalEffectiveGroups
-     *     The identifiers of any externally-asserted group memberships (e.g.
-     *     SAML claims) that should be used as seeds for DB group expansion.
-     *
-     * @return
-     *     The identifiers of all user groups that apply to this entity,
-     *     including DB-inherited parent groups of the external groups.
-     */
-    public Set<String> expandEffectiveGroups(Collection<String> externalEffectiveGroups) {
-        return entityService.retrieveEffectiveGroups(this, externalEffectiveGroups);
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -19,7 +19,6 @@
 
 package org.apache.guacamole.auth.jdbc.user;
 
-import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -170,11 +169,21 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
     public void setIdentifier(String identifier) {
         user.setIdentifier(identifier);
     }
-    
+
+
+    /**
+     * Expands a user's groups through the parents in database group hierarchy
+     * so that parent groups of external groups (e.g. SAML/SSO group claims)
+     * are included. This also covers the user's own direct
+     * DB memberships (via entity_id) and skeleton users with null entity_id.
+     *
+     * @return
+     *     The set of effective groups for this user, whether inherited or
+     *     direct.
+     */
     @Override
     public Set<String> getEffectiveUserGroups() {
-        return Sets.union(user.getEffectiveUserGroups(),
-                super.getEffectiveUserGroups());
+        return user.expandEffectiveGroups(super.getEffectiveUserGroups());
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledAuthenticatedUser.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.guacamole.GuacamoleException;
+import org.apache.guacamole.auth.jdbc.base.EntityService;
 import org.apache.guacamole.net.auth.AuthenticatedUser;
 import org.apache.guacamole.net.auth.AuthenticationProvider;
 import org.apache.guacamole.net.auth.Credentials;
@@ -45,6 +46,13 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
      * corresponding ModeledUser.
      */
     private final AuthenticationProvider modelAuthenticationProvider;
+
+    /**
+     * Service for resolving effective group memberships (including recursive
+     * expansion of parent groups in the database group hierarchy) for
+     * arbitrary entities.
+     */
+    private final EntityService entityService;
 
     /**
      * The connections which have been committed for use by this user in the
@@ -74,12 +82,19 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
      * @param user
      *     A ModeledUser object which is backed by the data associated with
      *     this user in the database.
+     *
+     * @param entityService
+     *     The service to use to resolve the effective group memberships of
+     *     this user, including recursive expansion of parent groups in the
+     *     database group hierarchy.
      */
     public ModeledAuthenticatedUser(AuthenticatedUser authenticatedUser,
-            AuthenticationProvider modelAuthenticationProvider, ModeledUser user) {
+            AuthenticationProvider modelAuthenticationProvider, ModeledUser user,
+            EntityService entityService) {
         super(authenticatedUser.getAuthenticationProvider(), authenticatedUser.getCredentials(), authenticatedUser.getEffectiveUserGroups());
         this.modelAuthenticationProvider = modelAuthenticationProvider;
         this.user = user;
+        this.entityService = entityService;
     }
 
     /**
@@ -96,12 +111,18 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
      *
      * @param credentials
      *     The credentials given by the user when they authenticated.
+     *
+     * @param entityService
+     *     The service to use to resolve the effective group memberships of
+     *     this user, including recursive expansion of parent groups in the
+     *     database group hierarchy.
      */
     public ModeledAuthenticatedUser(AuthenticationProvider authenticationProvider,
-            ModeledUser user, Credentials credentials) {
+            ModeledUser user, Credentials credentials, EntityService entityService) {
         super(authenticationProvider, credentials, user.getEffectiveUserGroups());
         this.modelAuthenticationProvider = authenticationProvider;
         this.user = user;
+        this.entityService = entityService;
     }
 
     /**
@@ -128,6 +149,18 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
      */
     public AuthenticationProvider getModelAuthenticationProvider() {
         return modelAuthenticationProvider;
+    }
+
+    /**
+     * Returns the EntityService instance this user was constructed with, which
+     * is used to resolve effective group memberships (including recursive
+     * expansion of parent groups in the database group hierarchy).
+     *
+     * @return
+     *     The EntityService instance this user was constructed with.
+     */
+    public EntityService getEntityService() {
+        return entityService;
     }
 
     /**
@@ -172,10 +205,11 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
 
 
     /**
-     * Expands a user's groups through the parents in database group hierarchy
-     * so that parent groups of external groups (e.g. SAML/SSO group claims)
-     * are included. This also covers the user's own direct
-     * DB memberships (via entity_id) and skeleton users with null entity_id.
+     * Returns the identifiers of all effective groups for this user, including
+     * any parent groups reachable through the database group hierarchy from
+     * externally-asserted memberships (e.g. SAML/SSO group claims), as well as
+     * the user's own direct DB memberships (via entity_id). Skeleton users with
+     * a null entity_id are also handled correctly.
      *
      * @return
      *     The set of effective groups for this user, whether inherited or
@@ -183,7 +217,7 @@ public class ModeledAuthenticatedUser extends RemoteAuthenticatedUser {
      */
     @Override
     public Set<String> getEffectiveUserGroups() {
-        return user.expandEffectiveGroups(super.getEffectiveUserGroups());
+        return entityService.retrieveEffectiveGroups(user, super.getEffectiveUserGroups());
     }
 
     /**

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/PrivilegedModeledAuthenticatedUser.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/PrivilegedModeledAuthenticatedUser.java
@@ -39,7 +39,8 @@ public class PrivilegedModeledAuthenticatedUser extends ModeledAuthenticatedUser
      *     in question.
      */
     public PrivilegedModeledAuthenticatedUser(ModeledAuthenticatedUser authenticatedUser){
-        super(authenticatedUser, authenticatedUser.getModelAuthenticationProvider(), authenticatedUser.getUser());
+        super(authenticatedUser, authenticatedUser.getModelAuthenticationProvider(),
+                authenticatedUser.getUser(), authenticatedUser.getEntityService());
     }
 
     @Override

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/UserService.java
@@ -36,6 +36,7 @@ import org.apache.guacamole.auth.jdbc.base.ActivityRecordModel;
 import org.apache.guacamole.auth.jdbc.base.ActivityRecordSearchTerm;
 import org.apache.guacamole.auth.jdbc.base.ActivityRecordSortPredicate;
 import org.apache.guacamole.auth.jdbc.base.EntityMapper;
+import org.apache.guacamole.auth.jdbc.base.EntityService;
 import org.apache.guacamole.auth.jdbc.base.ModeledActivityRecord;
 import org.apache.guacamole.auth.jdbc.permission.ObjectPermissionMapper;
 import org.apache.guacamole.auth.jdbc.permission.ObjectPermissionModel;
@@ -120,6 +121,14 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
      */
     @Inject
     private EntityMapper entityMapper;
+
+    /**
+     * Service for resolving effective group memberships (including recursive
+     * expansion of parent groups in the database group hierarchy) for
+     * ModeledAuthenticatedUser instances created here.
+     */
+    @Inject
+    private EntityService entityService;
 
     /**
      * Mapper for accessing users.
@@ -413,7 +422,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
 
         // Create corresponding user object, set up cyclic reference
         ModeledUser user = getObjectInstance(null, userModel);
-        user.setCurrentUser(new ModeledAuthenticatedUser(authenticationProvider, user, credentials));
+        user.setCurrentUser(new ModeledAuthenticatedUser(authenticationProvider, user, credentials, entityService));
 
         // Return now-authenticated user
         return user.getCurrentUser();
@@ -451,7 +460,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         // Create corresponding user object, set up cyclic reference
         ModeledUser user = getObjectInstance(null, userModel);
         user.setCurrentUser(new ModeledAuthenticatedUser(authenticatedUser,
-                authenticationProvider, user));
+                authenticationProvider, user, entityService));
 
         // Return already-authenticated user
         return user;
@@ -488,7 +497,7 @@ public class UserService extends ModeledDirectoryObjectService<ModeledUser, User
         
         // Create user object, and configure cyclic reference
         user.setCurrentUser(new ModeledAuthenticatedUser(authenticatedUser,
-                authenticationProvider, user));
+                authenticationProvider, user, entityService));
         
         // Return the new user.
         return user;


### PR DESCRIPTION
PR corresponding to https://issues.apache.org/jira/browse/GUACAMOLE-2224

## Problem

When a user authenticates via an external SSO provider (e.g. SAML with Azure AD), the identity provider asserts group membership by name. These names are stored on the `AuthenticatedUser` and surfaced through `getEffectiveUserGroups()`.

The previous implementation in `ModeledAuthenticatedUser` resolved this with a flat union:

```java
return Sets.union(user.getEffectiveUserGroups(), super.getEffectiveUserGroups());
```

This combined the user's database group memberships with the raw SSO claims, but made no attempt to walk the database group hierarchy. If `child-group` (matched by SAML claim) was a member of `parent-group` in the database, `parent-group` was never included — and any permissions granted only to `parent-group` were invisible to the SSO user.

Database-native users were unaffected because their memberships are stored as `entity_id` references already handled by the existing recursive expansion in `EntityService`.

## Changes

### `ModeledPermissions.expandEffectiveGroups()` — guacamole-auth-jdbc-base

A new method delegates to `EntityService.retrieveEffectiveGroups()`, passing caller-provided external group names as additional seeds for recursive DB group expansion:

```java
public Set<String> expandEffectiveGroups(Collection<String> externalEffectiveGroups) {
    return entityService.retrieveEffectiveGroups(this, externalEffectiveGroups);
}
```

This exposes the existing recursive CTE logic as a callable entry point on the permissions object.

### `ModeledAuthenticatedUser.getEffectiveUserGroups()` — guacamole-auth-jdbc-base

The flat union is replaced with a call to `expandEffectiveGroups()`, passing the raw SSO claims as seeds:

```java
@Override
public Set<String> getEffectiveUserGroups() {
    return user.expandEffectiveGroups(super.getEffectiveUserGroups());
}
```

`super.getEffectiveUserGroups()` returns the SSO group name claims from the originating `AuthenticatedUser`. These are now fed into the recursive expansion, so any ancestor groups of those claims in the database are included in the result — making inherited permissions visible to SSO users.
