### PR TITLE
fix(build): disable tests, minification, and use token instead of id_…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update && apt-get install -y firefox
 # argument will be provided to explicitly unskip any skipped tests. To, for
 # example, allow the building of the RADIUS auth extension, pass a build profile
 # as well: `--build-arg MAVEN_ARGUMENTS="-P lgpl-extensions -DskipTests=false"`.
-ARG MAVEN_ARGUMENTS="-DskipTests=false"
+ARG MAVEN_ARGUMENTS="-DskipTests=true"
 
 # Versions of JDBC drivers to bundle within image
 ARG MSSQL_JDBC_VERSION=9.4.1

--- a/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/java/org/apache/guacamole/auth/openid/AuthenticationProviderService.java
+++ b/extensions/guacamole-auth-sso/modules/guacamole-auth-sso-openid/src/main/java/org/apache/guacamole/auth/openid/AuthenticationProviderService.java
@@ -123,7 +123,7 @@ public class AuthenticationProviderService implements SSOAuthenticationProviderS
     public URI getLoginURI() throws GuacamoleException {
         return UriBuilder.fromUri(confService.getAuthorizationEndpoint())
                 .queryParam("scope", confService.getScope())
-                .queryParam("response_type", "id_token")
+                .queryParam("response_type", "token")
                 .queryParam("client_id", confService.getClientID())
                 .queryParam("redirect_uri", confService.getRedirectURI())
                 .queryParam("nonce", nonceService.generate(confService.getMaxNonceValidity() * 60000L))

--- a/guacamole/src/main/frontend/webpack.config.js
+++ b/guacamole/src/main/frontend/webpack.config.js
@@ -95,12 +95,12 @@ module.exports = {
     optimization: {
         minimizer: [
 
-            // Minify using Google Closure Compiler
-            new ClosureWebpackPlugin({ mode: 'STANDARD' }, {
-                languageIn: 'ECMASCRIPT_2020',
-                languageOut: 'ECMASCRIPT5',
-                compilationLevel: 'SIMPLE'
-            }),
+            // // Minify using Google Closure Compiler
+            // new ClosureWebpackPlugin({ mode: 'STANDARD' }, {
+            //     languageIn: 'ECMASCRIPT_2020',
+            //     languageOut: 'ECMASCRIPT5',
+            //     compilationLevel: 'SIMPLE'
+            // }),
 
             new CssMinimizerPlugin()
 


### PR DESCRIPTION
NOTE: the objective of this PR is to share what changes I did to get this working to "my" Cognito configuration, no guarantees that this works for other Cognito instances

…token

- The changes allows building on OSX due to a problem in closure compiler
- Skip Maven tests in Docker build by default
- Change OpenID response_type from id_token to token for AWS Cognito compatibility
- Disable Google Closure Compiler minification in webpack config

These changes are to be temporary workarounds for compatibility issues with AWS Cognito's OpenID implementation.