### PR TITLE
GUACAMOLE-2243: Allow displaying who is connected.

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/ActiveConnectionService.java
@@ -36,6 +36,7 @@ import org.apache.guacamole.net.GuacamoleTunnel;
 import org.apache.guacamole.net.auth.ActiveConnection;
 import org.apache.guacamole.net.auth.permission.ObjectPermission;
 import org.apache.guacamole.net.auth.permission.ObjectPermissionSet;
+import org.apache.guacamole.net.auth.permission.SystemPermission;
 
 /**
  * Service which provides convenience methods for creating, retrieving, and
@@ -82,6 +83,8 @@ public class ActiveConnectionService
 
         String username = user.getIdentifier();
         boolean isPrivileged = user.isPrivileged();
+        boolean canViewConnectionOwner = user.getUser().getEffectivePermissions()
+                .getSystemPermissions().hasPermission(SystemPermission.Type.VIEW_ACTIVE_CONNECTION_USERS);
         Set<String> identifierSet = new HashSet<String>(identifiers);
 
         // Retrieve all visible connections (permissions enforced by tunnel service)
@@ -100,7 +103,7 @@ public class ActiveConnectionService
             // Add connection if within requested identifiers
             if (identifierSet.contains(record.getUUID().toString())) {
                 TrackedActiveConnection activeConnection = trackedActiveConnectionProvider.get();
-                activeConnection.init(user, record, hasPrivilegedAccess, hasPrivilegedAccess);
+                activeConnection.init(user, record, hasPrivilegedAccess, canViewConnectionOwner, hasPrivilegedAccess);
                 activeConnections.add(activeConnection);
             }
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-base/src/main/java/org/apache/guacamole/auth/jdbc/activeconnection/TrackedActiveConnection.java
@@ -119,6 +119,11 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
      *     as well. This includes the remote host, associated tunnel, and
      *     username.
      *
+     * @param includeUsername
+     *     Whether the username of the user that initiated this connection
+     *     should be included. This is only relevant if
+     *     includeSensitiveInformation is false.
+     *
      * @param connectable
      *     Whether the user that retrieved this object should be allowed to
      *     join the active connection.
@@ -126,6 +131,7 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
     public void init(ModeledAuthenticatedUser currentUser,
             ActiveConnectionRecord activeConnectionRecord,
             boolean includeSensitiveInformation,
+            boolean includeUsername,
             boolean connectable) {
 
         super.init(currentUser);
@@ -143,6 +149,10 @@ public class TrackedActiveConnection extends RestrictedObject implements ActiveC
             this.remoteHost = activeConnectionRecord.getRemoteHost();
             this.tunnel     = activeConnectionRecord.getTunnel();
             this.username   = activeConnectionRecord.getUsername();
+        }
+
+        else if (includeUsername) {
+            this.username = activeConnectionRecord.getUsername();
         }
 
     }

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -460,6 +460,7 @@ CREATE TABLE `guacamole_system_permission` (
                     'CREATE_USER',
                     'CREATE_USER_GROUP',
                     'AUDIT',
+                    'VIEW_ACTIVE_CONNECTION_USERS',
                     'ADMINISTER') NOT NULL,
 
   PRIMARY KEY (`entity_id`,`permission`),

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-1.7.0.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-1.7.0.sql
@@ -1,0 +1,32 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--
+-- Add new system-level permission
+--
+
+ALTER TABLE `guacamole_system_permission`
+    MODIFY `permission` enum('CREATE_CONNECTION',
+                             'CREATE_CONNECTION_GROUP',
+                             'CREATE_SHARING_PROFILE',
+                             'CREATE_USER',
+                             'CREATE_USER_GROUP',
+                             'AUDIT',
+                             'VIEW_ACTIVE_CONNECTION_USERS',
+                             'ADMINISTER') NOT NULL;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -57,6 +57,7 @@ CREATE TYPE guacamole_system_permission_type AS ENUM(
     'CREATE_USER',
     'CREATE_USER_GROUP',
     'AUDIT',
+    'VIEW_ACTIVE_CONNECTION_USERS',
     'ADMINISTER'
 );
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-1.7.0.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-1.7.0.sql
@@ -1,0 +1,26 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--
+-- Add new system-level audit permission
+--
+
+ALTER TYPE guacamole_system_permission_type
+    ADD VALUE IF NOT EXISTS 'VIEW_ACTIVE_CONNECTION_USERS'
+    BEFORE 'ADMINISTER';

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/001-create-schema.sql
@@ -78,6 +78,7 @@ CREATE RULE [guacamole_system_permission_list] AS @list IN (
     'CREATE_USER',
     'CREATE_USER_GROUP',
     'AUDIT',
+    'VIEW_ACTIVE_CONNECTION_USERS',
     'ADMINISTER'
 );
 GO

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/upgrade/upgrade-pre-1.7.0.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/upgrade/upgrade-pre-1.7.0.sql
@@ -1,0 +1,44 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--
+-- Add new system-level audit permission
+--
+
+EXEC sp_unbindrule 'guacamole_system_permission';
+DROP RULE [guacamole_system_permission_list];
+GO
+
+CREATE RULE [guacamole_system_permission_list] AS @list IN (
+    'CREATE_CONNECTION',
+    'CREATE_CONNECTION_GROUP',
+    'CREATE_SHARING_PROFILE',
+    'CREATE_USER',
+    'CREATE_USER_GROUP',
+    'AUDIT',
+    'VIEW_ACTIVE_CONNECTION_USERS',
+    'ADMINISTER'
+);
+GO
+
+EXEC sp_bindrule
+    'guacamole_system_permission_list',
+    'guacamole_system_permission';
+GO
+

--- a/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/SystemPermission.java
+++ b/guacamole-ext/src/main/java/org/apache/guacamole/net/auth/permission/SystemPermission.java
@@ -66,6 +66,11 @@ public class SystemPermission implements Permission<SystemPermission.Type> {
         AUDIT,
 
         /**
+         * View the names of users currently using active connections.
+         */
+        VIEW_ACTIVE_CONNECTION_USERS,
+
+        /**
          * Administer the system in general, including adding permissions
          * which affect the system (like user creation, connection creation,
          * and system administration).

--- a/guacamole/src/main/frontend/src/app/groupList/directives/guacGroupList.js
+++ b/guacamole/src/main/frontend/src/app/groupList/directives/guacGroupList.js
@@ -99,6 +99,7 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
 
             // Required types
             var GroupListItem = $injector.get('GroupListItem');
+            var ConnectionHistoryEntry = $injector.get('ConnectionHistoryEntry');
 
             /**
              * Map of data source identifier to the number of active
@@ -109,6 +110,16 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
              * @type Object.<String, Object.<String, Number>>
              */
             var connectionCount = {};
