### PR TITLE
GUACAMOLE-2311: Profile changes are not saved when a user edits their own settings.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/user/ModeledUserContext.java
@@ -26,6 +26,7 @@ import org.apache.guacamole.auth.jdbc.connection.ConnectionDirectory;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import org.apache.guacamole.GuacamoleException;
 import org.apache.guacamole.auth.jdbc.base.RestrictedObject;
@@ -281,6 +282,11 @@ public class ModeledUserContext extends RestrictedObject
     @Override
     public Collection<Form> getUserAttributes() {
         return ModeledUser.ATTRIBUTES;
+    }
+
+    @Override
+    public Collection<Form> getUserPreferenceAttributes() {
+        return Collections.singletonList(ModeledUser.PROFILE);
     }
 
     @Override


### PR DESCRIPTION
When a user edits their own profile, changes to full name, email, organization, and role are silently discarded and never reach the database.

In `UserObjectTranslator.java`, self-edits take a different path than when editing another account.
```
    @Override
    public void filterExternalObject(UserContext userContext,
            User existingObject, APIUser object) throws GuacamoleException {

        // If a user is editing themselves ...
        if (existingObject != null && existingObject.getIdentifier().equals(userContext.self().getIdentifier())) {
            // ... they may only edit preference attributes
            object.setAttributes(filterAttributes(userContext.getUserPreferenceAttributes(),
                    object.getAttributes()));
        }

        else {
            // In all other cases, filter object attributes by defined schema
            object.setAttributes(filterAttributes(userContext.getUserAttributes(),
                    object.getAttributes()));
        }
    }
```

Self-edits are filtered by `UserObjectTranslator.filterExternalObject()` using `getUserPreferenceAttributes()`. For `ModeledUserContext`, that currently returns no allowed fields, so `filterAttributes()` strips all profile attributes before the update is processed. The fix is to have `ModeledUserContext `expose the standard profile fields as user-editable preferences.