### PR TITLE
GUACAMOLE-2307: Expose text-output parameter for terminal protocols in the UI

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/kubernetes.json
@@ -110,6 +110,11 @@
                     "options" : [ "true" ]
                 },
                 {
+                    "name"    : "text-output",
+                    "type"    : "ENUM",
+                    "options" : [ "", "true", "raw" ]
+                },
+                {
                     "name"    : "disable-paste",
                     "type"    : "BOOLEAN",
                     "options" : [ "true" ]

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/ssh.json
@@ -93,6 +93,11 @@
                     "options" : [ "true" ]
                 },
                 {
+                    "name"    : "text-output",
+                    "type"    : "ENUM",
+                    "options" : [ "", "true", "raw" ]
+                },
+                {
                     "name"    : "disable-paste",
                     "type"    : "BOOLEAN",
                     "options" : [ "true" ]

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/telnet.json
@@ -93,6 +93,11 @@
                     "options" : [ "true" ]
                 },
                 {
+                    "name"    : "text-output",
+                    "type"    : "ENUM",
+                    "options" : [ "", "true", "raw" ]
+                },
+                {
                     "name"    : "disable-paste",
                     "type"    : "BOOLEAN",
                     "options" : [ "true" ]

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -538,6 +538,7 @@
         "FIELD_HEADER_SCROLLBACK"      : "Maximum scrollback size:",
         "FIELD_HEADER_TERMINAL_TYPE"        : "Terminal type (available as $TERM in command):",
         "FIELD_HEADER_TERMINAL_TYPE_ATTACH" : "Terminal type (set manually in session):",
+        "FIELD_HEADER_TEXT_OUTPUT"     : "Raw terminal output (may contain secrets; disabled by \"Disable copying from terminal\"):",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript name:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript path:",
         "FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING" : "@:APP.FIELD_HEADER_TYPESCRIPT_WRITE_EXISTING",
@@ -577,6 +578,10 @@
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_EMPTY" : "",
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_ESC"   : "ESC[n~",
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_VT100" : "VT100",
+
+        "FIELD_OPTION_TEXT_OUTPUT_EMPTY" : "Disabled",
+        "FIELD_OPTION_TEXT_OUTPUT_TRUE"  : "Tee to STDOUT pipe",
+        "FIELD_OPTION_TEXT_OUTPUT_RAW"   : "Raw/headless STDOUT pipe",
 
         "FIELD_OPTION_TERMINAL_TYPE_ANSI"           : "ansi",
         "FIELD_OPTION_TERMINAL_TYPE_EMPTY"          : "",
@@ -801,6 +806,7 @@
         "FIELD_HEADER_SFTP_ROOT_DIRECTORY"   : "File browser root directory:",
         "FIELD_HEADER_SFTP_DISABLE_UPLOAD"   : "Disable file upload:",
         "FIELD_HEADER_TERMINAL_TYPE"   : "Terminal type:",
+        "FIELD_HEADER_TEXT_OUTPUT"     : "Raw terminal output (may contain secrets; disabled by \"Disable copying from terminal\"):",
         "FIELD_HEADER_TIMEOUT"         : "Connection timeout:",
         "FIELD_HEADER_TIMEZONE"        : "Time zone ($TZ):",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript name:",
@@ -846,6 +852,10 @@
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_EMPTY" : "",
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_ESC"   : "ESC[n~",
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_VT100" : "VT100",
+
+        "FIELD_OPTION_TEXT_OUTPUT_EMPTY" : "Disabled",
+        "FIELD_OPTION_TEXT_OUTPUT_TRUE"  : "Tee to STDOUT pipe",
+        "FIELD_OPTION_TEXT_OUTPUT_RAW"   : "Raw/headless STDOUT pipe",
 
         "FIELD_OPTION_TERMINAL_TYPE_ANSI"           : "ansi",
         "FIELD_OPTION_TERMINAL_TYPE_EMPTY"          : "",
@@ -900,6 +910,7 @@
         "FIELD_HEADER_RECORDING_PATH" : "Recording path:",
         "FIELD_HEADER_SCROLLBACK"     : "Maximum scrollback size:",
         "FIELD_HEADER_TERMINAL_TYPE"   : "Terminal type:",
+        "FIELD_HEADER_TEXT_OUTPUT"     : "Raw terminal output (may contain secrets; disabled by \"Disable copying from terminal\"):",
         "FIELD_HEADER_TIMEOUT"         : "Connection timeout:",
         "FIELD_HEADER_TYPESCRIPT_NAME" : "Typescript name:",
         "FIELD_HEADER_TYPESCRIPT_PATH" : "Typescript path:",
@@ -944,6 +955,10 @@
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_EMPTY" : "",
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_ESC"   : "ESC[n~",
         "FIELD_OPTION_FUNC_KEYS_AND_KEYPAD_VT100" : "VT100",
+
+        "FIELD_OPTION_TEXT_OUTPUT_EMPTY" : "Disabled",
+        "FIELD_OPTION_TEXT_OUTPUT_TRUE"  : "Tee to STDOUT pipe",
+        "FIELD_OPTION_TEXT_OUTPUT_RAW"   : "Raw/headless STDOUT pipe",
 
         "FIELD_OPTION_TERMINAL_TYPE_ANSI"           : "ansi",
         "FIELD_OPTION_TERMINAL_TYPE_EMPTY"          : "",


### PR DESCRIPTION
Implements the guacamole-client side of
[GUACAMOLE-2307](https://issues.apache.org/jira/browse/GUACAMOLE-2307).

Exposes the `text-output` connection parameter in the admin UI for the SSH,
telnet, and Kubernetes protocols as an enum (`""` disabled / `true` tee / `raw`
headless), matching the server-side parameter, together with the corresponding
English translation strings. UI convenience only — the parameter is
admin-provisioned on the connection and gated server-side behind `disable-copy`.

Server change: apache/guacamole-server#697
