### PR TITLE
GUACAMOLE-2293: Release active connection when guacd socket teardown throws on close

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -121,9 +121,11 @@ public class ActiveConnectionService
         
         if (hasObjectPermissions(user, identifier, ObjectPermission.Type.DELETE)) {
 
-            // Close connection if not already closed
+            // Always close, even if the peer already vanished (isOpen() may be
+            // false). close() releases the active connection record and is
+            // idempotent.
             GuacamoleTunnel tunnel = activeConnection.getTunnel();
-            if (tunnel != null && tunnel.isOpen())
+            if (tunnel != null)
                 tunnel.close();
 
         }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ManagedInetGuacamoleSocket.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ManagedInetGuacamoleSocket.java
@@ -59,8 +59,14 @@ public class ManagedInetGuacamoleSocket extends InetGuacamoleSocket {
 
     @Override
     public void close() throws GuacamoleException {
-        super.close();
-        socketClosedTask.run();
+        // Run cleanup even if super.close() throws, or the active connection
+        // record could leak.
+        try {
+            super.close();
+        }
+        finally {
+            socketClosedTask.run();
+        }
     }
     
 }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ManagedSSLGuacamoleSocket.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/tunnel/ManagedSSLGuacamoleSocket.java
@@ -59,8 +59,14 @@ public class ManagedSSLGuacamoleSocket extends SSLGuacamoleSocket {
 
     @Override
     public void close() throws GuacamoleException {
-        super.close();
-        socketClosedTask.run();
+        // Run cleanup even if super.close() throws, or the active connection
+        // record could leak.
+        try {
+            super.close();
+        }
+        finally {
+            socketClosedTask.run();
+        }
     }
     
 }


### PR DESCRIPTION
`ManagedInetGuacamoleSocket` / `ManagedSSLGuacamoleSocket` run their cleanup task (`socketClosedTask`, which removes the in-memory `ActiveConnectionRecord` and releases its concurrency seat) *after* `super.close()`, not in a `finally`. At disconnect the guacd socket is closed nearly simultaneously by the read thread and by `@OnClose`. When the two race, the JDK's NIO layer throws `IOException` on the second `close()` of the same fd (the `close()` syscall succeeds - it is a NIO double-close artifact). `super.close()` then throws, the cleanup task is skipped, and the active connection leaks in memory until guacamole-app restarts.

Run `socketClosedTask` in a `finally` so cleanup always happens, regardless of whether `super.close()` throws (`ConnectionCleanupTask` already guards itself to run once, so this is safe).

Also drop the `tunnel.isOpen()` guard in `ActiveConnectionService.deleteObject()` and always call `tunnel.close()`. Once the peer has vanished `isOpen()` returns `false`, which made "Kill session" a no-op and left admins unable to reap a leaked connection.