### PR TITLE
GUACAMOLE-2305: Do not reflect sensitive parameter values streamed via argv.

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -63,6 +63,19 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     var THUMBNAIL_UPDATE_FREQUENCY = 5000;
 
     /**
+     * Pattern matching connection parameter names whose values are sensitive
+     * (passwords, passphrases, private keys) and must therefore never be
+     * reflected into the UI-visible arguments model when streamed back by the
+     * server via "argv". Mutating such a parameter toward guacd is already
+     * rejected server-side; this keeps the value out of the connection-
+     * parameters panel as well (security finding L4, guacamole-server#21).
+     *
+     * @constant
+     * @type {!RegExp}
+     */
+    var SENSITIVE_ARGUMENT = /password|passphrase|private-key|client-key|secret|token/i;
+
+    /**
      * A deferred pipe stream, that has yet to be consumed, as well as all
      * axuilary information needed to pull data from the stream.
      *
@@ -645,6 +658,13 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
             // Test mutability once stream is finished, storing the current
             // value for the argument only if it is mutable
             reader.onend = function textComplete() {
+
+                // Never reflect a sensitive parameter value (password,
+                // passphrase, private key) streamed back via "argv" into the
+                // UI-visible arguments model (security finding L4).
+                if (SENSITIVE_ARGUMENT.test(name))
+                    return;
+
                 ManagedArgument.getInstance(managedClient, name, value).then(function argumentIsMutable(argument) {
                     managedClient.arguments[name] = argument;
                 }, function ignoreImmutableArguments() {});


### PR DESCRIPTION
Resolves [GUACAMOLE-2305](https://issues.apache.org/jira/browse/GUACAMOLE-2305).

When the server streams a connection parameter back to the client through an `argv`
stream, `ManagedClient` reflects the received value into the UI-visible arguments
model, which backs the connection parameters panel.

There is no filtering by parameter name, so when the streamed parameter holds a secret
— a password, a passphrase, a private key — the value becomes readable by any user
able to view that connection. This matters most where a connection is configured
centrally with credentials the user is not otherwise meant to see.

This is a display concern only. Mutating an immutable argument toward guacd is already
rejected server-side, so the issue is what a user can *read*, not what they can send.

**The change:** skip reflection for parameter names matching
`password|passphrase|private-key|client-key|secret|token`, case-insensitive. Public
material (`host-key`, `public-key`, `pubkey`) is deliberately not matched, since it is
not secret and is useful to display. One file, 20 lines added.

**Two things I'd rather have decided by someone with more context**, both noted on the
issue:

1. Is the client the right layer? Filtering here is defence-in-depth. If guacd should
   not be streaming sensitive values back at all, the durable fix belongs there. I
   don't know whether any protocol relies on streaming these back.
2. Name matching is a heuristic. `token` could match something that isn't secret, and a
   protocol could name a sensitive parameter something the pattern misses. A
   per-protocol flag in the protocol descriptor would be precise, at the cost of
   touching every protocol definition. Happy to do that instead if preferred.

Found while auditing a SPICE protocol implementation built on Guacamole
(GUACAMOLE-261); the issue is not SPICE-specific.
