### PR TITLE
GUACAMOLE-2225: On-Screen Keyboard: Make Meta latchable like Shift.

### DIFF
--- a/guacamole/src/main/frontend/src/app/osk/styles/osk.css
+++ b/guacamole/src/main/frontend/src/app/osk/styles/osk.css
@@ -92,6 +92,8 @@
 .guac-keyboard .guac-keyboard-key-alt-gr,
 .guac-keyboard .guac-keyboard-key-lctrl,
 .guac-keyboard .guac-keyboard-key-rctrl,
+.guac-keyboard .guac-keyboard-key-meta,
+.guac-keyboard .guac-keyboard-key-super,
 .guac-keyboard .guac-keyboard-key-lshift,
 .guac-keyboard .guac-keyboard-key-rshift {
     text-align: left;
@@ -116,7 +118,8 @@
 /* Active caps */
 .guac-keyboard.guac-keyboard-modifier-caps .guac-keyboard-key-caps,
 
-/* Active super */
+/* Active meta */
+.guac-keyboard.guac-keyboard-modifier-meta .guac-keyboard-key-meta,
 .guac-keyboard.guac-keyboard-modifier-super .guac-keyboard-key-super,
 
 /* Active latin */


### PR DESCRIPTION
##Summary

**Meta** already worked functionally as a modifier, but the CSS was only styling the legacy **Super** key for highlight and toggle. This updates **osk.css** so the Meta key highlights and toggles properly, just like Shift, Ctrl, and Alt. The Super key styling remains for backward compatibility.