### PR TITLE
GUACAMOLE-2277: On-Screen Keyboard: incorrect Meta keysym generated.

### DIFF
--- a/guacamole/src/main/frontend/src/layouts/de-de-qwertz.json
+++ b/guacamole/src/main/frontend/src/layouts/de-de-qwertz.json
@@ -118,7 +118,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
 
         "^" : [

--- a/guacamole/src/main/frontend/src/layouts/en-us-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/en-us-qwerty.json
@@ -90,7 +90,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
 
         "`" : [

--- a/guacamole/src/main/frontend/src/layouts/es-es-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/es-es-qwerty.json
@@ -118,7 +118,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
 
         "º" : [

--- a/guacamole/src/main/frontend/src/layouts/fr-fr-azerty.json
+++ b/guacamole/src/main/frontend/src/layouts/fr-fr-azerty.json
@@ -121,7 +121,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
 
         "²" : [

--- a/guacamole/src/main/frontend/src/layouts/it-it-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/it-it-qwerty.json
@@ -118,7 +118,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
 
         "\\" : [

--- a/guacamole/src/main/frontend/src/layouts/nl-nl-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/nl-nl-qwerty.json
@@ -118,7 +118,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
 
         "@" : [

--- a/guacamole/src/main/frontend/src/layouts/ru-ru-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/ru-ru-qwerty.json
@@ -90,7 +90,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
         "Latin" : [{
             "title"    : "Latin",

--- a/guacamole/src/main/frontend/src/layouts/tr-tr-qwerty.json
+++ b/guacamole/src/main/frontend/src/layouts/tr-tr-qwerty.json
@@ -89,7 +89,7 @@
         "Meta" : [{
             "title"    : "Meta",
             "modifier" : "meta",
-            "keysym"   : 65511
+            "keysym"   : 65515
         }],
 
         "\"" : [


### PR DESCRIPTION
Currently, the On-Screen Keyboard Meta key generates Super_L keysym. This works fine for RDP sessions:
- Linux, treats it as the Meta key.
- Windows interprets as Meta which is treated as the Windows key.

With VNC, inconsistent browser key events are generated
- Linux, pressing Meta emits an Alt/Shift sequence.
- macOS: pressing Meta emits AltLeft.

Emitting Meta_L instead:
- RDP, Windows and Linux: change in behavior.
- VNC, Linux macOS: Meta browser key events are generated.

See the Jira for more details: https://issues.apache.org/jira/browse/GUACAMOLE-2277