### PR TITLE
GUACAMOLE-2248: Move notifications on root of the yaml.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,8 +37,6 @@ github:
 
   # Automatically link/update JIRA when referenced
   autolink_jira: GUACAMOLE
-  notifications:
-    jira_options: link label
 
   # Require merge commits for all PR merges
   enabled_merge_buttons:
@@ -52,3 +50,6 @@ github:
     main: {}
     next: {}
     patch: {}
+
+notifications:
+  jira_options: link label


### PR DESCRIPTION
An error occurred while processing the github feature in .asf.yaml:

while parsing a mapping
  in "guacamole-server.git/.asf.yaml::github", line 19, column 1:
    notifications:
    ^ (line: 19)
unexpected key not in schema 'notifications'
  in "guacamole-server.git/.asf.yaml::github", line 22, column 1:
      # Require merge commits for al ...
    ^ (line: 22)
