### PR TITLE
GUACAMOLE-2281: Add WebAuthn passthrough relay over auth-challenge.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -23,7 +23,7 @@ var Guacamole = Guacamole || {};
  * Guacamole protocol client. Given a {@link Guacamole.Tunnel},
  * automatically handles incoming and outgoing Guacamole instructions via the
  * provided tunnel, updating its display using one or more canvas elements.
- * 
+ *
  * @constructor
  * @param {!Guacamole.Tunnel} tunnel
  *     The tunnel to use to send and receive Guacamole instructions.
@@ -540,6 +540,35 @@ Guacamole.Client = function(tunnel) {
     };
 
     /**
+     * Sends an auth-response instruction over the tunnel, announcing an
+     * output stream carrying the response body for a previously-received
+     * auth-challenge identified by the same challengeId.
+     *
+     * @param {!string} mimetype
+     *     The mimetype of the data which will be sent over the returned
+     *     stream.
+     *
+     * @param {!string} challengeId
+     *     The challenge identifier of the originating auth-challenge
+     *     being responded to.
+     *
+     * @return {Guacamole.OutputStream}
+     *     The created stream, or null if not connected.
+     */
+    this.sendAuthResponse = function(mimetype, challengeId) {
+
+        // Do not send if not connected
+        if (!isConnected())
+            return null;
+
+        var stream = guac_client.createOutputStream();
+        tunnel.sendMessage("auth-response", stream.index, mimetype,
+                challengeId);
+        return stream;
+
+    };
+
+    /**
      * Opens a new clipboard object for writing, having the given mimetype. The
      * instruction necessary to create this stream will automatically be sent.
      *
@@ -917,7 +946,26 @@ Guacamole.Client = function(tunnel) {
      *     The name of the pipe.
      */
     this.onpipe = null;
-    
+
+    /**
+     * Fired when an "auth-challenge" instruction is received from the
+     * server, announcing a stream carrying the challenge body for a
+     * pending authentication exchange. The handler is responsible for
+     * consuming the body from the given input stream and replying via
+     * sendAuthResponse() with the same challengeId.
+     *
+     * @event
+     * @param {!Guacamole.InputStream} stream
+     *     The input stream carrying the challenge body.
+     *
+     * @param {!string} mimetype
+     *     The mimetype of the challenge body. Identifies the auth flavor.
+     *
+     * @param {!string} challengeId
+     *     The challenge identifier carried by the auth-challenge.
+     */
+    this.onauthchallenge = null;
+
     /**
      * Fired when a "required" instruction is received. A required instruction
      * indicates that additional parameters are required for the connection to
@@ -1557,7 +1605,7 @@ Guacamole.Client = function(tunnel) {
             var mimetype = parameters[1];
             var name = parameters[2];
 
-            // Create stream 
+            // Create stream
             if (guac_client.onpipe) {
                 var stream = streams[stream_index] = new Guacamole.InputStream(guac_client, stream_index);
                 guac_client.onpipe(stream, mimetype, name);
@@ -1566,6 +1614,23 @@ Guacamole.Client = function(tunnel) {
             // Otherwise, unsupported
             else
                 guac_client.sendAck(stream_index, "Named pipes unsupported", 0x0100);
+
+        },
+
+        "auth-challenge": function(parameters) {
+
+            var stream_index = parseInt(parameters[0]);
+            var mimetype = parameters[1];
+            var challengeId = parameters[2];
+
+            if (guac_client.onauthchallenge) {
+                var stream = streams[stream_index] =
+                        new Guacamole.InputStream(guac_client, stream_index);
+                guac_client.onauthchallenge(stream, mimetype, challengeId);
+            }
+            else
+                guac_client.sendAck(stream_index,
+                        "Auth challenges unsupported", 0x0100);
 
         },
 

--- a/guacamole/src/main/frontend/src/app/client/templates/client.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/client.html
@@ -119,6 +119,9 @@
                     </div>
                 </div>
 
+                <!-- WebAuthn passthrough -->
+                <guac-web-authn client="focusedClient"></guac-web-authn>
+
                 <!-- Connection parameters which may be modified while the connection is open -->
                 <div class="menu-section connection-parameters" id="connection-settings" ng-if="focusedClient.protocol">
                     <guac-form namespace="getProtocolNamespace(focusedClient.protocol)"

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -36,6 +36,7 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     const ManagedFilesystem      = $injector.get('ManagedFilesystem');
     const ManagedFileUpload      = $injector.get('ManagedFileUpload');
     const ManagedShareLink       = $injector.get('ManagedShareLink');
+    const ManagedWebAuthn        = $injector.get('ManagedWebAuthn');
 
     // Required services
     const $document               = $injector.get('$document');
@@ -293,6 +294,17 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
          */
         this.deferredPipeStreamHandlers = template.deferredPipeStreamHandlers || {};
 
