### PR TITLE
GUACAMOLE-350: Allow SSH-Key with at least 4096 bits

### DIFF
--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/001-create-schema.sql
@@ -227,7 +227,7 @@ CREATE TABLE `guacamole_connection_parameter` (
 
   `connection_id`   int(11)       NOT NULL,
   `parameter_name`  varchar(128)  NOT NULL,
-  `parameter_value` varchar(4096) NOT NULL,
+  `parameter_value` varchar(8192) NOT NULL,
 
   PRIMARY KEY (`connection_id`,`parameter_name`),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-1.6.1.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/schema/upgrade/upgrade-pre-1.6.1.sql
@@ -1,0 +1,24 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--
+-- Allow RSA-4096 SSH keys to be stored
+--
+
+ALTER TABLE guacamole_connection_parameter MODIFY COLUMN parameter_value VARCHAR(8192) NOT NULL;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -299,7 +299,7 @@ CREATE TABLE guacamole_connection_parameter (
 
   connection_id   integer       NOT NULL,
   parameter_name  varchar(128)  NOT NULL,
-  parameter_value varchar(4096) NOT NULL,
+  parameter_value varchar(8196) NOT NULL,
 
   PRIMARY KEY (connection_id,parameter_name),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/001-create-schema.sql
@@ -299,7 +299,7 @@ CREATE TABLE guacamole_connection_parameter (
 
   connection_id   integer       NOT NULL,
   parameter_name  varchar(128)  NOT NULL,
-  parameter_value varchar(8196) NOT NULL,
+  parameter_value varchar(8192) NOT NULL,
 
   PRIMARY KEY (connection_id,parameter_name),
 

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-1.6.1.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-postgresql/schema/upgrade/upgrade-pre-1.6.1.sql
@@ -1,0 +1,24 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--
+-- Allow RSA-4096 SSH keys to be stored
+--
+
+ALTER TABLE guacamole_connection_parameter ALTER COLUMN parameter_value TYPE VARCHAR(8192), ALTER COLUMN parameter_value SET NOT NULL;

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/001-create-schema.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/001-create-schema.sql
@@ -487,7 +487,7 @@ CREATE TABLE [guacamole_connection_parameter] (
 
     [connection_id]   [int]            NOT NULL,
     [parameter_name]  [nvarchar](128)  NOT NULL,
-    [parameter_value] [nvarchar](4000) NOT NULL,
+    [parameter_value] [varchar](8000) NOT NULL,
 
     CONSTRAINT [PK_guacamole_connection_parameter]
         PRIMARY KEY CLUSTERED ([connection_id], [parameter_name]),

--- a/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/upgrade/upgrade-pre-1.6.1.sql
+++ b/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-sqlserver/schema/upgrade/upgrade-pre-1.6.1.sql
@@ -1,0 +1,24 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+
+--
+-- Allow RSA-4096 SSH keys to be stored. Only upto 8000 varchar allowed in SQLServer
+--
+
+ALTER TABLE [guacamole_connection_parameter] ALTER COLUMN [parameter_value] VARCHAR(8000) NOT NULL;


### PR DESCRIPTION
Don't like to see existing PRs open for 9 years, so here is an update of #175 addressing the comment to allow upgrade of existing installations. Please note that nvarchar in SQLServer only supports 4000 characters, so SQLServer can't support RSA-4096 keys as is.  If we can change the nvarchar to varchar SQLServer supports upto 8000 characters, so if we want this in SQLServer we'd have to change the type of 'parameter-value'