### PR TITLE
GUACAMOLE-2220: Kubernetes: add support for terminal-type.

### DIFF
--- a/guacamole-ext/src/main/java/org/apache/guacamole/form/Field.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/form/Field.java
@@ -22,6 +22,7 @@ package org.apache.guacamole.form;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Represents an arbitrary field, such as an HTTP parameter, the parameter of a
@@ -148,6 +149,31 @@ public class Field {
     private Collection<String> options;
 
     /**
+     * Conditionally overrides this field's label with an alternate
+     * label based on the value of another field.
+     *
+     * This value is a map of string keys to values, similar to a
+     * JSON object. For example:
+     *
+     * {
+     *     "field"    : "exec-command",
+     *     "equals"   : "",
+     *     "labelKey" : "FIELD_HEADER_TERMINAL_TYPE_ATTACH"
+     * }
+     *
+     * Supported entries include:
+     * - "field"      : (String) name of the field to evaluate
+     * - "equals"     : (Object) value the field must equal (optional)
+     * - "notEquals"  : (Object) value the field must not equal (optional)
+     * - "labelKey"   : (String) label key to use if the condition
+     *                           matches
+     *
+     * Exactly one of "equals" or "notEquals" should be specified. If both
+     * are specified, "equals" takes precedence and "notEquals" is ignored.
+     */
+    private Map<String, Object> conditionalLabel;
+
+    /**
      * Creates a new Parameter with no associated name or type.
      */
     public Field() {
@@ -245,6 +271,27 @@ public class Field {
      */
     public void setOptions(Collection<String> options) {
         this.options = options;
+    }
+
+    /**
+     * Returns the conditional label definition for this field, or null if the
+     * label is unconditional.
+     *
+     * @return
+     *     The conditional label map, or null.
+     */
+    public Map<String, Object> getConditionalLabel() {
+        return conditionalLabel;
+    }
+
+    /**
+     * Sets the conditional label definition for this field.
+     *
+     * @param conditionalLabel
+     *     The conditional label map, or null for no condition.
+     */
+    public void setConditionalLabel(Map<String, Object> conditionalLabel) {
+        this.conditionalLabel = conditionalLabel;
     }
 
 }

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
@@ -119,6 +119,16 @@
                     "name"    : "backspace",
                     "type"    : "ENUM",
                     "options" : [ "", "127", "8" ]
+                },
+                {
+                    "name"      : "terminal-type",
+                    "type"      : "ENUM",
+                    "options"   : [ "", "xterm", "xterm-256color", "vt220", "vt100", "ansi", "linux" ],
+                    "conditionalLabel" : {
+                        "field"    : "exec-command",
+                        "equals"   : "",
+                        "labelKey" : "FIELD_HEADER_TERMINAL_TYPE_ATTACH"
+                    }
                 }
             ]
         },