+        /**
+         * State tracking the WebAuthn passthrough relay for this client.
+         * Ceremony requests arrive as inbound "auth-challenge" streams
+         * with WebAuthn-flavored mimetypes; responses are sent back as
+         * outbound "auth-response" streams carrying the credential or
+         * error.
+         *
+         * @type ManagedWebAuthn
+         */
+        this.managedWebAuthn = template.managedWebAuthn || null;
+
     };
 
     /**
@@ -443,6 +455,25 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             tunnel : tunnel
         });
 
+        // Set up WebAuthn passthrough and dispatch inbound auth-challenge
+        // streams to it. Other mimetypes are not currently expected.
+        managedClient.managedWebAuthn = ManagedWebAuthn.getInstance(managedClient);
+
+        client.onauthchallenge = function clientAuthChallengeReceived(
+                stream, mimetype, challengeId) {
+            if (ManagedWebAuthn.handlesMimetype(mimetype))
+                ManagedWebAuthn.handleChallenge(
+                        managedClient.managedWebAuthn,
+                        stream, mimetype, challengeId);
+            else {
+                console.warn('[ManagedClient] no handler for auth-challenge '
+                        + 'mimetype "' + mimetype + '" (id=' + challengeId
+                        + ')');
+                stream.sendAck('Unsupported auth-challenge mimetype',
+                        Guacamole.Status.Code.UNSUPPORTED);
+            }
+        };
+
         // Fire events for tunnel errors
         tunnel.onerror = function tunnelError(status) {
             $rootScope.$apply(function handleTunnelError() {
@@ -485,6 +516,11 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
 
                     // Connection has closed
                     case Guacamole.Tunnel.State.CLOSED:
+                        // Dismiss any local authenticator UI left stranded
+                        // by the tunnel dropping mid-ceremony.
+                        if (managedClient.managedWebAuthn)
+                            ManagedWebAuthn.abortAll(
+                                    managedClient.managedWebAuthn);
                         ManagedClientState.setConnectionState(managedClient.clientState,
                             ManagedClientState.ConnectionState.DISCONNECTED);
                         break;

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedWebAuthn.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedWebAuthn.js
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides the ManagedWebAuthn class used by ManagedClient to relay
+ * WebAuthn ceremonies from a remote session to the user's local
+ * authenticator. Ceremony requests arrive as inbound "auth-challenge"
+ * streams whose mimetype identifies the ceremony kind; responses are
+ * sent back as outbound "auth-response" streams referencing the same
+ * challenge_id.
+ */
+angular.module('client').factory('ManagedWebAuthn', ['$injector', '$rootScope',
+    function defineManagedWebAuthn($injector, $rootScope) {
+
+    const webAuthnService = $injector.get('webAuthnService');
+
+    /**
+     * Mimetypes recognized by this relay, keyed by mimetype value to the
+     * ceremony kind ("create" or "get") that they identify.
+     *
+     * @private
+     * @constant
+     * @type {!Object.<String, String>}
+     */
+    const MIMETYPE_KIND = {
+        'application/x-webauthn-create+json': 'create',
+        'application/x-webauthn-get+json':    'get'
+    };
+
+    /**
+     * Runs the given mutation inside an Angular digest. handleChallenge
+     * is called from Guacamole's tunnel.oninstruction dispatch which runs
+     * outside Angular, so state changes the panel template watches need
+     * an explicit $apply. Callbacks resolved through $q are already
+     * inside a digest, so this is a no-op there.
+     *
+     * @private
+     * @param {!Function} updateFn
+     *     The mutation to apply.
+     */
+    function applyPanelStateChange(updateFn) {
+        if ($rootScope.$$phase)
+            updateFn();
+        else
+            $rootScope.$apply(updateFn);
+    }
+
+    /**
+     * Object which tracks the state of WebAuthn passthrough for a single
+     * ManagedClient.
+     *
+     * @constructor
+     * @param {ManagedWebAuthn|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     ManagedWebAuthn.
+     */
+    const ManagedWebAuthn = function ManagedWebAuthn(template) {
+
+        template = template || {};
+
+        /**
+         * The ManagedClient that owns this WebAuthn relay.
+         *
+         * @type ManagedClient
+         */
+        this.client = template.client;
+
+        /**
+         * The number of WebAuthn ceremonies currently in flight (awaiting
+         * the user's authenticator).
+         *
+         * @type {!Number}
+         */
+        this.inFlight = template.inFlight || 0;
+
+        /**
+         * The status of the most recently-completed ceremony. One of
+         * "completed", "failed", or null if no ceremony has run yet.
+         *
+         * @type {String}
+         */
+        this.lastStatus = template.lastStatus || null;
+
+        /**
+         * Whether the browser has refused a ceremony due to enterprise
+         * policy. Once set, remains true for the lifetime of this client
+         * since the policy is not expected to change mid-session.
+         *
+         * @type {!Boolean}
+         */
+        this.policyBlocked = !!template.policyBlocked;
+
+        /**
+         * Whether the browser has reported that WebAuthn is not supported
+         * (NotSupportedError from navigator.credentials). Once set,
+         * remains true for the lifetime of this client since browser
+         * support is not expected to change mid-session.
+         *
+         * @type {!Boolean}
+         */
+        this.notSupported = !!template.notSupported;
+
+        /**
+         * AbortControllers for in-flight ceremonies, keyed by challenge
+         * id. Used to dismiss the local authenticator UI when the
+         * Guacamole connection drops.
+         *
+         * @private
+         * @type {!Object.<String, AbortController>}
+         */
+        this._abortControllers = {};
+
+    };
+
+    /**
+     * Creates a new ManagedWebAuthn instance bound to the given client.
+     *
+     * @param {ManagedClient} client
+     *     The client that this ManagedWebAuthn should be associated with.
+     *
+     * @returns {ManagedWebAuthn}
+     *     The newly-created ManagedWebAuthn.
+     */
+    ManagedWebAuthn.getInstance = function getInstance(client) {
+        return new ManagedWebAuthn({ client });
+    };
+
+    /**
+     * Returns whether the given auth-challenge mimetype is one this relay
+     * handles.
+     *
+     * @param {!String} mimetype
+     *     The mimetype to check.
+     *
+     * @returns {!Boolean}
+     *     true if the mimetype is recognized, false otherwise.
+     */
+    ManagedWebAuthn.handlesMimetype = function handlesMimetype(mimetype) {
+        return Object.prototype.hasOwnProperty.call(MIMETYPE_KIND, mimetype);
+    };
+
+    /**
+     * Handles a single inbound WebAuthn ceremony challenge, dispatched
+     * from the ManagedClient's auth-challenge handler. Reads the JSON
+     * payload off the stream, dispatches the ceremony to the user's
+     * local authenticator via webAuthnService, and sends the result (or
+     * error) back as an auth-response stream with the matching
+     * challenge_id.
+     *
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn that should handle the challenge.
+     *
+     * @param {!Guacamole.InputStream} stream
+     *     The input stream carrying the challenge body.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the challenge body. Used to determine the
+     *     ceremony kind.
+     *
+     * @param {!String} challengeId
+     *     The challenge identifier; the matching auth-response will echo
+     *     this value back.
+     */
+    ManagedWebAuthn.handleChallenge = function handleChallenge(
+            managedWebAuthn, stream, mimetype, challengeId) {
+
+        const kind = MIMETYPE_KIND[mimetype];
+        if (!kind) {
+            stream.sendAck('Unsupported auth-challenge mimetype',
+                    Guacamole.Status.Code.UNSUPPORTED);
+            return;
+        }
+
+        stream.sendAck('Ready', Guacamole.Status.Code.SUCCESS);
+
+        let payload = '';
+        const reader = new Guacamole.StringReader(stream);
+        reader.ontext = function challengeChunk(text) {
+            payload += text;
+        };
+        reader.onend = function challengeComplete() {
+            dispatchCeremony(
+                    managedWebAuthn, mimetype, challengeId, kind, payload);
+        };
+
+    };
+
+    /**
+     * Aborts every in-flight ceremony. Used when the Guacamole connection
+     * drops, so the local authenticator UI does not sit on screen with
+     * no live session behind it.
+     *
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn whose ceremonies should be canceled.
+     */
+    ManagedWebAuthn.abortAll = function abortAll(managedWebAuthn) {
+        const controllers = managedWebAuthn._abortControllers;
+        for (const id in controllers) {
+            if (Object.prototype.hasOwnProperty.call(controllers, id))
+                controllers[id].abort();
+        }
+    };
+
+    /**
+     * Dispatches a fully-assembled ceremony challenge to the user's local
+     * authenticator. Parses the JSON body, runs the WebAuthn ceremony
+     * under an AbortController stored by challenge id, and sends the
+     * response back via client.sendAuthResponse.
+     *
+     * @private
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn that owns the in-flight challenge.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the originating auth-challenge, echoed onto
+     *     the auth-response so the peer can route it.
+     *
+     * @param {!String} challengeId
+     *     The challenge identifier parsed from the auth-challenge.
+     *
+     * @param {!String} kind
+     *     The ceremony kind, "create" or "get", derived from the
+     *     mimetype.
+     *
+     * @param {!String} payloadJson
+     *     The JSON-encoded request body. Expected to deserialize to an
+     *     object with originOverride, sameOriginWithAncestors, and
+     *     publicKey fields.
+     */
+    function dispatchCeremony(managedWebAuthn, mimetype, challengeId, kind,
+            payloadJson) {
+
+        let request;
+        try {
+            request = JSON.parse(payloadJson);
+        }
+        catch (e) {
+            console.warn('[WebAuthn] dropped malformed ceremony challenge id='
+                    + challengeId + ' kind=' + kind, e);
+            sendResponse(managedWebAuthn, mimetype, challengeId, 'error', {
+                name: 'DataError',
+                message: 'Malformed WebAuthn request payload'
+            });
+            return;
+        }
+
+        const controller = new AbortController();
+        managedWebAuthn._abortControllers[challengeId] = controller;
+
+        applyPanelStateChange(function trackInFlight() {
+            managedWebAuthn.inFlight++;
+        });
+
+        webAuthnService.performCeremony({
+            kind: kind,
+            opts: request.publicKey,
+            originOverride: request.originOverride,
+            sameOriginWithAncestors: request.sameOriginWithAncestors
+        }, controller.signal).then(function ceremonyResolved(credential) {
+            sendResponse(managedWebAuthn, mimetype, challengeId, 'ok',
+                    { credential: credential });
+        }, function ceremonyRejected(error) {
+
+            if (error && error.policyBlocked)
+                managedWebAuthn.policyBlocked = true;
+
+            if (error && error.name === 'NotSupportedError')
+                managedWebAuthn.notSupported = true;
+
+            console.warn('[WebAuthn] ceremony id=' + challengeId
+                    + ' kind=' + kind
+                    + (error && error.policyBlocked ? ' (policy-blocked)' : '')
+                    + ' failed:', error);
+
+            sendResponse(managedWebAuthn, mimetype, challengeId, 'error', {
+                name: (error && error.name) || 'Error',
+                message: (error && error.message) || String(error)
+            });
+        });
+
+    }
+
+    /**
+     * Sends an auth-response settling the given challenge with the given
+     * status and payload, and updates the status fields of the
+     * ManagedWebAuthn accordingly. The response JSON carries the status
+     * field alongside the payload so the peer can pull the status
+     * without inspecting credential shape.
+     *
+     * @private
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn whose status should be updated.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the originating auth-challenge, echoed back.
+     *
+     * @param {!String} challengeId
+     *     The challenge identifier being settled.
+     *
+     * @param {!String} status
+     *     The status of the ceremony: "ok" or "error".
+     *
+     * @param {!Object} payload
+     *     The response payload object; will be JSON-encoded into the
+     *     body alongside the status.
+     */
+    function sendResponse(managedWebAuthn, mimetype, challengeId, status,
+            payload) {
+
+        delete managedWebAuthn._abortControllers[challengeId];
+
+        const client = managedWebAuthn.client && managedWebAuthn.client.client;
+        if (client) {
+            const stream = client.sendAuthResponse(mimetype, challengeId);
+            if (stream) {
+                const writer = new Guacamole.StringWriter(stream);
+                writer.sendText(JSON.stringify(Object.assign(
+                        { status: status }, payload)));
+                writer.sendEnd();
+            }
+        }
+
+        applyPanelStateChange(function recordCeremonySettled() {
+            managedWebAuthn.inFlight =
+                    Math.max(0, managedWebAuthn.inFlight - 1);
+            managedWebAuthn.lastStatus =
+                    (status === 'ok') ? 'completed' : 'failed';
+        });
+
+    }
+
+    return ManagedWebAuthn;
+
+}]);

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedWebAuthn.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedWebAuthn.js
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides the ManagedWebAuthn class used by ManagedClient to relay
+ * WebAuthn ceremonies from a remote session to the user's local
+ * authenticator. Ceremony requests arrive as inbound "auth-challenge"
+ * streams whose mimetype identifies the ceremony kind; responses are
+ * sent back as outbound "auth-response" streams referencing the same
+ * challenge_id.
+ */
+angular.module('client').factory('ManagedWebAuthn', ['$injector', '$rootScope',
+    function defineManagedWebAuthn($injector, $rootScope) {
+
+    const webAuthnService = $injector.get('webAuthnService');
+
+    /**
+     * Mimetypes recognized by this relay, keyed by mimetype value to the
+     * ceremony kind ("create" or "get") that they identify.
+     *
+     * @private
+     * @constant
+     * @type {!Object.<String, String>}
+     */
+    const MIMETYPE_KIND = {
+        'application/x-webauthn-create+json': 'create',
+        'application/x-webauthn-get+json':    'get'
+    };
+
+    /**
+     * Runs the given mutation inside an Angular digest. handleChallenge
+     * is called from Guacamole's tunnel.oninstruction dispatch which runs
+     * outside Angular, so state changes the panel template watches need
+     * an explicit $apply. Callbacks resolved through $q are already
+     * inside a digest, so this is a no-op there.
+     *
+     * @private
+     * @param {!Function} updateFn
+     *     The mutation to apply.
+     */
+    function applyPanelStateChange(updateFn) {
+        if ($rootScope.$$phase)
+            updateFn();
+        else
+            $rootScope.$apply(updateFn);
+    }
+
+    /**
+     * Object which tracks the state of WebAuthn passthrough for a single
+     * ManagedClient.
+     *
+     * @constructor
+     * @param {ManagedWebAuthn|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     ManagedWebAuthn.
+     */
+    const ManagedWebAuthn = function ManagedWebAuthn(template) {
+
+        template = template || {};
+
+        /**
+         * The ManagedClient that owns this WebAuthn relay.
+         *
+         * @type ManagedClient
+         */
+        this.client = template.client;
+
+        /**
+         * The number of WebAuthn ceremonies currently in flight (awaiting
+         * the user's authenticator).
+         *
+         * @type {!Number}
+         */
+        this.inFlight = template.inFlight || 0;
+
+        /**
+         * The status of the most recently-completed ceremony. One of
+         * "completed", "failed", or null if no ceremony has run yet.
+         *
+         * @type {String}
+         */
+        this.lastStatus = template.lastStatus || null;
+
+        /**
+         * Whether the browser has refused a ceremony due to enterprise
+         * policy. Once set, remains true for the lifetime of this client
+         * since the policy is not expected to change mid-session.
+         *
+         * @type {!Boolean}
+         */
+        this.policyBlocked = !!template.policyBlocked;
+
+        /**
+         * Whether the browser has reported that WebAuthn is not supported
+         * (NotSupportedError from navigator.credentials). Once set,
+         * remains true for the lifetime of this client since browser
+         * support is not expected to change mid-session.
+         *
+         * @type {!Boolean}
+         */
+        this.notSupported = !!template.notSupported;
+
+        /**
+         * AbortControllers for in-flight ceremonies, keyed by challenge
+         * id. Used to dismiss the local authenticator UI when the
+         * Guacamole connection drops.
+         *
+         * @private
+         * @type {!Object.<String, AbortController>}
+         */
+        this._abortControllers = {};
+
+    };
+
+    /**
+     * Creates a new ManagedWebAuthn instance bound to the given client.
+     *
+     * @param {ManagedClient} client
+     *     The client that this ManagedWebAuthn should be associated with.
+     *
+     * @returns {ManagedWebAuthn}
+     *     The newly-created ManagedWebAuthn.
+     */
+    ManagedWebAuthn.getInstance = function getInstance(client) {
+        return new ManagedWebAuthn({ client });
+    };
+
+    /**
+     * Returns whether the given auth-challenge mimetype is one this relay
+     * handles.
+     *
+     * @param {!String} mimetype
+     *     The mimetype to check.
+     *
+     * @returns {!Boolean}
+     *     true if the mimetype is recognized, false otherwise.
+     */
+    ManagedWebAuthn.handlesMimetype = function handlesMimetype(mimetype) {
+        return Object.prototype.hasOwnProperty.call(MIMETYPE_KIND, mimetype);
+    };
+
+    /**
+     * Handles a single inbound WebAuthn ceremony challenge, dispatched
+     * from the ManagedClient's auth-challenge handler. Reads the JSON
+     * payload off the stream, dispatches the ceremony to the user's
+     * local authenticator via webAuthnService, and sends the result (or
+     * error) back as an auth-response stream with the matching
+     * challenge_id.
+     *
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn that should handle the challenge.
+     *
+     * @param {!Guacamole.InputStream} stream
+     *     The input stream carrying the challenge body.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the challenge body. Used to determine the
+     *     ceremony kind.
+     *
+     * @param {!String} challengeId
+     *     The challenge identifier; the matching auth-response will echo
+     *     this value back.
+     */
+    ManagedWebAuthn.handleChallenge = function handleChallenge(
+            managedWebAuthn, stream, mimetype, challengeId) {
+
+        const kind = MIMETYPE_KIND[mimetype];
+        if (!kind) {
+            stream.sendAck('Unsupported auth-challenge mimetype',
+                    Guacamole.Status.Code.UNSUPPORTED);
+            return;
+        }
+
+        stream.sendAck('Ready', Guacamole.Status.Code.SUCCESS);
+
+        const reader = new Guacamole.JSONReader(stream);
+        reader.onend = function challengeComplete() {
+            let request;
+            try {
+                request = reader.getJSON();
+            }
+            catch (e) {
+                console.warn('[WebAuthn] dropped malformed ceremony '
+                        + 'challenge id=' + challengeId + ' kind=' + kind, e);
+                sendResponse(managedWebAuthn, mimetype, challengeId, 'error', {
+                    name: 'DataError',
+                    message: 'Malformed WebAuthn request payload'
+                });
+                return;
+            }
+            dispatchCeremony(
+                    managedWebAuthn, mimetype, challengeId, kind, request);
+        };
+
+    };
+
+    /**
+     * Aborts every in-flight ceremony. Used when the Guacamole connection
+     * drops, so the local authenticator UI does not sit on screen with
+     * no live session behind it.
+     *
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn whose ceremonies should be canceled.
+     */
+    ManagedWebAuthn.abortAll = function abortAll(managedWebAuthn) {
+        const controllers = managedWebAuthn._abortControllers;
+        for (const id in controllers) {
+            if (Object.prototype.hasOwnProperty.call(controllers, id))
+                controllers[id].abort();
+        }
+    };
+
+    /**
+     * Dispatches a fully-assembled ceremony challenge to the user's local
+     * authenticator. Parses the JSON body, runs the WebAuthn ceremony
+     * under an AbortController stored by challenge id, and sends the
+     * response back via client.sendAuthResponse.
+     *
+     * @private
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn that owns the in-flight challenge.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the originating auth-challenge, echoed onto
+     *     the auth-response so the peer can route it.
+     *
+     * @param {!String} challengeId
+     *     The challenge identifier parsed from the auth-challenge.
+     *
+     * @param {!String} kind
+     *     The ceremony kind, "create" or "get", derived from the
+     *     mimetype.
+     *
+     * @param {!Object} request
+     *     The parsed request body, with originOverride,
+     *     sameOriginWithAncestors, and publicKey fields.
+     */
+    function dispatchCeremony(managedWebAuthn, mimetype, challengeId, kind,
+            request) {
+
+        const controller = new AbortController();
+        managedWebAuthn._abortControllers[challengeId] = controller;
+
+        applyPanelStateChange(function trackInFlight() {
+            managedWebAuthn.inFlight++;
+        });
+
+        webAuthnService.performCeremony({
+            kind: kind,
+            opts: request.publicKey,
+            originOverride: request.originOverride,
+            sameOriginWithAncestors: request.sameOriginWithAncestors
+        }, controller.signal).then(function ceremonyResolved(credential) {
+            sendResponse(managedWebAuthn, mimetype, challengeId, 'ok',
+                    { credential: credential });
+        }, function ceremonyRejected(error) {
+
+            if (error && error.policyBlocked)
+                managedWebAuthn.policyBlocked = true;
+
+            if (error && error.name === 'NotSupportedError')
+                managedWebAuthn.notSupported = true;
+
+            console.warn('[WebAuthn] ceremony id=' + challengeId
+                    + ' kind=' + kind
+                    + (error && error.policyBlocked ? ' (policy-blocked)' : '')
+                    + ' failed:', error);
+
+            sendResponse(managedWebAuthn, mimetype, challengeId, 'error', {
+                name: (error && error.name) || 'Error',
+                message: (error && error.message) || String(error)
+            });
+        });
+
+    }
+
+    /**
+     * Sends an auth-response settling the given challenge with the given
+     * status and payload, and updates the status fields of the
+     * ManagedWebAuthn accordingly. The response JSON carries the status
+     * field alongside the payload so the peer can pull the status
+     * without inspecting credential shape.
+     *
+     * @private
+     * @param {!ManagedWebAuthn} managedWebAuthn
+     *     The ManagedWebAuthn whose status should be updated.
+     *
+     * @param {!String} mimetype
+     *     The mimetype of the originating auth-challenge, echoed back.
+     *
+     * @param {!String} challengeId
+     *     The challenge identifier being settled.
+     *
+     * @param {!String} status
+     *     The status of the ceremony: "ok" or "error".
+     *
+     * @param {!Object} payload
+     *     The response payload object; will be JSON-encoded into the
+     *     body alongside the status.
+     */
+    function sendResponse(managedWebAuthn, mimetype, challengeId, status,
+            payload) {
+
+        delete managedWebAuthn._abortControllers[challengeId];
+
+        try {
+            const client =
+                    managedWebAuthn.client && managedWebAuthn.client.client;
+            const stream = client
+                    && client.sendAuthResponse(mimetype, challengeId);
+            if (stream) {
+                const writer = new Guacamole.StringWriter(stream);
+                writer.sendText(JSON.stringify(Object.assign(
+                        { status: status }, payload)));
+                writer.sendEnd();
+            }
+            else {
+                console.warn('[WebAuthn] dropped ceremony response id='
+                        + challengeId + ' status=' + status
+                        + ' (session unavailable)');
+            }
+        }
+        finally {
+            applyPanelStateChange(function recordCeremonySettled() {
+                managedWebAuthn.inFlight =
+                        Math.max(0, managedWebAuthn.inFlight - 1);
+                managedWebAuthn.lastStatus =
+                        (status === 'ok') ? 'completed' : 'failed';
+            });
+        }
+
+    }
+
+    return ManagedWebAuthn;
+
+}]);

