### PR TITLE
GUACAMOLE-2276: Add and update Czech localization entries

### DIFF
--- a/guacamole/src/main/frontend/src/translations/cs.json
+++ b/guacamole/src/main/frontend/src/translations/cs.json
@@ -84,6 +84,7 @@
         "ERROR_CLIENT_201"     : "Synchronizační server je zaneprázdněn, zkuste to prosím znovu později.",
         "ERROR_CLIENT_202"     : "Guacamole server zavřel spojení protože vzdálený počítač příliš dlouho neodpovídal. Zkuste to prosím později, nebo kontaktujte správce.",
         "ERROR_CLIENT_203"     : "Chyba vzdáleného serveru, spojení bylo uzavřeno. Zkuste to prosím později, nebo kontaktujte správce.",
+        "ERROR_CLIENT_205"     : "Toto připojení vyžaduje prostředek, který je právě používán, ale sdílený přístup k tomuto prostředku buď není možný, nebo není povolen. Zkuste to prosím později.",
         "ERROR_CLIENT_207"     : "Server vzdálené plochy je aktuálně nedostupný. Pokud problém přetrvává, informujte prosím správce systému nebo zkontrolujte systémové protokoly.",
         "ERROR_CLIENT_208"     : "Server vzdálené plochy není aktuálně k dispozici. Pokud problém přetrvává, informujte prosím správce systému nebo zkontrolujte systémové protokoly.",
         "ERROR_CLIENT_209"     : "Server vzdálené plochy ukončil připojení, protože je v konfliktu s jiným připojením. Prosím zkuste to znovu později.",
@@ -127,7 +128,7 @@
         "HELP_INPUT_METHOD_OSK"    : "Zobrazte a přijměte vstup z vestavěné klávesnice Guacamole na obrazovce. Klávesnice na obrazovce umožňuje zadávat kombinace kláves, které jinak mohou být nemožné (například Ctrl-Alt-Del).",
         "HELP_INPUT_METHOD_TEXT"   : "Povolit psaní textu a emulovat události klávesnice na základě zadaného textu. To je nezbytné pro zařízení, jako jsou mobilní telefony, které nemají fyzickou klávesnici.",
         "HELP_MOUSE_MODE"          : "Určuje, jak se bude vzdálená myš chovat s ohledem na dotyky.",
-        "HELP_MOUSE_MODE_ABSOLUTE" : "Tap to click. Kliknutí nastane v místě dotyku.",
+        "HELP_MOUSE_MODE_ABSOLUTE" : "Klepnutím kliknete. Kliknutí nastane v místě dotyku.",
         "HELP_MOUSE_MODE_RELATIVE" : "Přetažením myši posuňte ukazatel myši a klepněte na tlačítko. Kliknutí nastane v místě ukazatele.",
         "HELP_SHARE_LINK"          : "Aktuální připojení je sdíleno a může k němu přistupovat kdokoli s následujícím {LINKS, plural, one{odkazem} other{odkazy}}:",
 
