### PR TITLE
GUACAMOLE-2002: Deduplicate Kubernetes clipboard configuration section.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
@@ -68,17 +68,6 @@
         },
 
         {
-            "name"  : "clipboard",
-            "fields" : [
-                {
-                    "name"    : "clipboard-buffer-size",
-                    "type"    : "ENUM",
-                    "options" : [ "", "262144", "1048576", "10485760" ]
-                }
-            ]
-        },
-
-        {
             "name"  : "display",
             "fields" : [
                 {
@@ -110,6 +99,11 @@
         {
             "name"  : "clipboard",
             "fields" : [
+                {
+                    "name"    : "clipboard-buffer-size",
+                    "type"    : "ENUM",
+                    "options" : [ "", "262144", "1048576", "10485760" ]
+                },
                 {
                     "name"    : "disable-copy",
                     "type"    : "BOOLEAN",


### PR DESCRIPTION
Only the **main** branch has the duplication issue. So I assume this should be merged to there directly.