--- a/guacamole/src/main/frontend/src/app/webauthn/controllers/webAuthnController.js
+++ b/guacamole/src/main/frontend/src/app/webauthn/controllers/webAuthnController.js
@@ -18,18 +18,21 @@
  */
 
 /**
- * The module for code used to connect to a connection or balancing group.
+ * Controller for the WebAuthn status panel within the connection menu.
+ * Surfaces in-flight ceremony count and last-ceremony status from the
+ * client's ManagedWebAuthn instance.
  */
-angular.module('client', [
-    'auth',
-    'clipboard',
-    'element',
-    'history',
-    'navigation',
-    'notification',
-    'osk',
-    'rest',
-    'textInput',
-    'touch',
-    'webauthn'
+angular.module('webauthn').controller('webAuthnController', ['$scope',
+    function webAuthnController($scope) {
+
+        /**
+         * The current page origin, exposed for the policy-blocked hint so
+         * the user can see the exact value that must be added to the
+         * WebAuthenticationRemoteDesktopAllowedOrigins entry.
+         *
+         * @type {!String}
+         */
+        $scope.webAuthnOrigin = window.location.origin;
+
+    }
 ]);

--- a/guacamole/src/main/frontend/src/app/webauthn/directives/guacWebAuthn.js
+++ b/guacamole/src/main/frontend/src/app/webauthn/directives/guacWebAuthn.js
@@ -18,18 +18,25 @@
  */
 
 /**
- * The module for code used to connect to a connection or balancing group.
+ * Directive which displays the current status of WebAuthn passthrough for
+ * the given client.
  */
-angular.module('client', [
-    'auth',
-    'clipboard',
-    'element',
-    'history',
-    'navigation',
-    'notification',
-    'osk',
-    'rest',
-    'textInput',
-    'touch',
-    'webauthn'
-]);
+angular.module('webauthn').directive('guacWebAuthn', [function guacWebAuthn() {
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+
+            /**
+             * The ManagedClient for which the WebAuthn status should be
+             * shown.
+             *
+             * @type ManagedClient
+             */
+            client: '='
+
+        },
+        templateUrl: 'app/webauthn/templates/guacWebAuthn.html',
+        controller: 'webAuthnController'
+    };
+}]);