@@ -484,6 +485,7 @@
     "PLAYER" : {
 
         "ACTION_CANCEL"       : "@:APP.ACTION_CANCEL",
+        "ACTION_CLOSE"        : "Zavřít",
         "ACTION_PAUSE"        : "@:APP.ACTION_PAUSE",
         "ACTION_PLAY"         : "@:APP.ACTION_PLAY",
         "ACTION_SHOW_KEY_LOG" : "Záznam stisků kláves",
@@ -492,7 +494,7 @@
         "INFO_KEY_EVENTS_LEGEND"   : "Aktivita klávesnice",
         "INFO_LOADING_RECORDING"   : "Vaše nahrávka se nyní načítá. Prosím, vyčkejte...",
         "INFO_NO_KEY_LOG"          : "Záznam stisků kláves není k dispozici",
-        "INFO_NUMBER_OF_RESULTS"   : "{RESULTS} {RESULTS, plural, one{Match} other{Matches}}",
+        "INFO_NUMBER_OF_RESULTS"   : "{RESULTS} {RESULTS, plural, one{shoda} few{shody} other{shod}}",
         "INFO_SEEK_IN_PROGRESS"    : "Hledání požadované pozice. Čekejte prosím...",
 
         "FIELD_PLACEHOLDER_TEXT_BATCH_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER"
@@ -513,8 +515,8 @@
         "FIELD_HEADER_DISABLE_COPY"    : "Zakázat kopírování ze vzdáleného terminálu:",
         "FIELD_HEADER_DISABLE_PASTE"   : "Zakázat vkládání z klienta:",
         "FIELD_HEADER_EXEC_COMMAND"    : "Příkaz (exec):",
-        "FIELD_HEADER_FONT_NAME"       : "Jméno fontu:",
-        "FIELD_HEADER_FONT_SIZE"       : "Velikost fontu:",
+        "FIELD_HEADER_FONT_NAME"       : "Název písma:",
+        "FIELD_HEADER_FONT_SIZE"       : "Velikost písma:",
         "FIELD_HEADER_HOSTNAME"        : "Jméno hostitele:",
         "FIELD_HEADER_IGNORE_CERT"     : "Ignorovat serverový certifikát:",
         "FIELD_HEADER_NAMESPACE"       : "Obor názvů:",
@@ -740,7 +742,7 @@
         "FIELD_HEADER_CREATE_TYPESCRIPT_PATH" : "Automaticky vytvořit cestu ke strojopisu:",
         "FIELD_HEADER_DISABLE_COPY"  : "Zakázat kopírování ze vzdáleného terminálu:",
         "FIELD_HEADER_DISABLE_PASTE" : "Zakázat vkládání z klienta:",
-        "FIELD_HEADER_FONT_NAME"     : "Typ fontu:",
+        "FIELD_HEADER_FONT_NAME"     : "Název písma:",
         "FIELD_HEADER_FONT_SIZE"     : "Velikost písma:",
         "FIELD_HEADER_ENABLE_SFTP"   : "Povolit SFTP:",
         "FIELD_HEADER_HOST_KEY"      : "Veřejný klíč hosta (Base64):",
@@ -834,8 +836,8 @@
         "FIELD_HEADER_CREATE_TYPESCRIPT_PATH" : "Automaticky vytvořit cestu ke strojopisu:",
         "FIELD_HEADER_DISABLE_COPY"   : "Zakázat kopírování z terminálu:",
         "FIELD_HEADER_DISABLE_PASTE"  : "Zakázat vkládání z klienta:",
-        "FIELD_HEADER_FONT_NAME"      : "Jméno fontu:",
-        "FIELD_HEADER_FONT_SIZE"      : "Velikost fontu:",
+        "FIELD_HEADER_FONT_NAME"      : "Název písma:",
+        "FIELD_HEADER_FONT_SIZE"      : "Velikost písma:",
         "FIELD_HEADER_HOSTNAME"       : "Jméno hostitele:",
         "FIELD_HEADER_LOGIN_FAILURE_REGEX" : "Přihlášení se nezdařilo regulární výraz:",
         "FIELD_HEADER_LOGIN_SUCCESS_REGEX" : "Přihlášení bylo úspěšné regulární výraz:",
@@ -968,7 +970,6 @@
         "FIELD_OPTION_COLOR_DEPTH_24"    : "Opravdové barvy (24-bitů)",
         "FIELD_OPTION_COLOR_DEPTH_32"    : "Opravdové barvy (32-bitů)",
         "FIELD_OPTION_COLOR_DEPTH_EMPTY" : "",
-
 
         "FIELD_OPTION_CURSOR_EMPTY"  : "",
         "FIELD_OPTION_CURSOR_LOCAL"  : "Místní",


### PR DESCRIPTION
Update `cs.json` for the 1.6.1 release line.

**Added translations**
- `CLIENT.ERROR_CLIENT_205` - connection resource sharing error
- `PLAYER.ACTION_CLOSE` - recording player close action

**Updated translations**
- `CLIENT.HELP_MOUSE_MODE_ABSOLUTE` - remove mixed English wording
- `PLAYER.INFO_NUMBER_OF_RESULTS` - Czech plural forms (`shoda` / `shody` / `shod`)
- `FIELD_HEADER_FONT_NAME` / `FIELD_HEADER_FONT_SIZE` - standardized to "Název písma" / "Velikost písma" (Kubernetes, SSH, Telnet)