### PR TITLE
GUACAMOLE-2232: On-Screen Keyboard: CapsLock gets out-of-sync on macOS.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/OnScreenKeyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/OnScreenKeyboard.js
@@ -306,28 +306,36 @@ Guacamole.OnScreenKeyboard = function(layout) {
                 // Retrieve originally-pressed keysym, if modifier was already pressed
                 var originalKeysym = modifierKeysyms[key.modifier];
 
-                // Activate modifier if not pressed
                 if (originalKeysym === undefined) {
-                    
+                    // Activate modifier if not pressed
                     addClass(keyboard, modifierClass);
                     modifierKeysyms[key.modifier] = key.keysym;
-                    
-                    // Send key event only if keysym is meaningful
-                    if (key.keysym && osk.onkeydown)
-                        osk.onkeydown(key.keysym);
-
                 }
-
-                // Deactivate if not pressed
                 else {
-
+                    // Deactivate modifier if pressed
                     removeClass(keyboard, modifierClass);
                     delete modifierKeysyms[key.modifier];
-                    
-                    // Send key event only if original keysym is meaningful
-                    if (originalKeysym && osk.onkeyup)
-                        osk.onkeyup(originalKeysym);
+                }
 
+                // Toggle modifiers send both keydown and keyup on each press
+                if (key.toggle) {
+                    if (key.keysym && osk.onkeydown)
+                        osk.onkeydown(key.keysym);
+                    if (key.keysym && osk.onkeyup)
+                        osk.onkeyup(key.keysym);
+                }
+
+                // Sticky modifiers send keydown on activate, keyup on deactivate
+                else {
+                    if (originalKeysym === undefined) {
+                        if (key.keysym && osk.onkeydown)
+                            osk.onkeydown(key.keysym);
+                    }
+                    // Deactivate modifier if pressed
+                    else {
+                        if (originalKeysym && osk.onkeyup)
+                            osk.onkeyup(originalKeysym);
+                    }
                 }
 
             }
@@ -928,10 +936,21 @@ Guacamole.OnScreenKeyboard.Key = function(template, name) {
      * the names of keys; both the "RightShift" and "LeftShift" keys may set
      * the "shift" modifier, for example. By default, the key will affect no
      * modifiers.
-     * 
+     *
      * @type {string}
      */
     this.modifier = template.modifier;
+
+    /**
+     * Whether this key is a toggle modifier. Toggle modifiers send both
+     * keydown and keyup events when pressed, so each press performs one
+     * toggle of the modifier state (e.g., Caps Lock, Num Lock, Scroll Lock).
+     * Non-toggle modifiers remain sticky and are released by a subsequent
+     * press. By default, modifiers are not toggles.
+     *
+     * @type {boolean}
+     */
+    this.toggle = template.toggle || false;
 
     /**
      * An array containing the names of each modifier required for this key to

--- a/guacamole/src/main/frontend/src/layouts/de-de-qwertz.json
+++ b/guacamole/src/main/frontend/src/layouts/de-de-qwertz.json
@@ -103,6 +103,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{

--- a/guacamole/src/main/frontend/src/layouts/en-us-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/en-us-qwerty.json
@@ -75,6 +75,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{

--- a/guacamole/src/main/frontend/src/layouts/es-es-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/es-es-qwerty.json
@@ -103,6 +103,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{

--- a/guacamole/src/main/frontend/src/layouts/fr-fr-azerty.json
+++ b/guacamole/src/main/frontend/src/layouts/fr-fr-azerty.json
@@ -106,6 +106,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{

--- a/guacamole/src/main/frontend/src/layouts/it-it-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/it-it-qwerty.json
@@ -103,6 +103,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{

--- a/guacamole/src/main/frontend/src/layouts/nl-nl-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/nl-nl-qwerty.json
@@ -103,6 +103,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{

--- a/guacamole/src/main/frontend/src/layouts/ru-ru-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/ru-ru-qwerty.json
@@ -75,6 +75,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{

--- a/guacamole/src/main/frontend/src/layouts/tr-tr-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/tr-tr-qwerty.json
@@ -74,6 +74,7 @@
         "Caps" : [{
             "title"    : "Caps",
             "modifier" : "caps",
+            "toggle"   : true,
             "keysym"   : 65509
         }],
         "LAlt" : [{


### PR DESCRIPTION
## Summary
- `OnBoardKeyBoard.js`: 
   - Added `Key` object  `toggle` property.
   - Updated logic to send `<keyup><keydown>` for each key press for keys with `toggle == true`.
 - `*erty.json`:
    - Add `toggle = true` for `<Caps>` for all keyboard layouts.

## Testing
- macOS Tahoe (26.3): native browser (Chrome) and Rocky 9 VM  Chrome browser
- Windows 11: native browser (Chrome) and Rocky 9 VM  Chrome browser