--- a/guacamole/src/main/frontend/src/app/webauthn/services/webAuthnService.js
+++ b/guacamole/src/main/frontend/src/app/webauthn/services/webAuthnService.js
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Service for performing WebAuthn ceremonies against the user's local
+ * authenticator on behalf of a remote session, using the
+ * remoteDesktopClientOverride extension to override the origin embedded in
+ * the resulting signed clientDataJSON.
+ *
+ * Requires that the user's browser is configured (typically via the
+ * Chromium WebAuthenticationRemoteDesktopAllowedOrigins enterprise policy)
+ * to permit this extension from this application's origin.
+ */
+angular.module('webauthn').factory('webAuthnService', ['$injector',
+    function webAuthnService($injector) {
+
+        const $q = $injector.get('$q');
+        const service = {};
+
+        /**
+         * Whether WebAuthn passthrough is supported by the current browser.
+         * Requires both the Web Authentication API and a Chromium-based
+         * browser, since the origin-override mechanism this service relies
+         * on (the remoteDesktopClientOverride extension, gated by the
+         * WebAuthenticationRemoteDesktopAllowedOrigins policy) is currently
+         * only implemented in Chromium.
+         *
+         * @type {Boolean}
+         */
+        service.isSupported = (function detectSupport() {
+
+            if (!window.PublicKeyCredential)
+                return false;
+
+            // Modern: userAgentData.brands enumerates the engine brands
+            const brands = navigator.userAgentData && navigator.userAgentData.brands;
+            if (Array.isArray(brands)) {
+                return brands.some(function (b) {
+                    return /Chromium|Google Chrome|Microsoft Edge/i.test(b.brand);
+                });
+            }
+
+            // Fallback: legacy userAgent sniff (Firefox advertises "Gecko"
+            // but no Chrome/Chromium token; Safari has "Safari" but not
+            // "Chrome" outside the Chrome marketing token used by Chromium)
+            const ua = navigator.userAgent || '';
+            return /Chrome|Chromium|Edg\//.test(ua) && !/Firefox|FxiOS/.test(ua);
+
+        })();
+
+        /**
+         * Encodes the given ArrayBuffer (or ArrayBufferView) as a standard,
+         * unpadded base64 string suitable for inclusion in JSON.
+         *
+         * @param {!ArrayBuffer|!ArrayBufferView} buf
+         *     The buffer to encode.
+         *
+         * @returns {!String}
+         *     The base64 encoding of the given buffer.
+         */
+        function base64Encode(buf) {
+            const bytes = buf instanceof ArrayBuffer
+                    ? new Uint8Array(buf)
+                    : new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++)
+                str += String.fromCharCode(bytes[i]);
+            return btoa(str);
+        }
+
+        /**
+         * Decodes the given base64 string into a new ArrayBuffer.
+         *
+         * @param {!String} encoded
+         *     The base64-encoded string to decode.
+         *
+         * @returns {!ArrayBuffer}
+         *     A new ArrayBuffer containing the decoded bytes.
+         */
+        function base64Decode(encoded) {
+            const bin = atob(encoded);
+            const bytes = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++)
+                bytes[i] = bin.charCodeAt(i);
+            return bytes.buffer;
+        }
+
+        /**
+         * Walks the given value, replacing any object of the form
+         * { "__ab": "<base64>" } with a real ArrayBuffer containing the
+         * decoded bytes. Used to rehydrate BufferSource fields that were
+         * serialized for transport over the Guacamole protocol.
+         *
+         * @param {*} value
+         *     The value to rehydrate. May be any JSON-compatible value.
+         *
+         * @returns {*}
+         *     The rehydrated value. Returned as-is if no rehydration is
+         *     required.
+         */
+        function rehydrateBuffers(value) {
+
+            if (value === null || typeof value !== 'object')
+                return value;
+
+            // The marker shape, as produced by the corresponding serializer
+            // on the remote end
+            if (typeof value.__ab === 'string'
+                    && Object.keys(value).length === 1)
+                return base64Decode(value.__ab);
+
+            if (Array.isArray(value))
+                return value.map(rehydrateBuffers);
+
+            const result = {};
+            for (const key in value)
+                if (Object.prototype.hasOwnProperty.call(value, key))
+                    result[key] = rehydrateBuffers(value[key]);
+            return result;
+
+        }
+
+        /**
+         * Converts a PublicKeyCredential returned from the Web Authentication
+         * API into a plain JSON-compatible object suitable for transport over
+         * the Guacamole protocol. All ArrayBuffer fields are base64-encoded.
+         *
+         * @param {!PublicKeyCredential} credential
+         *     The credential to serialize.
+         *
+         * @returns {!Object}
+         *     A plain object describing the credential.
+         */
+        function serializeCredential(credential) {
+
+            const response = credential.response;
+            const out = {
+                id: credential.id,
+                rawId: base64Encode(credential.rawId),
+                type: credential.type,
+                authenticatorAttachment: credential.authenticatorAttachment || null,
+                clientExtensionResults: credential.getClientExtensionResults
+                        ? credential.getClientExtensionResults() : {},
+                response: {
+                    clientDataJSON: base64Encode(response.clientDataJSON)
+                }
+            };
+
+            // AuthenticatorAttestationResponse (create)
+            if (response.attestationObject)
+                out.response.attestationObject = base64Encode(response.attestationObject);
+
+            // AuthenticatorAssertionResponse (get)
+            if (response.authenticatorData)
+                out.response.authenticatorData = base64Encode(response.authenticatorData);
+            if (response.signature)
+                out.response.signature = base64Encode(response.signature);
+            if (response.userHandle)
+                out.response.userHandle = base64Encode(response.userHandle);
+
+            return out;
+
+        }
+
+        /**
+         * Performs a WebAuthn ceremony of the given kind against the user's
+         * local authenticator, using the remoteDesktopClientOverride
+         * extension to embed the given origin in the resulting clientDataJSON.
+         *
+         * @param {!Object} request
+         *     The ceremony request.
+         *
+         * @param {!String} request.kind
+         *     Either "create" or "get".
+         *
+         * @param {!Object} request.opts
+         *     The PublicKeyCredentialCreationOptions or
+         *     PublicKeyCredentialRequestOptions for the ceremony, with any
+         *     BufferSource fields serialized as { "__ab": "<base64>" }
+         *     markers.
+         *
+         * @param {!String} request.originOverride
+         *     The origin to embed in the resulting clientDataJSON. This is
+         *     the origin of the remote page that initiated the ceremony, not
+         *     this application's origin.
+         *
+         * @param {Boolean} [request.sameOriginWithAncestors=true]
+         *     Whether the remote page that initiated the ceremony is
+         *     same-origin with all its ancestor frames.
+         *
+         * @param {AbortSignal} [signal]
+         *     Optional AbortSignal. Aborting it cancels the in-flight
+         *     ceremony, dismisses the local authenticator UI, and
+         *     rejects the returned promise with an AbortError.
+         *
+         * @returns {!Promise.<!Object>}
+         *     A promise that resolves with the serialized credential, or
+         *     rejects with an Error decorated with a "policyBlocked" property
+         *     set to true if the browser refused the override due to policy.
+         */
+        service.performCeremony = function performCeremony(request, signal) {
+
+            const deferred = $q.defer();
+
+            if (!service.isSupported) {
+                const err = new Error('WebAuthn is not available in this browser.');
+                err.name = 'NotSupportedError';
+                deferred.reject(err);
+                return deferred.promise;
+            }
+
+            if (request.kind !== 'create' && request.kind !== 'get') {
+                deferred.reject(new Error('Unknown ceremony kind: ' + request.kind));
+                return deferred.promise;
+            }
+
+            const publicKey = rehydrateBuffers(request.opts || {});
+
+            // Layer our origin override on top of any extensions provided by
+            // the remote page
+            publicKey.extensions = Object.assign({}, publicKey.extensions || {}, {
+                remoteDesktopClientOverride: {
+                    origin: request.originOverride,
+                    sameOriginWithAncestors:
+                            request.sameOriginWithAncestors !== false
+                }
+            });
+
+            const options = { publicKey: publicKey };
+            if (signal)
+                options.signal = signal;
+
+            const op = request.kind === 'create'
+                    ? navigator.credentials.create(options)
+                    : navigator.credentials.get(options);
+
+            op.then(function ceremonyResolved(credential) {
+
+                // The Credential Management API resolves null when
+                // mediation is "silent" or "conditional" and no credential
+                // is available. Treat that as a refusal so
+                // serializeCredential never sees null.
+                if (credential === null) {
+                    const err = new Error(
+                            'Authenticator returned no credential.');
+                    err.name = 'NotAllowedError';
+                    deferred.reject(err);
+                    return;
+                }
+
+                deferred.resolve(serializeCredential(credential));
+
+            }, function ceremonyRejected(error) {
+
+                // Surface the policy-blocked case distinctly so the UI can
+                // explain the WebAuthenticationRemoteDesktopAllowedOrigins
+                // requirement. Two failure shapes both indicate the policy
+                // is not honoring the override: NotAllowedError mentioning
+                // the extension by name (policy present but origin not
+                // allowlisted), and SecurityError from the RP-ID check
+                // (policy missing entirely, so the extension is silently
+                // ignored and Chrome falls through to standard validation
+                // against the calling page's origin).
+                if (error && typeof error.message === 'string') {
+                    const msg = error.message;
+                    if (error.name === 'NotAllowedError'
+                            && msg.indexOf('remoteDesktopClientOverride') !== -1) {
+                        error.policyBlocked = true;
+                    }
+                    else if (error.name === 'SecurityError'
+                            && msg.indexOf('relying party ID') !== -1) {
+                        error.policyBlocked = true;
+                    }
+                }
+
+                deferred.reject(error);
+            });
+
+            return deferred.promise;
+
+        };
+
+        return service;
+
+    }
+]);