+
+            /**
+             * Map of data source identifier to the users currently using a
+             * given connection identifier, along with the duration of their
+             * usage. If this information is unknown, or there are no active
+             * connections for a given identifier, no users will be stored.
+             *
+             * @type {Object.<string, {value: number, unit: string}>}
+             */
+            var connectionUsers = {};
 
             /**
              * Like connectionCount, but restricted to the connections owned
@@ -179,6 +190,26 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
             };
 
             /**
+             * Returns the usernames of all users currently using a given
+             * connection, along with the start date of their usage.
+             *
+             * @param {String} dataSource
+             *     The identifier of the data source containing the given
+             *     connection.
+             *
+             * @param {Connection} connection
+             *     The connection whose active users should be retrieved.
+             *
+             * @returns {Object.<string, {value: number, unit: string}>}
+             *     An object mapping the usernames of all users currently using
+             *     the given connection to the duration of their usage, or an
+             *     empty object if there are no active users.
+             */
+            var getActiveUsersMap = function getActiveUsersMap(dataSource, connection) {
+                return connectionUsers[dataSource][connection.identifier] ?? {};
+            };
+
+            /**
              * Returns whether a @link{GroupListItem} of the given type can be
              * displayed. If there is no template associated with the given
              * type, then a @link{GroupListItem} of that type cannot be
@@ -202,6 +233,7 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
                 var dataSources = [];
                 $scope.rootItems = [];
                 connectionCount = {};
+                connectionUsers = {};
 
                 // If connection groups are given, add them to the interface
                 if (connectionGroups) {
@@ -214,6 +246,7 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
                         // Prepare data source for active connection counting
                         dataSources.push(dataSource);
                         connectionCount[dataSource] = {};
+                        connectionUsers[dataSource] = {};
 
                         // If the provided connection group is already a
                         // GroupListItem, no need to create a new item
@@ -225,7 +258,8 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
                             rootItem = GroupListItem.fromConnectionGroup(dataSource, connectionGroup,
                                 $scope.isVisible(GroupListItem.Type.CONNECTION),
                                 $scope.isVisible(GroupListItem.Type.SHARING_PROFILE),
-                                countActiveConnections, null, countUserActiveConnectionGroups);
+                                countActiveConnections, null, countUserActiveConnectionGroups,
+                                getActiveUsersMap);
 
                         // If root group is to be shown, add it as a root item
                         if ($scope.showRootGroup)
@@ -269,6 +303,20 @@ angular.module('groupList').directive('guacGroupList', [function guacGroupList()
                                 if (activeConnection.username === currentUsername) {
                                     userConnectionCount[dataSource][identifier] ??= 0;
                                     userConnectionCount[dataSource][identifier]++;
+                                }
+
+                                // Store usernames and duration of active connections for each
+                                // connection identifier
+                                if (activeConnection.username) {
+                                    const username = activeConnection.username;
+                                    const startDate = activeConnection.startDate;
+                                    const duration = new ConnectionHistoryEntry.Duration(Date.now() - startDate);
+
+                                    connectionUsers[dataSource][identifier] ??= {};
+                                    connectionUsers[dataSource][identifier][username] = {
+                                        value: duration.value,
+                                        unit: duration.unit,
+                                    };
                                 }
 
                             });

--- a/guacamole/src/main/frontend/src/app/groupList/types/GroupListItem.js
+++ b/guacamole/src/main/frontend/src/app/groupList/types/GroupListItem.js
@@ -125,6 +125,17 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
         });
 
         /**
+         * Returns an object mapping the usernames of all users currently using
+         * this connection to the duration (value and unit) of their usage, if
+         * known. If unknown, an empty object may be returned.
+         *
+         * @returns {Object.<string, {value: number, unit: string}>}
+         */
+        this.getActiveUsers = template.getActiveUsers || (function getActiveUsers() {
+            return {};
+        });
+
+        /**
          * Returns the number of available connections for this connection
          * group.
          *
@@ -202,6 +213,16 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
         });
 
         /**
+         * Returns whether there are any currently visible active users for this
+         * connection. If unknown, false may be returned.
+         *
+         * @returns {Boolean}
+         */
+        this.showActiveUsers = template.showActiveUsers || (function showActiveUsers() {
+            return false;
+        });
+
+        /**
          * The connection, connection group, or sharing profile whose data is
          * exposed within this GroupListItem. If the type of this GroupListItem
          * is not one of the types defined by GroupListItem.Type, then this
@@ -245,11 +266,19 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
      *     function will be passed, in order, the data source identifier and
      *     the connection in question.
      *
+     * @param {Function} [getActiveUsersMap]
+     *     A getter which returns an object mapping the usernames of all users
+     *     currently using the given connection to the duration (value and unit)
+     *     of their usage, if known. If unknown, an empty object may be returned.
+     *     This function will be passed, in order, the data source identifier and
+     *     the connection in question.
+     *
      * @returns {GroupListItem}
      *     A new GroupListItem which represents the given connection.
      */
     GroupListItem.fromConnection = function fromConnection(dataSource,
-        connection, includeSharingProfiles, countActiveConnections) {
+        connection, includeSharingProfiles, countActiveConnections,
+        getActiveUsersMap) {
 
         var children = [];
 
@@ -286,6 +315,21 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
 
                 return connection.activeConnections;
 
+            },
+
+            // Returns the usernames of all currently active users for this connection
+            getActiveUsers : function getActiveUsers() {
+                if (getActiveUsersMap)
+                    return getActiveUsersMap(dataSource, connection)
+
+                return {};
+            },
+
+            // Returns whether there are any currently visible active users for this connection
+            showActiveUsers : function showActiveUsers() {
+                if (getActiveUsersMap)
+                    return Object.keys(getActiveUsersMap(dataSource, connection) ?? {}).length > 0;
+                return false;
             },
 
             // Wrapped item
