### PR TITLE
GUACAMOLE-1852: Expose the RDP desktop scale factor parameter.

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -162,6 +162,10 @@
                     "type"  : "NUMERIC"
                 },
                 {
+                    "name"  : "desktop-scale-factor",
+                    "type"  : "NUMERIC"
+                },
+                {
                     "name"    : "color-depth",
                     "type"    : "ENUM",
                     "options" : [ "", "8", "16", "24", "32" ]

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -610,6 +610,7 @@
         "FIELD_HEADER_CONSOLE_AUDIO"         : "Support audio in console:",
         "FIELD_HEADER_CREATE_DRIVE_PATH"     : "Automatically create drive:",
         "FIELD_HEADER_CREATE_RECORDING_PATH" : "Automatically create recording path:",
+        "FIELD_HEADER_DESKTOP_SCALE_FACTOR"  : "Desktop scale factor (%):",
         "FIELD_HEADER_DISABLE_AUDIO"    : "Disable audio:",
         "FIELD_HEADER_DISABLE_AUTH"     : "Disable authentication:",
         "FIELD_HEADER_DISABLE_COPY"     : "Disable copying from remote desktop:",


### PR DESCRIPTION
Add the "desktop-scale-factor" field to the RDP connection "Display" settings, along with its English translation, matching the new guacd parameter that maps to the RDP DesktopScaleFactor / DeviceScaleFactor.