--- a/guacamole/src/main/frontend/src/app/form/directives/formField.js
+++ b/guacamole/src/main/frontend/src/app/form/directives/formField.js
@@ -75,7 +75,15 @@ angular.module('form').directive('guacFormField', [function formField() {
              *
              * @type ManagedClient
              */
-            client: '='
+            client: '=',
+
+            /**
+             * All current field values in the form, keyed by field name.
+             * Required to evaluate conditionalLabel conditions.
+             *
+             * @type Object.<String, String>
+             */
+            values: '='
 
         },
         templateUrl: 'app/form/templates/formField.html',
@@ -107,18 +115,12 @@ angular.module('form').directive('guacFormField', [function formField() {
             }) + '-' + new Date().getTime().toString(36);
 
             /**
-             * Produces the translation string for the header of the current
-             * field. The translation string will be of the form:
-             *
-             * <code>NAMESPACE.FIELD_HEADER_NAME<code>
-             *
-             * where <code>NAMESPACE</code> is the namespace provided to the
-             * directive and <code>NAME</code> is the field name transformed
-             * via translationStringService.canonicalize().
+             * Returns the translation key for this field's label, of the form
+             * NAMESPACE.FIELD_HEADER_NAME. If the field defines a
+             * conditionalLabel and its condition is met, returns the alternate
+             * key instead.
              *
              * @returns {String}
-             *     The translation string which produces the translated header
-             *     of the field.
              */
             $scope.getFieldHeader = function getFieldHeader() {
 
@@ -126,8 +128,34 @@ angular.module('form').directive('guacFormField', [function formField() {
                 if (!$scope.field || !$scope.field.name)
                     return '';
 
-                return translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE')
-                        + '.FIELD_HEADER_' + translationStringService.canonicalize($scope.field.name);
+                var ns = translationStringService.canonicalize($scope.namespace || 'MISSING_NAMESPACE');
+
+                var conditionalLabel = $scope.field.conditionalLabel;
+                if (conditionalLabel && conditionalLabel.labelKey && $scope.values) {
+
+                    var depValue = $scope.values[conditionalLabel.field];
+                    if (depValue == null)
+                        depValue = '';
+
+                    // equals and notEquals are mutually exclusive; equals wins if both are set
+                    var hasEquals    = 'equals'    in conditionalLabel;
+                    var hasNotEquals = 'notEquals' in conditionalLabel;
+                    var conditionMet;
+                    if (hasEquals)
+                        conditionMet = depValue === conditionalLabel.equals;
+                    else if (hasNotEquals)
+                        conditionMet = depValue !== conditionalLabel.notEquals;
+                    else {
+                        $log.warn('conditionalLabel for field "' + $scope.field.name
+                                + '" specifies neither "equals" nor "notEquals"; ignoring.');
+                        conditionMet = false;
+                    }
+
+                    if (conditionMet)
+                        return ns + '.' + conditionalLabel.labelKey;
+                }
+
+                return ns + '.FIELD_HEADER_' + translationStringService.canonicalize($scope.field.name);
 
             };
 

--- a/guacamole/src/main/frontend/src/app/form/templates/form.html
+++ b/guacamole/src/main/frontend/src/app/form/templates/form.html
@@ -14,7 +14,8 @@
                              focused="isFocused(field)"
                              field="field"
                              client="client"
-                             model="values[field.name]"></guac-form-field>
+                             model="values[field.name]"
+                             values="values"></guac-form-field>
         </div>
 
     </div>

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -531,6 +531,8 @@
         "FIELD_HEADER_RECORDING_NAME"  : "Recording name:",
         "FIELD_HEADER_RECORDING_PATH"  : "Recording path:",
         "FIELD_HEADER_SCROLLBACK"      : "Maximum scrollback size:",
+        "FIELD_HEADER_TERMINAL_TYPE"        : "Terminal type (available as $TERM in command):",
+        "FIELD_HEADER_TERMINAL_TYPE_ATTACH" : "Terminal type (set manually in session):",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript name:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript path:",
         "FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING" : "@:APP.FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING",
@@ -561,6 +563,14 @@
         "FIELD_OPTION_FONT_SIZE_72"    : "72",
         "FIELD_OPTION_FONT_SIZE_96"    : "96",
         "FIELD_OPTION_FONT_SIZE_EMPTY" : "",
+
+        "FIELD_OPTION_TERMINAL_TYPE_ANSI"           : "ansi",
+        "FIELD_OPTION_TERMINAL_TYPE_EMPTY"          : "",
+        "FIELD_OPTION_TERMINAL_TYPE_LINUX"          : "linux",
+        "FIELD_OPTION_TERMINAL_TYPE_VT100"          : "vt100",
+        "FIELD_OPTION_TERMINAL_TYPE_VT220"          : "vt220",
+        "FIELD_OPTION_TERMINAL_TYPE_XTERM"          : "xterm",
+        "FIELD_OPTION_TERMINAL_TYPE_XTERM_256COLOR" : "xterm-256color",
 
         "NAME" : "Kubernetes",
 


### PR DESCRIPTION
### Related PRs
[GUACAMOLE-2220 (server 637)](https://github.com/apache/guacamole-server/pull/637)
[GUACAMOLE-2220 (manual 291)](https://github.com/apache/guacamole-manual/pull/291)

### Overview
Unlike SSH and Telnet, Kubernetes sessions do not automatically pass a terminal type. Kubernetes exposes stdin, stdout, and stderr, but has no built-in way to propagate the TERM environment variable.

Kubernetes supports two connection modes:
- **Attach**: connect stdin/stdout/stderr to the main process already running in the container.
- **Exec**: start a new process in the container and connect to that process.

Because Kubernetes does not pass the terminal type itself, this change adds a server-side substitution mechanism for Exec sessions: Any **$TERM** in the Exec command line is replaced with the configured terminal type when the session starts. This lets users decide whether and how to pass the terminal type, for example:
```
env TERM=$TERM /bin/bash
```
Attach mode has no command line, so the terminal type is not propagated automatically.

- Adds support for `terminal-type` for Kubernetes sessions.
- Adds `conditionalLabel` for `Field`, so a form field can replace its label based on another field's value.
- `conditionalLabel`  is used for the Kubernetes `terminal-type` label:
   - If `exec-command` is empty,  the label uses the default `Terminal type (set manually in session):`.
<img width="433" height="100" alt="image" src="https://github.com/user-attachments/assets/79177b9b-5741-4e05-b768-53d5c0514c22" />
   - Else, (a command was specified), the label switches to `Terminal type (available as $TERM in command):`.
<img width="493" height="101" alt="image" src="https://github.com/user-attachments/assets/cd19f435-fc36-49d1-bb4a-0cf738ce7746" />