@@ -336,7 +380,7 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
     GroupListItem.fromConnectionGroup = function fromConnectionGroup(dataSource,
         connectionGroup, includeConnections, includeSharingProfiles,
         countActiveConnections, countActiveConnectionGroups, 
-        countUserActiveConnectionGroups) {
+        countUserActiveConnectionGroups, getActiveUsersMap) {
 
         var children = [];
 
@@ -344,7 +388,7 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
         if (connectionGroup.childConnections && includeConnections !== false) {
             connectionGroup.childConnections.forEach(function addChildConnection(child) {
                 children.push(GroupListItem.fromConnection(dataSource, child,
-                    includeSharingProfiles, countActiveConnections));
+                    includeSharingProfiles, countActiveConnections, getActiveUsersMap));
             });
         }
 
@@ -354,7 +398,7 @@ angular.module('groupList').factory('GroupListItem', ['$injector', function defi
                 children.push(GroupListItem.fromConnectionGroup(dataSource,
                     child, includeConnections, includeSharingProfiles,
                     countActiveConnections, countActiveConnectionGroups,
-                    countUserActiveConnectionGroups));
+                    countUserActiveConnectionGroups, getActiveUsersMap));
             });
         }
 

--- a/guacamole/src/main/frontend/src/app/home/templates/connection.html
+++ b/guacamole/src/main/frontend/src/app/home/templates/connection.html
@@ -8,9 +8,18 @@
     <!-- Connection name -->
     <span class="name">{{item.name}}</span>
 