--- a/guacamole/src/main/frontend/src/app/webauthn/styles/webauthn.css
+++ b/guacamole/src/main/frontend/src/app/webauthn/styles/webauthn.css
@@ -17,19 +17,19 @@
  * under the License.
  */
 
-/**
- * The module for code used to connect to a connection or balancing group.
- */
-angular.module('client', [
-    'auth',
-    'clipboard',
-    'element',
-    'history',
-    'navigation',
-    'notification',
-    'osk',
-    'rest',
-    'textInput',
-    'touch',
-    'webauthn'
-]);
+.menu-section.webauthn .content p {
+    margin: 0.5em 0;
+}
+
+.menu-section.webauthn .content p.hint {
+    color: #666;
+    font-style: italic;
+}
+
+.menu-section.webauthn .content p.hint.warn {
+    color: #b80000;
+}
+
+.menu-section.webauthn .content p.ok {
+    color: #2d8a2d;
+}

--- a/guacamole/src/main/frontend/src/app/webauthn/templates/guacWebAuthn.html
+++ b/guacamole/src/main/frontend/src/app/webauthn/templates/guacWebAuthn.html
@@ -1,0 +1,49 @@
+<div class="menu-section webauthn"
+     ng-show="client.managedWebAuthn
+              && (client.managedWebAuthn.policyBlocked
+                  || client.managedWebAuthn.notSupported
+                  || client.managedWebAuthn.inFlight > 0
+                  || client.managedWebAuthn.lastStatus)">
+    <h3>{{'WEBAUTHN.SECTION_HEADER_WEBAUTHN' | translate}}</h3>
+    <div class="content">
+
+        <!-- Browser refused our origin override due to policy -->
+        <p class="hint warn"
+           ng-if="client.managedWebAuthn.policyBlocked"
+           translate="WEBAUTHN.INFO_POLICY_BLOCKED"
+           translate-values="{ORIGIN: webAuthnOrigin}"></p>
+
+        <!-- Browser reported no WebAuthn support -->
+        <p class="hint warn"
+           ng-if="!client.managedWebAuthn.policyBlocked
+                  && client.managedWebAuthn.notSupported">
+            {{'WEBAUTHN.INFO_NOT_SUPPORTED' | translate}}
+        </p>
+
+        <!-- Ceremony in progress -->
+        <p ng-if="!client.managedWebAuthn.policyBlocked
+                  && !client.managedWebAuthn.notSupported
+                  && client.managedWebAuthn.inFlight > 0">
+            {{'WEBAUTHN.STATUS_AWAITING' | translate}}
+        </p>
+
+        <!-- Last ceremony succeeded -->
+        <p class="ok"
+           ng-if="!client.managedWebAuthn.policyBlocked
+                  && !client.managedWebAuthn.notSupported
+                  && client.managedWebAuthn.inFlight === 0
+                  && client.managedWebAuthn.lastStatus === 'completed'">
+            {{'WEBAUTHN.STATUS_COMPLETED' | translate}}
+        </p>
+
+        <!-- Last ceremony failed -->
+        <p class="hint warn"
+           ng-if="!client.managedWebAuthn.policyBlocked
+                  && !client.managedWebAuthn.notSupported
+                  && client.managedWebAuthn.inFlight === 0
+                  && client.managedWebAuthn.lastStatus === 'failed'">
+            {{'WEBAUTHN.STATUS_FAILED' | translate}}
+        </p>
+
+    </div>
+</div>

