### PR TITLE
GUACAMOLE-2259: Fix crash when cursor instruction has zero width or height

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Layer.js
+++ b/guacamole-common-js/src/main/webapp/modules/Layer.js
@@ -314,9 +314,10 @@ Guacamole.Layer = function(width, height) {
         canvas.width = layer.width;
         canvas.height = layer.height;
 
-        // Copy image contents to new canvas
+        // Copy image contents to new canvas if layer has nonzero dimensions
         var context = canvas.getContext('2d');
-        context.drawImage(layer.getCanvas(), 0, 0);
+        if (layer.width > 0 && layer.height > 0)
+            context.drawImage(layer.getCanvas(), 0, 0);
 
         return canvas;
 


### PR DESCRIPTION
After implementing server changes in https://github.com/apache/guacamole-server/pull/657.  This bug was exposed and caused the client to crash.