-    <!-- Active user count -->
-    <span class="activeUserCount" ng-show="item.getActiveConnections()"
-        translate="HOME.INFO_ACTIVE_USER_COUNT"
-        translate-values="{USERS: item.getActiveConnections()}"></span>
+    <div class="activeUsers">
+        <!-- Active user count -->
+        <span class="activeUserCount" ng-show="item.getActiveConnections()"
+            translate="HOME.INFO_ACTIVE_USER_COUNT"
+            translate-values="{USERS: item.getActiveConnections()}"></span>
 
+        <!-- Usernames of currently connected users -->
+        <ul class="activeUserList" ng-show="item.showActiveUsers()">
+            <li ng-repeat="(username, start) in item.getActiveUsers()"
+                translate="HOME.INFO_ACTIVE_USER_DETAILS"
+                translate-values="{USERNAME: username, SINCE: start.value, UNIT: start.unit}"></li>
+        </ul>
+    </div>
+    
 </a>

--- a/guacamole/src/main/frontend/src/app/home/templates/connectionGroup.html
+++ b/guacamole/src/main/frontend/src/app/home/templates/connectionGroup.html
@@ -8,7 +8,7 @@
     <span class="name">{{item.name}}</span>
 
     <!-- Available vs. total connection slots (respects global and per-user limits) -->