--- a/guacamole/src/main/frontend/src/app/webauthn/webauthnModule.js
+++ b/guacamole/src/main/frontend/src/app/webauthn/webauthnModule.js
@@ -18,18 +18,9 @@
  */
 
 /**
- * The module for code used to connect to a connection or balancing group.
+ * The module for code used to relay WebAuthn ceremonies between a remote
+ * session and the user's local browser, allowing a WebAuthn authenticator
+ * connected to the user's local machine to satisfy WebAuthn requests
+ * originating from the remote session.
  */
-angular.module('client', [
-    'auth',
-    'clipboard',
-    'element',
-    'history',
-    'navigation',
-    'notification',
-    'osk',
-    'rest',
-    'textInput',
-    'touch',
-    'webauthn'
-]);
+angular.module('webauthn', []);

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -1259,6 +1259,19 @@
         "ACTION_NAVIGATE_HOME"      : "@:APP.ACTION_NAVIGATE_HOME",
         "ACTION_VIEW_HISTORY"       : "@:APP.ACTION_VIEW_HISTORY"
 
+    },
+
+    "WEBAUTHN" : {
+
+        "SECTION_HEADER_WEBAUTHN" : "WebAuthn Passthrough",
+
+        "INFO_NOT_SUPPORTED"      : "This browser does not support WebAuthn. WebAuthn passthrough requires a browser that implements the WebAuthn API, such as Chrome or Edge.",
+        "INFO_POLICY_BLOCKED"     : "This browser is not configured to allow WebAuthn passthrough from this site. Add {ORIGIN} to the WebAuthenticationRemoteDesktopAllowedOrigins Chromium policy.",
+
+        "STATUS_AWAITING"         : "Awaiting authenticator...",
+        "STATUS_COMPLETED"        : "Last WebAuthn ceremony completed.",
+        "STATUS_FAILED"           : "Last WebAuthn ceremony failed."
+
     }
 
 }


### PR DESCRIPTION
Adds a WebAuthn passthrough relay that runs ceremonies on the user's local authenticator on behalf of a remote session. The server opens an inbound auth-challenge stream carrying the ceremony request body; the relay runs the WebAuthn ceremony and replies on an outbound auth-response stream.

guacamole-common-js (Client.js)

sendAuthChallenge and sendAuthResponse returning a Guacamole.OutputStream the caller writes the body to.
onauthchallenge and onauthresponse events firing with (stream, mimetype, challengeId).
Matching auth-challenge and auth-response instruction handlers.
Angular client

ManagedClient routes inbound auth-challenge streams to ManagedWebAuthn based on mimetype (application/x-webauthn-create+json or application/x-webauthn-get+json), acking unsupported mimetypes.
ManagedWebAuthn assembles the challenge body off the stream, runs the ceremony via the existing webAuthnService under an AbortController keyed by challenge_id, and writes the credential or error JSON back on an auth-response stream.
On tunnel CLOSED, abortAll dismisses the local authenticator UI for any ceremonies left in flight.

[Guacamole Server PR](https://github.com/apache/guacamole-server/pull/675)