### PR TITLE
GUACAMOLE-1969: Clamp negative timestamps in ClipboardEventInterpreter.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/ClipboardEventInterpreter.js
+++ b/guacamole-common-js/src/main/webapp/modules/ClipboardEventInterpreter.js
@@ -130,11 +130,16 @@ Guacamole.ClipboardEventInterpreter = function ClipboardEventInterpreter(startTi
                 }
             }
 
-            // Create the clipboard event
+            // Create the clipboard event. A clipboard stream may arrive
+            // before the first sync instruction has set lastTimestamp, in
+            // which case stream.timestamp - startTimestamp is negative.
+            // Clamp to 0 so pre-connection clipboard syncs land at the
+            // start of the playback timeline rather than producing a
+            // negative timestamp that breaks playerTimeService.formatTime().
             parsedEvents.push(new Guacamole.ClipboardEventInterpreter.ClipboardEvent({
                 mimetype: stream.mimetype,
                 data: decodedData,
-                timestamp: stream.timestamp - startTimestamp
+                timestamp: Math.max(0, stream.timestamp - startTimestamp)
             }));
 
             // Clean up the stream


### PR DESCRIPTION
A clipboard stream may arrive in the recording before the first sync instruction sets `lastTimestamp`, leaving `stream.timestamp` at 0 when the event is finalized. The resulting event timestamp is then computed as `0 - startTimestamp`, producing a large negative value.

When the recording player renders the affected batch, it calls `playerTimeService.formatTime(value)` on that negative timestamp. The leading '-' breaks the regex match used to strip leading zeroes, `.exec()` returns `null`, and indexing null throws a `TypeError` inside `$interpolate`. Angular swallows the exception and leaves the "{{ formatTime(batch.events[0].timestamp) }}" placeholder literal in the DOM for that batch.

Clamp the event timestamp to a minimum of 0 so clipboard syncs that predate the first sync instruction land at the start of the playback timeline.