### PR TITLE
GUACAMOLE-2252: Preserve Ctrl+Alt when AltGr is genuinely held.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Keyboard.js
+++ b/guacamole-common-js/src/main/webapp/modules/Keyboard.js
@@ -1339,6 +1339,13 @@ Guacamole.Keyboard = function Keyboard(element) {
         if (!guac_keyboard.modifiers.ctrl || !guac_keyboard.modifiers.alt)
             return;
 
+        // Do not release Ctrl+Alt when AltGr is genuinely held. On Windows,
+        // the browser sends a synthetic Left Ctrl before AltGraph. RDP
+        // targets require both Ctrl and Alt scancodes to remain active for
+        // AltGr character resolution.
+        if (guac_keyboard.pressed[0xFE03] || guac_keyboard.pressed[0xFFEA])
+            return;
+
         // Assume [A-Z] never require AltGr
         if (keysym >= 0x0041 && keysym <= 0x005A)
             return;


### PR DESCRIPTION
On Windows, the browser sends a synthetic Left Ctrl keydown before the AltGraph keydown. The release_simulated_altgr function checks whether Ctrl+Alt are pressed and, for printable keysyms, releases them. This breaks AltGr character input because Windows RDP targets require both Ctrl and Alt scancodes to remain active for AltGr resolution.

Add a guard that checks whether AltGr (0xFE03) or Right Alt (0xFFEA) is genuinely held in guac_keyboard.pressed before allowing the release. When either key is active, Ctrl+Alt are preserved, and the correct AltGr character is produced on the target.