-    <span class="activeUserCount"
+    <span class="activeUsers"
           ng-if="item.balancing && item.getEffectiveMaxConnections() !== null"
           translate="HOME.INFO_AVAILABLE_CONNECTIONS"
           translate-values="{AVAILABLE: item.getAvailableConnections(), TOTAL: item.getEffectiveMaxConnections()}"></span>

--- a/guacamole/src/main/frontend/src/app/index/styles/ui.css
+++ b/guacamole/src/main/frontend/src/app/index/styles/ui.css
@@ -115,10 +115,15 @@ div.section {
     opacity: 0.5;
 }
 
-.caption .activeUserCount {
+.caption .activeUsers {
     font-style: italic;
     margin-right: 1em;
     float: right;
+}
+
+.caption .activeUserList {
+    margin: 0;
+    padding: 0 0 0 25px;
 }
 
 .list-item:not(.selected) .caption:hover {

--- a/guacamole/src/main/frontend/src/app/manage/directives/systemPermissionEditor.js
+++ b/guacamole/src/main/frontend/src/app/manage/directives/systemPermissionEditor.js
@@ -126,6 +126,10 @@ angular.module('manage').directive('systemPermissionEditor', ['$injector',
                 value: PermissionSet.SystemPermissionType.AUDIT
             },
             {
+                label: "MANAGE_USER.FIELD_HEADER_VIEW_ACTIVE_CONNECTION_USERS",
+                value: PermissionSet.SystemPermissionType.VIEW_ACTIVE_CONNECTION_USERS
+            },
+            {
                 label: "MANAGE_USER.FIELD_HEADER_CREATE_NEW_USERS",
                 value: PermissionSet.SystemPermissionType.CREATE_USER
             },

--- a/guacamole/src/main/frontend/src/app/rest/types/PermissionSet.js
+++ b/guacamole/src/main/frontend/src/app/rest/types/PermissionSet.js
@@ -143,6 +143,11 @@ angular.module('rest').factory('PermissionSet', [function definePermissionSet() 
         AUDIT : "AUDIT",
 
         /**
+         * Permission to view active connection users for the entire system.
+         */
+        VIEW_ACTIVE_CONNECTION_USERS : "VIEW_ACTIVE_CONNECTION_USERS",
+
+        /**
          * Permission to create new users.
          */
         CREATE_USER : "CREATE_USER",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -423,6 +423,7 @@
         "FIELD_HEADER_PASSWORD_AGAIN"                : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
         "FIELD_HEADER_USER_DISABLED"                 : "Login disabled:",
         "FIELD_HEADER_USERNAME"                      : "Username:",
+        "FIELD_HEADER_VIEW_ACTIVE_CONNECTION_USERS"  : "View names of active connection users:",
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -53,6 +53,7 @@
         "FORMAT_DATE_TIME_PRECISE" : "yyyy-MM-dd HH:mm:ss",
 
         "INFO_ACTIVE_USER_COUNT" : "Currently in use by {USERS} {USERS, plural, one{user} other{users}}.",
+        "INFO_ACTIVE_USER_DETAILS" : "{USERNAME} (since {SINCE} {UNIT, select, second{{VALUE, plural, one{second} other{seconds}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{hour} other{hours}}} day{{VALUE, plural, one{day} other{days}}} other{}})",
         "INFO_LOGGED_OUT"        : "You have been logged out.",
 
         "TEXT_ANONYMOUS_USER"   : "Anonymous",
@@ -286,6 +287,7 @@
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
+        "INFO_ACTIVE_USER_DETAILS" : "@:APP.INFO_ACTIVE_USER_DETAILS",
         "INFO_AVAILABLE_CONNECTIONS"   : "{AVAILABLE} of {TOTAL} {TOTAL, plural, one{connection} other{connections}} available",
 
         "INFO_NO_RECENT_CONNECTIONS" : "No recent connections.",
@@ -1131,6 +1133,7 @@
         "HELP_CONNECTIONS"   : "Click or tap on a connection below to manage that connection. Depending on your access level, connections can be added and deleted, and their properties (protocol, hostname, port, etc.) can be changed.",
         
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
+        "INFO_ACTIVE_USER_DETAILS" : "@:APP.INFO_ACTIVE_USER_DETAILS",
 
         "SECTION_HEADER_CONNECTIONS"     : "Connections"
 

--- a/guacamole/src/main/frontend/src/translations/fr.json
+++ b/guacamole/src/main/frontend/src/translations/fr.json
@@ -50,6 +50,7 @@
         "FORMAT_DATE_TIME_PRECISE" : "dd-MM-yyyy HH:mm:ss",
 
         "INFO_ACTIVE_USER_COUNT" : "Actuellement utilisé par {USERS} {USERS, plural, one{utilisateur} other{utilisateurs}}.",
+        "INFO_ACTIVE_USER_DETAILS" : "{USERNAME} (depuis {SINCE} {UNIT, select, second{{VALUE, plural, one{seconde} other{secondes}}} minute{{VALUE, plural, one{minute} other{minutes}}} hour{{VALUE, plural, one{heure} other{heures}}} day{{VALUE, plural, one{jour} other{jours}}} other{}})",
         "INFO_LOGGED_OUT"        : "Vous avez été déconnecté.",
 
         "TEXT_ANONYMOUS_USER"   : "Anonyme",
@@ -280,6 +281,7 @@
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 
         "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
+        "INFO_ACTIVE_USER_DETAILS" : "@:APP.INFO_ACTIVE_USER_DETAILS",
         "INFO_AVAILABLE_CONNECTIONS" : "{AVAILABLE} {AVAILABLE, plural, one{connexion disponible} other{connexions disponibles}} sur {TOTAL}",
 
         "INFO_NO_RECENT_CONNECTIONS" : "Pas de connexion récente.",
@@ -1039,6 +1041,7 @@
       "HELP_CONNECTIONS"   : "Cliquer ou appuyer sur une connexion en dessous pour la gérer. Selon vos permissions, les connexions peuvent être ajoutées, supprimées, leur propriétés (protocole, nom d'hôte, port, etc.) changées.",
 
       "INFO_ACTIVE_USER_COUNT" : "@:APP.INFO_ACTIVE_USER_COUNT",
+      "INFO_ACTIVE_USER_DETAILS" : "@:APP.INFO_ACTIVE_USER_DETAILS",
 
       "SECTION_HEADER_CONNECTIONS"     : "Connexions"
 

--- a/guacamole/src/main/frontend/src/translations/fr.json
+++ b/guacamole/src/main/frontend/src/translations/fr.json
@@ -417,6 +417,7 @@
         "FIELD_HEADER_PASSWORD_AGAIN"                : "@:APP.FIELD_HEADER_PASSWORD_AGAIN",
         "FIELD_HEADER_USER_DISABLED"                 : "Connexion désactivée\u202F:",
         "FIELD_HEADER_USERNAME"                      : "Identifiant\u202F:",
+        "FIELD_HEADER_VIEW_ACTIVE_CONNECTION_USERS"  : "Voir les noms des utilisateurs actifs\u202F:",
 
         "FIELD_PLACEHOLDER_FILTER" : "@:APP.FIELD_PLACEHOLDER_FILTER",
 


### PR DESCRIPTION
A permission dedicated to this use (allows to see active connections, but not history or the IP address):
<img width="371" height="290" alt="image" src="https://github.com/user-attachments/assets/00902b86-192b-4dc4-bd8d-af18cbf55407" />

With the permission:
<img width="623" height="119" alt="image" src="https://github.com/user-attachments/assets/04f28a3a-f8ad-4ccd-9298-00501acaf8fb" />

Without (allow to see only owned active connections):
<img width="622" height="78" alt="image" src="https://github.com/user-attachments/assets/b63d9b26-cedb-4717-bd88-5f50fdd5c52b" />
