### PR TITLE
GUACAMOLE-2212: Bust translation JSON URLs and clear language cache on login.

### DIFF
--- a/guacamole/src/main/frontend/src/app/locale/services/translationLoader.js
+++ b/guacamole/src/main/frontend/src/app/locale/services/translationLoader.js
@@ -26,10 +26,19 @@
 angular.module('locale').factory('translationLoader', ['$injector', function translationLoader($injector) {
 
     // Required services
+    var $document       = $injector.get('$document');
     var $http           = $injector.get('$http');
     var $q              = $injector.get('$q');
     var cacheService    = $injector.get('cacheService');
     var languageService = $injector.get('languageService');
+
+    /**
+     * The current build identifier, if available. This is used for
+     * cache-busting translation file requests between deployments.
+     *
+     * @type {String}
+     */
+    const buildMeta = $document[0].querySelector('meta[name="build"]');
 
     /**
      * Satisfies a translation request for the given key by searching for the
@@ -82,11 +91,17 @@ angular.module('locale').factory('translationLoader', ['$injector', function tra
                 return;
             }
 
+            // Construct translation URL; append ?b=<build>
+            // when meta is present to avoid stale cached JSON after deploy.
+            const translationURL = 'translations/' + encodeURIComponent(currentKey) + '.json'
+                    + ((buildMeta && buildMeta.content) ? ('?b='
+                    + encodeURIComponent(buildMeta.content)) : '');
+
             // Attempt to retrieve language
             $http({
                 cache   : cacheService.languages,
                 method  : 'GET',
-                url     : 'translations/' + encodeURIComponent(currentKey) + '.json'
+                url     : translationURL
             })
 
             // Resolve promise if translation retrieved successfully

--- a/guacamole/src/main/frontend/src/app/login/directives/login.js
+++ b/guacamole/src/main/frontend/src/app/login/directives/login.js
@@ -71,6 +71,7 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
         var $route                = $injector.get('$route');
         var $translate            = $injector.get('$translate');
         var authenticationService = $injector.get('authenticationService');
+        var cacheService          = $injector.get('cacheService');
         var requestService        = $injector.get('requestService');
 
         /**
@@ -226,6 +227,7 @@ angular.module('login').directive('guacLogin', [function guacLogin() {
         // after route change has succeeded as this can take time)
         // and refresh the translation
         $rootScope.$on('guacLogin', function loginSuccessful() {
+            cacheService.languages.removeAll();
             $route.reload();
             $translate.refresh();
         });


### PR DESCRIPTION
- Append `?b=<build>` to `translations/<lang>.json` when `<meta name="build">` is present so browsers and intermediaries do not reuse an old JSON object for the same path after a release.
- On successful login, clear `cacheService.languages` before `$translate.refresh()` so **Angular’s** in-memory language cache cannot keep an outdated translation table across sessions in the same tab.